### PR TITLE
Refine Output Generator and LM Field Exclusion

### DIFF
--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -15,7 +15,7 @@ export function buildDynamicForm(subStatusKey, container, state) {
         if (["{TAGS_IMPLEMENTED}", "{SCREENSHOTS_LIST}", "{CONSENTIU_GRAVACAO}", "{CASO_PORTUGAL}"].includes(placeholder)) return;
         const fieldName = placeholder.slice(1, -1);
         const fieldId = `field-${fieldName}`;
-        if (state.excludedFields.has(fieldId)) return;
+        if (state.excludedFields.has(fieldId) || (fieldName === "ON_CALL" && state.currentCaseType === "lm")) return;
 
         const label = document.createElement("label");
         const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;
@@ -58,7 +58,6 @@ export function buildDynamicForm(subStatusKey, container, state) {
         } else {
             field = document.createElement("input"); field.type = "text"; field.classList.add("cw-input");
         }
-        if (fieldName === "ON_CALL" && state.currentCaseType === "lm") { label.style.display = "none"; field.style.display = "none"; field.value = "N/A"; }
         field.id = fieldId; field.value = state.formData[fieldId] || "";
         field.addEventListener('input', (e) => state.updateField(fieldId, e.target.value));
         container.appendChild(label); container.appendChild(field);

--- a/src/modules/notes/core/output-generator.js
+++ b/src/modules/notes/core/output-generator.js
@@ -92,14 +92,15 @@ export function generateOutputHtml(state, stepTasks, tagSupport) {
         let rawValue = state.formData[fieldId] || '';
         let value = rawValue.trim();
 
-        const isExcluded = state.excludedFields.has(fieldId);
+        const isExcluded = state.excludedFields.has(fieldId) || (fieldName === 'ON_CALL' && state.currentCaseType === 'lm');
 
         // Treat "N/A", ".", "-", "•" or empty values as "to be removed"
         const isEmptyValue = !value || value.toLowerCase() === 'n/a' || value === '.' || value === '-' || value === '•';
 
         if (isExcluded || isEmptyValue) {
-            // Regex to catch the labeled line if the placeholder is the ONLY content after the colon
-            const lineRegex = new RegExp(`(?:<br>\\s*)?(?:<p[^>]*>)?<[b|strong]+>[^<]+:\\s*<\\/[b|strong]+>\\s*{${fieldName}}(?:<\\/p>)?(?:<br>\\s*)?`, 'gi');
+            // Regex to catch the labeled line if the placeholder is the ONLY content after the label (bold/strong)
+            // It handles labels ending with ":" or "?" or nothing, and optional <br> before the placeholder.
+            const lineRegex = new RegExp(`(?:<br>\\s*)?(?:<p[^>]*>)?<(?:b|strong)>[^<]+<\\/(?:b|strong)>[:?]?\\s*(?:<br\\s*\\/?>\\s*)*{${fieldName}}(?:<\\/p>)?(?:<br>\\s*)?`, 'gi');
 
             const newOutput = outputText.replace(lineRegex, '');
             if (newOutput !== outputText) {
@@ -119,7 +120,7 @@ export function generateOutputHtml(state, stepTasks, tagSupport) {
                                .join('');
             value = lines ? `<ul ${ulStyle}>${lines}</ul>` : '';
             if (!lines) {
-                 const lineRegex = new RegExp(`(?:<br>\\s*)?(?:<p[^>]*>)?<[b|strong]+>[^<]+:\\s*<\\/[b|strong]+>\\s*{${fieldName}}(?:<\\/p>)?(?:<br>\\s*)?`, 'gi');
+                 const lineRegex = new RegExp(`(?:<br>\\s*)?(?:<p[^>]*>)?<(?:b|strong)>[^<]+<\\/(?:b|strong)>[:?]?\\s*(?:<br\\s*\\/?>\\s*)*{${fieldName}}(?:<\\/p>)?(?:<br>\\s*)?`, 'gi');
                  const newOutput = outputText.replace(lineRegex, '');
                  if (newOutput !== outputText) {
                      outputText = newOutput;

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -260,6 +260,9 @@ export function initCaseNotesAssistant() {
                 btn.classList.add('active');
                 updateIndicator('lang-selector', idx);
                 SoundManager.playHover();
+                if (notesState.currentSubStatus) {
+                    buildDynamicForm(notesState.currentSubStatus, dynamicFormContainer, notesState);
+                }
             };
         });
 
@@ -270,6 +273,9 @@ export function initCaseNotesAssistant() {
                 btn.classList.add('active');
                 updateIndicator('type-selector', idx);
                 SoundManager.playHover();
+                if (notesState.currentSubStatus) {
+                    onSubStatusChange(notesState.currentSubStatus);
+                }
             };
         });
 


### PR DESCRIPTION
I have refined the output generator to ensure that field titles are correctly removed when the corresponding field is empty or excluded. This was achieved by updating the `lineRegex` to handle various label formats and optional line breaks. 

Additionally, I have implemented the requested exclusion for the `ON_CALL` field in Lead Management (LM) cases. The field is now explicitly skipped during form building and output generation for LM flux. I also ensured that the UI updates immediately when switching between BAU and LM modes or changing the language.

---
*PR created automatically by Jules for task [11721826980416519120](https://jules.google.com/task/11721826980416519120) started by @lucastdcs*