### PR TITLE
chore: Tier 2 dedup — bau-form status, objectToCss, stale email template

### DIFF
--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -22,6 +22,16 @@ const ICONS = {
     edit: `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`
 };
 
+function getStatusData(status) {
+    switch (status) {
+        case 'PENDING_TL_CREATION': return { text: "Aguardando TL", class: "status-yellow", aura: "status-yellow-aura" };
+        case 'CREATED': return { text: "Aprovado / Criado", class: "status-green", aura: "status-green-aura" };
+        case 'DISCARDED': return { text: "Descartado pelo TL", class: "status-red", aura: "status-red-aura" };
+        case 'CANCELED_BY_AGENT': return { text: "Cancelado", class: "status-gray", aura: "" };
+        default: return { text: status || "Pendente", class: "status-gray", aura: "" };
+    }
+}
+
 function createField(fieldConfig) {
     const wrapper = document.createElement('div');
     wrapper.className = 'bau-dynamic-input';
@@ -451,15 +461,6 @@ export function initBAUForm() {
     function openCaseDetails(c) {
         if (!c) return;
 
-        const getStatusData = (status) => {
-            switch(status) {
-                case 'PENDING_TL_CREATION': return { text: "Aguardando TL", class: "status-yellow" };
-                case 'CREATED': return { text: "Aprovado / Criado", class: "status-green" };
-                case 'DISCARDED': return { text: "Descartado pelo TL", class: "status-red" };
-                case 'CANCELED_BY_AGENT': return { text: "Cancelado", class: "status-gray" };
-                default: return { text: status || "Pendente", class: "status-gray" };
-            }
-        };
         const statusData = getStatusData(c.status);
 
         const copyToClipboard = (text, btn) => {
@@ -562,15 +563,6 @@ export function initBAUForm() {
     function renderCaseCard(c) {
         if (!c) return '';
 
-        const getStatusData = (status) => {
-            switch(status) {
-                case 'PENDING_TL_CREATION': return { text: "Aguardando TL", class: "status-yellow", aura: "status-yellow-aura" };
-                case 'CREATED': return { text: "Aprovado / Criado", class: "status-green", aura: "status-green-aura" };
-                case 'DISCARDED': return { text: "Descartado pelo TL", class: "status-red", aura: "status-red-aura" };
-                case 'CANCELED_BY_AGENT': return { text: "Cancelado", class: "status-gray", aura: "" };
-                default: return { text: status || "Pendente", class: "status-gray", aura: "" };
-            }
-        };
         const statusData = getStatusData(c?.status);
         const dateStr = formatToLocalUserDate(c?.date);
 

--- a/src/modules/broadcast/broadcast-assistant.js
+++ b/src/modules/broadcast/broadcast-assistant.js
@@ -13,7 +13,8 @@ import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { BROADCAST_MESSAGES, setBroadcastMessages } from "./broadcast-data.js"; 
 import { DataService } from "../shared/data-service.js";
-import { getAgentEmail } from "../shared/page-data.js"; 
+import { getAgentEmail } from "../shared/page-data.js";
+import { objectToCss } from "../shared/dom-utils.js";
 import { ADMINS } from "../shared/config.js";
 
 // --- CONFIGURAÇÃO ---
@@ -172,11 +173,6 @@ export function initBroadcastAssistant() {
   };
 
   // --- PARSERS & UTILS ---
-  function objectToCss(obj) {
-      if (!obj) return ""; 
-      return Object.entries(obj).map(([k, v]) => `${k.replace(/[A-Z]/g, m => "-" + m.toLowerCase())}:${v}`).join(';');
-  }
-
   function parseMessageText(rawText) {
       if (!rawText || typeof rawText !== 'string') return ""; 
       let html = rawText;

--- a/src/modules/email-assistant/email-data.js
+++ b/src/modules/email-assistant/email-data.js
@@ -11,22 +11,6 @@ export const EMAIL_TEMPLATES = [
     ],
     "template": "<p>Olá,</p><br><p>Aqui é o <strong>[Seu Nome]</strong> da equipe de Soluções Técnicas do Google. Tentei ligar no seguinte número: <strong>...</strong> sem sucesso, teria outro número para que eu pudesse entrar em contato?</p><br><p>Lembrando que vou auxiliar a implementar a seguinte tarefa:</p><p><strong>Ads Conversion Tracking</strong></p><br><p>Em seu site: <strong>[INSERIR URL]</strong></p><p>Tentarei ligar novamente dentro de 10 minutos, caso prefira, você pode acessar o link da nossa reunião: <strong>[LINK DO MEET]</strong></p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>"
   },
-  {
-    "id": "reschedule",
-    "name": "Proposta de Reagendamento",
-    "category": "Tentativas & Agendamento",
-    "subject": "Reagendamento de Consultoria",
-    "placeholders": [
-      { "key": "[DATA 1]", "label": "Data 1", "type": "text" },
-      { "key": "[HORA 1]", "label": "Hora 1", "type": "text" },
-      { "key": "[DATA 2]", "label": "Data 2", "type": "text" },
-      { "key": "[HORA 2]", "label": "Hora 2", "type": "text" },
-      { "key": "[DATA 3]", "label": "Data 3", "type": "text" },
-      { "key": "[HORA 3]", "label": "Hora 3", "type": "text" },
-      { "key": "[Seu Nome]", "label": "Assinatura", "type": "text", "auto": "agentName" }
-    ],
-    "template": "<p>Olá, tudo bem?</p><br><p>Seguem as próximas datas disponíveis:</p><ul><li><strong>[DATA 1] às [HORA 1]</strong></li><li><strong>[DATA 2] às [HORA 2]</strong></li><li><strong>[DATA 3] às [HORA 3]</strong></li></ul><br><p>Também informo que se não houver resposta a este email, realizarei um acompanhamento neste caso durante 6 dias, onde entrarei em contato a cada 3 dias para tentarmos reagendar seu caso o mais breve possível.</p><p>Reforço que minha agenda é dinâmica, sendo assim, a qualquer momento um atendimento pode ser marcado para os dias disponíveis. Logo, quanto mais rápido conseguir me responder, mais garantido será o agendamento de data e horário.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>"
-  },
   {"id": "reschedule2",
     "name": "Proposta de Reagendamento",
     "category": "Tentativas & Agendamento",

--- a/src/modules/personal-library/personal-library-assistant.js
+++ b/src/modules/personal-library/personal-library-assistant.js
@@ -5,6 +5,7 @@ import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
 import { SnippetService } from "./snippet-service.js";
+import { objectToCss } from "../shared/dom-utils.js";
 
 export function initPersonalLibrary() {
     const CURRENT_VERSION = "v1.1";
@@ -678,10 +679,6 @@ export function initPersonalLibrary() {
 
         div.appendChild(input);
         return div;
-    }
-
-    function objectToCss(obj) {
-        return Object.entries(obj).map(([k, v]) => `${k.replace(/[A-Z]/g, m => "-" + m.toLowerCase())}:${v}`).join(';');
     }
 
     function toggleVisibility() {

--- a/src/modules/shared/dom-utils.js
+++ b/src/modules/shared/dom-utils.js
@@ -21,3 +21,10 @@ export function simularClique(el) {
         el.dispatchEvent(new MouseEvent(evt, { bubbles: true, cancelable: true, view: window }))
     );
 }
+
+// Converte um objeto de estilos JS (camelCase) numa string CSS inline
+// (kebab-case), para montar innerHTML com style="..." dinâmico.
+export function objectToCss(obj) {
+    if (!obj) return "";
+    return Object.entries(obj).map(([k, v]) => `${k.replace(/[A-Z]/g, m => "-" + m.toLowerCase())}:${v}`).join(';');
+}


### PR DESCRIPTION
## Summary
- `bau-form-assistant.js`: unifica `getStatusData()`, que estava duplicado dentro de `openCaseDetails()` e `renderCaseCard()`, numa única função no escopo do módulo.
- `objectToCss()`, duplicado em `broadcast-assistant.js` e `personal-library-assistant.js`, movido para `shared/dom-utils.js` (mesmo arquivo criado no Tier 1).
- `email-data.js`: removida a entrada de template "Proposta de Reagendamento" da versão de 6 dias (id `reschedule`) — ela tinha nome/categoria/assunto idênticos à versão de 48h (`reschedule2`), ficando indistinguível na lista do Email Assistant. Decisão de conteúdo confirmada: manter a versão de 48h.

## Por que
Continuação do plano de limpeza priorizado por risco (Tier 2), depois do #201 (Tier 1). Cada item foi commitado separadamente para facilitar review e reduzir risco de erro grande.

## O que revisar
- Nenhuma mudança de comportamento nos dois dedups de código (`getStatusData`/`objectToCss`) — só remoção de duplicação.
- A remoção do template `reschedule` É uma mudança de conteúdo visível: o item "Proposta de Reagendamento" no Email Assistant agora só existe na versão de 48h.
- Build validado localmente após cada commit com `esbuild src/app.js --bundle --minify`, sem erros.

## Test plan
- [x] `esbuild --bundle --minify` roda sem erros após os 3 commits
- [ ] Testar no CRM via bookmarklet de dev: BAU Central (dashboard + detalhes de caso), Central de Avisos, Minha Biblioteca, e o template de reagendamento no Email Assistant

🤖 Gerado com [Claude Code](https://claude.com/claude-code)