### PR TITLE
Refactor BAU Form Highlights and Dashboard Case ID

### DIFF
--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -99,6 +99,13 @@ export function initBAUForm() {
     step1.className = "bau-step active";
     step1.id = "bau-step-1";
 
+    const contextCard = document.createElement("div");
+    contextCard.className = "bau-card bau-context-card";
+    contextCard.innerHTML = `
+        <div id="bau-vital-highlights" class="bau-highlight-panel"></div>
+        <div id="bau-all-data"></div>
+    `;
+
     const dynamicInputsContainer = document.createElement("div");
     dynamicInputsContainer.className = "bau-dynamic-inputs-container";
     dynamicInputsContainer.innerHTML = `
@@ -122,13 +129,8 @@ export function initBAUForm() {
             </div>
         </div>
     `;
-    step1.appendChild(dynamicInputsContainer);
 
-    const contextCard = document.createElement("div");
-    contextCard.className = "bau-card bau-context-card";
-    contextCard.innerHTML = `
-        <div id="bau-all-data"></div>
-    `;
+    contextCard.insertBefore(dynamicInputsContainer, contextCard.querySelector('#bau-all-data'));
     step1.appendChild(contextCard);
     form.appendChild(step1);
 
@@ -343,7 +345,7 @@ export function initBAUForm() {
                                 <h3 class="bau-case-title">${c.advName || 'Nome indefinido'}</h3>
                                 <span class="bau-case-date">${dateStr}</span>
                             </div>
-                            <p class="bau-case-details">CID: ${c.cid || 'N/A'} • Motivo: ${c.reason || 'N/A'}</p>
+                            <p class="bau-case-details">Case: ${c.caseId || 'N/A'} • CID: ${c.cid || 'N/A'} • Motivo: ${c.reason || 'N/A'}</p>
                         </div>
                     </div>
                     <span class="bau-case-status-badge ${statusData.class}">${statusData.text}</span>
@@ -411,6 +413,26 @@ export function initBAUForm() {
     async function populateContextData() {
         const pageData = await getPageData() || {};
         currentContextData = pageData;
+
+        const highlightsContainer = form.querySelector('#bau-vital-highlights');
+        if (highlightsContainer) {
+            const vitals = [
+                { label: "Anunciante", value: pageData.advName },
+                { label: "CID", value: pageData.cid },
+                { label: "Website", value: pageData.site || pageData.website },
+                { label: "Case ID", value: pageData.caseId }
+            ];
+
+            highlightsContainer.innerHTML = vitals.map(v => {
+                const displayValue = (v.value && v.value !== "N/A" && v.value !== "undefined" && v.value !== "null") ? v.value : "---";
+                return `
+                    <div class="bau-highlight-item">
+                        <span class="bau-highlight-label">${v.label}</span>
+                        <span class="bau-highlight-value">${displayValue}</span>
+                    </div>
+                `;
+            }).join('');
+        }
 
         const smartFields = ['advName', 'cid', 'amName', 'seId'];
         smartFields.forEach(field => {

--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -246,6 +246,40 @@ export const injectStyles = () => {
       padding: 20px;
     }
 
+    .bau-context-card .bau-label {
+        color: #e8f0fe;
+    }
+
+    .bau-highlight-panel {
+        background: rgba(26, 115, 232, 0.05);
+        border-left: 4px solid #1a73e8;
+        padding: 16px;
+        border-radius: 4px;
+        margin-bottom: 20px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px 24px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .bau-highlight-item {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .bau-highlight-label {
+        font-size: 11px;
+        font-weight: 700;
+        color: #5f6368;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+    }
+    .bau-highlight-value {
+        font-size: 13px;
+        font-weight: 800;
+        color: #202124;
+        word-break: break-all;
+    }
+
     .bau-dynamic-inputs-container {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
I have refactored the BAU Form and Dashboard to improve the visibility of vital case information. 

Key changes include:
1. **Captured Data Hero Panel**: A new high-contrast summary at the top of Step 1 in the BAU Form, displaying the Advertiser Name, CID, Website, and Case ID.
2. **Dashboard Enhancement**: Each case card in the BAU Dashboard now explicitly shows the Case ID.
3. **UI/UX Refinement**: Updated the Design System in `bau-form-styles.js` to include a premium-looking grid panel and adjusted label colors for better readability against the blue context card.

I have verified these changes by generating new portfolio screenshots and running a custom Playwright verification script. All core functionalities, including automatic data capture and "Smart Rendering" of inputs, remain fully operational.

---
*PR created automatically by Jules for task [18222785656909580186](https://jules.google.com/task/18222785656909580186) started by @lucastdcs*