### PR TITLE
Style BAU Central Edit Button

### DIFF
--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -258,6 +258,33 @@ export const injectStyles = () => {
     .bau-case-status-badge.status-red { background: rgba(217, 48, 37, 0.2); color: #D93025; }
     .bau-case-status-badge.status-gray { background: rgba(128, 134, 139, 0.2); color: #5F6368; }
 
+    .bau-case-edit-btn {
+      background: transparent;
+      border: 1px solid #DADCE0;
+      color: #5F6368;
+      border-radius: 8px;
+      padding: 6px 12px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      transition: all 0.2s ease;
+      white-space: nowrap;
+    }
+
+    .bau-case-edit-btn:hover {
+      background: rgba(26, 115, 232, 0.08);
+      color: #1A73E8;
+      border-color: #1A73E8;
+    }
+
+    .bau-case-edit-btn svg {
+      width: 14px;
+      height: 14px;
+    }
+
     .bau-empty-state {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Identified and fixed the absence of styling for the `bau-case-edit-btn` in the BAU Central module. The button now follows the 'Liquid Glass' design system (Material 3) with a translucent outline, specific hover states, and proper internal alignment. Verified the changes via Playwright screenshot.

---
*PR created automatically by Jules for task [18291815842881836879](https://jules.google.com/task/18291815842881836879) started by @lucastdcs*