### PR TITLE
BAU Central: Implement specialized Discard flow routing and templates

### DIFF
--- a/gas-backend/BAU_API.js
+++ b/gas-backend/BAU_API.js
@@ -9,8 +9,8 @@ function handleBAUEscalation(ss, p) {
     const timestamp = p.date || new Date().toISOString();
     const userEmail = p.user || 'anon';
     
-    // Define o status inicial. Se for um motivo de descarte conhecido, podemos rotear no futuro.
-    const status = "PENDING_TL_CREATION"; 
+    // Define o status inicial vindo do payload ou fallback para criação
+    const status = p.status || "PENDING_TL_CREATION";
 
     // Monta a linha respeitando a ordem estrita das 18 colunas do Code.gs
     const novaLinha = [
@@ -36,11 +36,12 @@ function handleBAUEscalation(ss, p) {
 
     sheet.appendRow(novaLinha);
 
-    // Tenta enviar o e-mail transacional. Falhas de e-mail não devem quebrar a criação.
+    // Feedback transacional para o Agente
     try {
       if (typeof sendDynamicTechSolEmail === "function") {
-        // Rastreabilidade: O agente (p.user) é o autor real desta criação
-        sendDynamicTechSolEmail(userEmail, p, newId, 'AGENT_BAU_SENT', userEmail);
+        // Define o tipo de e-mail de feedback com base no status
+        const tipoEmail = (status === 'PENDING_TL_DISCARD') ? 'AGENT_DISCARD_SENT' : 'AGENT_BAU_SENT';
+        sendDynamicTechSolEmail(userEmail, p, newId, tipoEmail, userEmail);
       }
     } catch(e) {
       console.warn("Aviso: Falha ao enviar email do agente", e);

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
This PR finalizes the branching logic for the 'Solicitar Descarte' flow in the BAU Central module.

Key changes:
1. **Frontend (bau-form-assistant.js)**: The form submission now identifies if the user is in the Discard flow and sets the appropriate status in the payload.
2. **Backend Routing (BAU_API.js)**: The escalation handler now respects the incoming status and triggers the correct feedback email type.
3. **Email System (BAUForm.js & Templates)**:
    - Added `EmailTemplateDiscard.html` for a specialized TL-approval look.
    - Updated `sendDynamicTechSolEmail` to route between standard and discard templates based on request status.
    - Switched all placeholder replacements to global regex (e.g., `/{{PLACEHOLDER}}/g`) to ensure consistent rendering across templates.
    - Added support for `{{LANGUAGE}}` and `{{DESCRIPTION}}` placeholders in the discard context.
4. **Policy**: Confirmed that submission-time notifications (AGENT_BAU_SENT/AGENT_DISCARD_SENT) are sent to the requesting agent as confirmation, maintaining current system behavior while adding visual distinction for discard requests.

---
*PR created automatically by Jules for task [13620221971400166874](https://jules.google.com/task/13620221971400166874) started by @lucastdcs*