### PR TITLE
Fix ghost draft recovery popup

### DIFF
--- a/src/modules/notes/core/notes-state.js
+++ b/src/modules/notes/core/notes-state.js
@@ -12,11 +12,31 @@ export class NotesState {
         const savedFavorites = typeof localStorage !== 'undefined' ? localStorage.getItem('cw-notes-favorites') : null;
         this.favorites = new Set(JSON.parse(savedFavorites || '[]'));
         this.screenshotMode = "implementation";
+        this.notify();
     }
-    setCaseType(type) { this.currentCaseType = type; this.isDirty = true; this.notify(); }
-    setLanguage(lang) { this.currentLang = lang; this.notify(); }
-    setPortugalCase(val) { this.isPortugalCase = val; this.isDirty = true; this.notify(); }
-    setConsent(val) { this.consent = val; this.isDirty = true; this.notify(); }
+    setCaseType(type) {
+        if (this.currentCaseType === type) return;
+        this.currentCaseType = type;
+        this.isDirty = true;
+        this.notify();
+    }
+    setLanguage(lang) {
+        if (this.currentLang === lang) return;
+        this.currentLang = lang;
+        this.notify();
+    }
+    setPortugalCase(val) {
+        if (this.isPortugalCase === val) return;
+        this.isPortugalCase = val;
+        this.isDirty = true;
+        this.notify();
+    }
+    setConsent(val) {
+        if (this.consent === val) return;
+        this.consent = val;
+        this.isDirty = true;
+        this.notify();
+    }
     setTagSupportUsed(val) {
         this.tagSupportUsed = val;
         if (!val) this.forcedScreenshots.clear();
@@ -62,8 +82,18 @@ export class NotesState {
         this.isDirty = true;
         this.notify();
     }
-    setStatus(status) { this.currentStatus = status; this.isDirty = true; this.notify(); }
-    setSubStatus(subStatus) { this.currentSubStatus = subStatus; this.isDirty = true; this.notify(); }
+    setStatus(status) {
+        if (this.currentStatus === status) return;
+        this.currentStatus = status;
+        this.isDirty = true;
+        this.notify();
+    }
+    setSubStatus(subStatus) {
+        if (this.currentSubStatus === subStatus) return;
+        this.currentSubStatus = subStatus;
+        this.isDirty = true;
+        this.notify();
+    }
     setScreenshotMode(mode) { this.screenshotMode = mode; this.notify(); }
     setActiveTasks(tasks) { this.activeTasks = tasks; this.isDirty = true; this.notify(); }
     toggleFavorite(id) {
@@ -74,7 +104,12 @@ export class NotesState {
         }
         this.notify();
     }
-    updateField(id, value) { this.formData[id] = value; this.isDirty = true; this.notify(); }
+    updateField(id, value) {
+        if (this.formData[id] === value) return;
+        this.formData[id] = value;
+        this.isDirty = true;
+        this.notify();
+    }
     listeners = [];
     subscribe(fn) { this.listeners.push(fn); return () => this.listeners = this.listeners.filter(l => l !== fn); }
     notify() { this.listeners.forEach(fn => fn(this)); }

--- a/src/modules/notes/drafts/draft-service.js
+++ b/src/modules/notes/drafts/draft-service.js
@@ -56,6 +56,9 @@ export const DraftService = {
                 localStorage.removeItem(EMERGENCY_KEY);
                 return null;
             }
+            if (!parsed.data || !parsed.data.subStatus) {
+                return null;
+            }
             return parsed.data;
         } catch (e) { return null; }
     },

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -130,9 +130,18 @@ export function initCaseNotesAssistant() {
             if (autosaveTimeout) clearTimeout(autosaveTimeout);
             autosaveTimeout = setTimeout(async () => {
                 const fullState = await collectFullState(true); // Fast save
-                DraftService.saveEmergency(fullState);
+                if (fullState.subStatus) {
+                    DraftService.saveEmergency(fullState);
+                } else {
+                    DraftService.clearEmergency();
+                }
                 state.isDirty = false;
             }, 2000);
+        } else {
+            if (autosaveTimeout) {
+                clearTimeout(autosaveTimeout);
+                autosaveTimeout = null;
+            }
         }
     });
 
@@ -657,6 +666,7 @@ export function initCaseNotesAssistant() {
         stepTasks.reset();
         tagSupport.reset();
         refreshGlobalBadge();
+        DraftService.clearEmergency();
         // Reset UI elements
         content.querySelectorAll('select').forEach(s => s.value = "");
         content.querySelector('#sub-status-select').disabled = true;

--- a/src/modules/shared/utils.js
+++ b/src/modules/shared/utils.js
@@ -437,7 +437,6 @@ export const stylePopup = {
   `,
   
   border: "1px solid rgba(255, 255, 255, 0.6)", // Borda interna de luz
-  zIndex: "9999",
   display: "flex",
   flexDirection: "column",
   fontFamily: "'Google Sans', Roboto, sans-serif",


### PR DESCRIPTION
The issue was that the Notes module would Mark the state as "dirty" and trigger an emergency autosave even when no note content (specifically, no sub-status) had been selected. This resulted in an "empty" draft being stored, which then triggered the recovery dialog ("Detectamos um rascunho...") every time the application was opened.

Changes implemented:
1. **src/modules/notes/core/notes-state.js**: Added checks to all setter methods to only toggle `isDirty` and notify listeners if the value has actually changed. Added `notify()` to the `reset()` method.
2. **src/modules/notes/notes-assistant.js**: Refined the subscription logic so that `saveEmergency` is only called if the draft has a truthy `subStatus`. Added explicit calls to `clearEmergency` when the state is reset or becomes clean.
3. **src/modules/notes/drafts/draft-service.js**: Added a heuristic check in `getEmergency` to return `null` if the stored data lacks a `subStatus`.
4. **src/modules/shared/utils.js**: Cleaned up a duplicate `zIndex` property in `stylePopup`.

Verified the fix with a Playwright script confirming that:
- No recovery dialog appears on a clean start.
- A recovery dialog CORRECTLY appears if a sub-status was selected before a refresh.
- The recovery dialog is cleared after being dismissed or the form is reset.

---
*PR created automatically by Jules for task [8023921817393956704](https://jules.google.com/task/8023921817393956704) started by @lucastdcs*