### PR TITLE
Fix Website Field Data Flow and Edit Mode Visual Glitch in BAU Central

### DIFF
--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -233,6 +233,19 @@ export function initBAUForm() {
     formUiContainer.className = "bau-content";
     formView.appendChild(formUiContainer);
 
+    // Inject loading overlay for edit mode transitions
+    const loadingOverlay = document.createElement('div');
+    loadingOverlay.className = 'bau-form-loading-overlay';
+    loadingOverlay.innerHTML = `
+        <div class="bau-spinner"></div>
+        <div class="bau-loading-text">Configurando Edição...</div>
+    `;
+    formUiContainer.appendChild(loadingOverlay);
+
+    const showFormLoading = (show) => {
+        loadingOverlay.classList.toggle('active', show);
+    };
+
     const progressIndicator = document.createElement("div");
     progressIndicator.className = "bau-progress-indicator";
     formUiContainer.appendChild(progressIndicator);
@@ -908,7 +921,7 @@ export function initBAUForm() {
             const vitals = [
                 { label: "Anunciante", value: pageData.advName },
                 { label: "CID", value: pageData.cid },
-                { label: "Website", value: pageData.site || pageData.website },
+                { label: "Website", value: pageData.website || pageData.site },
                 { label: "Case ID", value: pageData.caseId }
             ];
 
@@ -970,7 +983,7 @@ export function initBAUForm() {
                 { label: "CID", value: pageData.cid },
                 { label: "AM", value: pageData.amName },
                 { label: "SE ID", value: pageData.seId },
-                { label: "Site", value: pageData.site },
+                { label: "Site", value: pageData.website || pageData.site },
                 { label: "Email", value: pageData.email },
                 { label: "Timezone", value: pageData.timezone },
                 { label: "Case ID", value: pageData.caseId },
@@ -1027,6 +1040,10 @@ export function initBAUForm() {
                     <div class="bau-confirm-row">
                         <span class="bau-confirm-label">AM</span>
                         <input class="bau-confirm-value-input" data-field="amName" data-step="1" value="${data.amName || ''}" placeholder="---">
+                    </div>
+                    <div class="bau-confirm-row">
+                        <span class="bau-confirm-label">Website</span>
+                        <input class="bau-confirm-value-input" data-field="website" data-step="1" value="${data.website || ''}" placeholder="---">
                     </div>
                     <div class="bau-confirm-row">
                         <span class="bau-confirm-label">Speakeasy ID</span>
@@ -1128,6 +1145,8 @@ export function initBAUForm() {
 
         if (!confirmed) return;
 
+        showFormLoading(true);
+
         resetForm();
         isEditing = true;
         editingCaseId = c.id;
@@ -1143,7 +1162,7 @@ export function initBAUForm() {
             cid: c.cid || currentContextData.cid,
             caseId: c.caseId || currentContextData.caseId,
             seId: c.seId || currentContextData.seId,
-            site: c.site || currentContextData.site,
+            site: c.site || c.website || currentContextData.site || currentContextData.website,
             email: c.advEmail || currentContextData.email,
             timezone: c.timezone || currentContextData.timezone,
             language: c.language || currentContextData.language,
@@ -1157,12 +1176,14 @@ export function initBAUForm() {
         form.querySelectorAll('input, select, textarea').forEach(input => {
             const fieldName = input.name;
 
-            // Map common field names to data keys
+            // Map common field names to data keys for correct population
             const keyMap = {
                 'advEmail': 'advEmail',
                 'website': 'site',
                 'site': 'site'
             };
+
+            const dataKey = keyMap[fieldName] || fieldName;
 
             if (fieldName === 'taskType') {
                 const tasks = (c.task || c.taskType || "").split(',').map(t => t.trim());
@@ -1182,8 +1203,8 @@ export function initBAUForm() {
                         }
                     } catch(e) {}
                 }
-            } else if (c[fieldName] !== undefined) {
-                input.value = c[fieldName];
+            } else if (c[dataKey] !== undefined) {
+                input.value = c[dataKey];
             } else if (fieldName === 'reason') {
                 input.value = c.reason;
             } else if (fieldName === 'description') {
@@ -1196,6 +1217,8 @@ export function initBAUForm() {
         currentStep = (requestType === 'BAU') ? 1 : 5;
         updateWizardState();
         SoundManager.playClick();
+
+        setTimeout(() => showFormLoading(false), 500);
     }
 
     form.onsubmit = async (e) => {
@@ -1233,6 +1256,7 @@ export function initBAUForm() {
         else if (context.email) payload.advEmail = context.email;
 
         if (data.website) payload.website = data.website;
+        else if (context.website) payload.website = context.website;
         else if (context.site) payload.website = context.site;
 
         if (requestType === 'BAU') {

--- a/src/modules/bau-form/bau-form-config.js
+++ b/src/modules/bau-form/bau-form-config.js
@@ -43,6 +43,15 @@ export const FORM_CONFIG = {
                     isSmart: true
                 },
                 {
+                    id: 'website',
+                    name: 'website',
+                    label: 'Website',
+                    type: 'text',
+                    placeholder: 'https://www.exemplo.com',
+                    required: true,
+                    isSmart: true
+                },
+                {
                     id: 'seId',
                     name: 'seId',
                     label: 'Speakeasy ID (SE ID)',

--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -996,6 +996,45 @@ export const injectStyles = () => {
       justify-content: center;
     }
 
+    /* --- LOADING OVERLAY --- */
+    .bau-form-loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.7);
+      backdrop-filter: blur(8px);
+      z-index: 1000;
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      border-radius: 12px;
+      animation: bauFadeIn 0.3s ease;
+    }
+
+    .bau-form-loading-overlay.active {
+      display: flex;
+    }
+
+    .bau-spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid rgba(26, 115, 232, 0.1);
+      border-top-color: #1A73E8;
+      border-radius: 50%;
+      animation: rotate 0.8s linear infinite;
+      margin-bottom: 12px;
+    }
+
+    .bau-loading-text {
+      font-size: 14px;
+      font-weight: 600;
+      color: #1A73E8;
+      letter-spacing: 0.3px;
+    }
+
     .bau-mini-btn-input:hover {
       background: #F1F3F4;
       color: #202124;


### PR DESCRIPTION
This PR addresses two critical execution issues in the BAU Central module:

1. **Website Field Persistence**: The 'Website' field was previously lost during the flow. I have unified the property name as 'website' (internally mapping to 'site' where necessary for backend compatibility). It is now correctly captured from CRM data, displayed in the confirmation summary (Step 4), and included in the final submission payload.
2. **Edit Mode UX**: To fix the visual glitch where the empty form was momentarily visible before being populated with case data, I implemented a `.bau-form-loading-overlay`. This overlay uses a blur backdrop and a material-style spinner, ensuring a professional and smooth transition during the edit setup process.

Technical Changes:
- Modified `bau-form-config.js` to include the `website` field.
- Updated `bau-form-assistant.js` with loading state logic and improved data merge/population handlers.
- Added necessary CSS for the loading overlay to `bau-form-styles.js`.
- Verified the fix via local frontend verification and bundle analysis.

---
*PR created automatically by Jules for task [7224621228919012198](https://jules.google.com/task/7224621228919012198) started by @lucastdcs*