### PR TITLE
Implement Safety Confirmation for Case Editing in BAU Central

### DIFF
--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -2,7 +2,7 @@
 import { injectStyles, COLORS } from './bau-form-styles.js';
 import { createStandardHeader } from '../shared/header-factory.js';
 import { toggleGenieAnimation } from '../shared/animations.js';
-import { showToast, formatToLocalUserDate } from '../shared/utils.js';
+import { showToast, formatToLocalUserDate, confirmDialog } from '../shared/utils.js';
 import { SoundManager } from '../shared/sound-manager.js';
 import { sendBAUEscalation, readAgentBAU, updateBAUEscalation } from '../shared/data-service.js';
 import { getPageData } from '../shared/page-data.js';
@@ -1121,6 +1121,13 @@ export function initBAUForm() {
         });
     }
     async function handleEditCase(c) {
+        const confirmed = await confirmDialog(
+            "Atenção: Para editar as informações, você deve estar com a página deste Caso específico aberta no sistema. Caso contrário, os dados capturados estarão incorretos.",
+            { confirmText: "Estou na página correta" }
+        );
+
+        if (!confirmed) return;
+
         resetForm();
         isEditing = true;
         editingCaseId = c.id;


### PR DESCRIPTION
Implemented a safety interception for case editing in the BAU Central module. When an agent clicks "Editar", a blocking confirmation modal is displayed warning that they must be on the specific Case page to avoid incorrect data capture. The process only continues if the user clicks "Estou na página correta". Verified with Playwright tests on mock-crm.html.

---
*PR created automatically by Jules for task [15647989599163659492](https://jules.google.com/task/15647989599163659492) started by @lucastdcs*