### PR TITLE
Fix Data Wiping in BAU Central Submission and Editing

### DIFF
--- a/gas-backend/BAU_API.js
+++ b/gas-backend/BAU_API.js
@@ -145,6 +145,24 @@ function update_bau_case(ss, p) {
              newStatus = p.requestType === 'DISCARD' ? 'PENDING_TL_DISCARD' : 'PENDING_TL_CREATION';
         }
 
+        // Column 17 Logic (Description) - Smart Merge for BAU
+        let finalDescription = data[i][16];
+        if (p.requestType === 'BAU') {
+          const currentDesc = String(data[i][16] || "");
+          const parts = currentDesc.split(" | ");
+          let oldNIR = parts[0] || "";
+          let oldDetail = parts.slice(1).join(" | ") || "";
+
+          const newNIR = p.nonImplementationReason !== undefined ? p.nonImplementationReason : oldNIR;
+          const newDetail = p.description !== undefined ? p.description : oldDetail;
+
+          if (p.nonImplementationReason !== undefined || p.description !== undefined) {
+            finalDescription = newNIR + " | " + newDetail;
+          }
+        } else if (p.description !== undefined) {
+          finalDescription = p.description;
+        }
+
         const rowUpdate = [
             newStatus,
             p.caseId !== undefined ? p.caseId : data[i][4],
@@ -159,9 +177,7 @@ function update_bau_case(ss, p) {
             p.salesProgram !== undefined ? p.salesProgram : data[i][13],
             p.reason !== undefined ? p.reason : data[i][14],
             p.taskType !== undefined ? p.taskType : data[i][15],
-            (p.requestType === 'BAU' && p.nonImplementationReason)
-              ? p.nonImplementationReason + " | " + (p.description || "")
-              : (p.description !== undefined ? p.description : data[i][16]),
+            finalDescription,
             p.availability !== undefined ? p.availability : data[i][17]
         ];
 

--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -1237,18 +1237,40 @@ export function initBAUForm() {
             payload.taskType = tasks.join(', ');
             payload.availability = disponibilidadeUnificada;
 
-            // Fallback preventivo e Auditoria de Dados (Garantir que cheguem à planilha)
-            payload.nonImplementationReason = data.nonImplementationReason || "";
-            payload.description = data.description || "";
+            if (isEditing) {
+                // Shielding: Only send if present and not empty to avoid "Data Wiping"
+                if (data.nonImplementationReason) payload.nonImplementationReason = data.nonImplementationReason;
+                else delete payload.nonImplementationReason;
 
-            if (!payload.nonImplementationReason) console.warn("Aviso: Campo 'Justificativa' (nonImplementationReason) está saindo vazio.");
-            if (!payload.description) console.warn("Aviso: Campo 'Descrição detalhada' (description) está saindo vazio.");
+                if (data.description) payload.description = data.description;
+                else delete payload.description;
+            } else {
+                // Creation flow: empty strings are acceptable fallbacks
+                payload.nonImplementationReason = data.nonImplementationReason || "";
+                payload.description = data.description || "";
+
+                if (!payload.nonImplementationReason) console.warn("Aviso: Campo 'Justificativa' (nonImplementationReason) está saindo vazio.");
+                if (!payload.description) console.warn("Aviso: Campo 'Descrição detalhada' (description) está saindo vazio.");
+            }
         } else {
-            // Discard Flow: KISS Principle - nullify irrelevant fields
-            payload.taskType = "";
-            payload.availability = "";
-            payload.nonImplementationReason = "";
-            payload.reason = data.reason; // This comes from step 5 'reason' field
+            // Discard Flow: KISS Principle
+            payload.reason = data.reason;
+
+            if (isEditing) {
+                // Shielding for Discard Edit
+                if (data.description) payload.description = data.description;
+                else delete payload.description;
+
+                // Remove BAU specific fields to preserve them if they exist in the DB
+                delete payload.taskType;
+                delete payload.availability;
+                delete payload.nonImplementationReason;
+            } else {
+                payload.taskType = "";
+                payload.availability = "";
+                payload.nonImplementationReason = "";
+                payload.description = data.description || "";
+            }
         }
 
         try {


### PR DESCRIPTION
This PR fixes a critical bug where the 'Justification' and 'Description' fields were being overwritten with empty strings during edits in the BAU Central module.

Key changes:
- Frontend (bau-form-assistant.js): Implemented 'Shielding' logic in the submission payload. During edits, fields that are empty are removed from the payload instead of being sent as empty strings.
- Backend (BAU_API.js): Refactored 'update_bau_case' to implement a 'Smart Merge' for column 17 (Description). It now splits the existing concatenated value and only updates the parts explicitly provided in the payload, preserving existing data for others.
- Improved 'Discard' flow editing to ensure BAU-specific fields are not accidentally wiped.

---
*PR created automatically by Jules for task [5940544379902153644](https://jules.google.com/task/5940544379902153644) started by @lucastdcs*