### PR TITLE
Ensure original language for stable data capture

### DIFF
--- a/src/modules/notes/automation/case-log-scraper.js
+++ b/src/modules/notes/automation/case-log-scraper.js
@@ -1,6 +1,7 @@
 // src/modules/automation/case-log-scraper.js
 import { showToast } from '../../shared/utils.js';
 import { SoundManager } from '../../shared/sound-manager.js';
+import { ensureOriginalLanguage } from '../../shared/page-data.js';
 
 const esperar = (ms) => new Promise(r => setTimeout(r, ms));
 
@@ -89,6 +90,9 @@ function toggleLoadingOverlay(show) {
  */
 export async function fetchAndInsertSpeakeasyId(targetInputId) {
     console.log("🚀 Iniciando extração automática...");
+
+    // Garante que a página esteja no idioma original antes de iniciar a extração
+    await ensureOriginalLanguage();
 
     const inputWidget = document.getElementById(targetInputId);
     let originalPlaceholder = "";

--- a/src/modules/shared/page-data.js
+++ b/src/modules/shared/page-data.js
@@ -8,6 +8,29 @@ let cachedUserProfile = null;
 
 const esperar = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+/**
+ * Garante que a página esteja no idioma original caso o recurso de tradução do CRM esteja ativo.
+ * Isso evita falhas de mapeamento e regex durante a raspagem de dados.
+ */
+export async function ensureOriginalLanguage() {
+    try {
+        const translateBtn = document.querySelector('material-button[debug-id="toggle-translation-button"]');
+
+        if (translateBtn) {
+            const text = translateBtn.textContent.toLowerCase();
+            // Verifica se o botão indica que a página está traduzida (exibindo opção de mostrar original)
+            if (text.includes('show original') || text.includes('mostrar original')) {
+                console.log("TechSol: Tradução detectada. Revertendo para o idioma original...");
+                translateBtn.click();
+                await esperar(400); // Aguarda renderização da interface original
+            }
+        }
+    } catch (e) {
+        // Silencioso: não deve interromper o fluxo principal se o botão falhar
+        console.warn("TechSol: Erro ao tentar reverter tradução:", e);
+    }
+}
+
 // --- 1. SHERLOCK HOLMES (Captura Silenciosa do Nome do Agente) ---
 export async function captureNameWithMagic() {
     // Se já temos nome E email, retorna rápido
@@ -378,6 +401,9 @@ export function isCurrentUserOverhead() {
 
 // --- 9. COMPILADOR DE DADOS DA PÁGINA ---
 export async function getPageData() {
+    // Garante que os dados estejam no idioma original para evitar falhas de raspagem
+    await ensureOriginalLanguage();
+
     // Garante que a identidade foi capturada antes de prosseguir
     if (!cachedAgentEmail) {
         await captureNameWithMagic();


### PR DESCRIPTION
Implemented a stability routine to ensure Salesforce/Cases pages are in their original language before data scraping occurs.

Key changes:
1. Created an asynchronous `ensureOriginalLanguage` function in `src/modules/shared/page-data.js` that detects the "Show original" button (debug-id="toggle-translation-button"), clicks it if necessary, and waits 400ms for the UI to revert.
2. Integrated this routine at the beginning of the `getPageData` flow to protect all BAU form data capture.
3. Integrated the routine into `fetchAndInsertSpeakeasyId` in `src/modules/notes/automation/case-log-scraper.js` to ensure SE ID extraction is also protected from translation errors.
4. Wrapped the logic in try/catch blocks for silent failure, ensuring no disruption to the user flow if the button is absent.

---
*PR created automatically by Jules for task [3545303748547438976](https://jules.google.com/task/3545303748547438976) started by @lucastdcs*