### PR TITLE
docs: refresh README and docs/ to match current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ Assista à suite em ação, desde a inicialização com Sound UX até a automaç
 | <img src="docs/media/email-assistant.png" width="400"> | <img src="docs/media/call-script.png" width="400"> |
 | *Templates dinâmicos e rascunhos automáticos.* | *Roteiros guiados para chamadas com clientes.* |
 
-| **Timezone Assistant** |
+| **Timezone Assistant** | **BAU Central** |
+| :---: | :---: |
+| <img src="docs/media/timezone-assistant.png" width="400"> | <img src="docs/media/bau-dashboard.png" width="400"> |
+| *Conversão de fusos horários e planejamento de reuniões.* | *Dashboard de escalação BAU com fluxo de aprovação.* |
+
+| **Configurações & Perfil** |
 | :---: |
-| <img src="docs/media/timezone-assistant.png" width="400"> |
-| *Conversão de fusos horários e planejamento de reuniões.* |
+| <img src="docs/media/configs-profile.png" width="400"> |
+| *Perfil do agente, papel/segmento e preferências.* |
 
 -----
 
@@ -86,14 +91,40 @@ Uma vez carregado, o `bundle.js`:
 
 ## 📦 Funcionalidades Principais
 
-### 📧 Automação de E-mail
+### 📝 Case Notes
+
+  * Gera notas de caso padronizadas (BAU/LM, PT/ES) a partir de Status → Sub-status → template.
+  * Seletor visual de tasks, cenários rápidos, suporte a tags de implementação e captura automática de Speakeasy ID.
+  * Sistema de rascunhos "estacionados" com autosave de emergência.
+
+### 📧 Email Assistant
 
   * **Detecção de Rascunho:** Algoritmo de *polling* que identifica, descarta e limpa rascunhos "fantasmas" antes de inserir um novo template.
-  * **Quick Responses:** Inserção inteligente de texto rico (HTML) com substituição de variáveis (`{{cliente}}`, `{{data}}`).
+  * **Templates dinâmicos:** biblioteca de templates com placeholders + atalhos "Smart CR" ligados aos sub-status do Case Notes.
+
+### 📞 Call Script Assistant
+
+  * Checklist interativo de roteiro de chamada (PT/ES/EN × BAU/LT), com barra de progresso e captura ao vivo de CID/e-mail do cliente.
+
+### 🌎 Timezone Assistant
+
+  * Monitoramento de horário local por país atendido e planejador de horário de reunião com o cliente.
+
+### 🅿️ BAU Central
+
+  * Wizard de escalação de caso para BAU (abertura ou descarte), dashboard de acompanhamento dos próprios casos e fluxo de edição.
+
+### 📚 Minha Biblioteca
+
+  * Snippets pessoais (notas, e-mails, textos gerais) com sincronia entre dispositivos via Google Sheets.
+
+### ⚙️ Configurações
+
+  * Perfil do agente (papel, segmento, idioma), preferências de som e link de feedback/reporte de bug.
 
 ### 📢 Broadcast System
 
-  * Sistema de avisos globais consumindo JSON remoto.
+  * Sistema de avisos globais consumindo dados do backend.
   * Persistência de leitura via `localStorage`.
   * Suporte a emojis customizados (parser interno de shortcodes).
 
@@ -106,14 +137,16 @@ Uma vez carregado, o `bundle.js`:
 
 ## 💻 Desenvolvimento Local
 
-Este projeto não possui um servidor local (localhost) devido às restrições de HTTPS e CORS do CRM alvo.
+O front-end injeta em cima do CRM real, então não existe um "localhost" tradicional para ele — mas o repositório inclui um `mock-crm.html` (HTML estático que imita o layout do CRM) usado pelo `generate-portfolio.py` (Playwright) para gerar os prints/vídeo deste README sem depender do ambiente de produção.
 
 **Fluxo de Trabalho Sugerido:**
 
-1.  Faça alterações nos arquivos `.js` locais (`src/`).
-2.  Compile o projeto (se houver build step) para `bundle-dev.js`.
-3.  Faça push para o branch que alimenta o GitHub Pages.
+1.  `npm install` (primeira vez).
+2.  Edite os arquivos em `src/`.
+3.  Rode `npm run build` (gera `dist/bundle.js`, minificado) ou `npm run dev` (gera `dist/bundle-dev.js`, sem minificação). O GitHub Actions roda o build automaticamente a cada push — veja `docs/WORKFLOW.md`.
 4.  Use o **Bookmarklet de Dev** para testar as alterações em tempo real no ambiente de produção.
+
+**Backend (Google Apps Script):** o código do backend vive em `gas-backend/` e é sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp) (`clasp push`/`clasp pull`), separado do pipeline de build do front-end.
 
 -----
 
@@ -124,5 +157,5 @@ Este projeto não possui um servidor local (localhost) devido às restrições d
 
 -----
 
-> **Status do Projeto:** 🟢 Estável (v2.5)
-> **Mantenedor:** [Seu Nome/Time TechSol]
+> **Status do Projeto:** 🟢 Estável (v5.2)
+> **Mantenedor:** Lucas Teixeira / Time TechSol

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # 🏛️ Arquitetura do Sistema (TechSol Operations Assistant)
 
+> **Nota sobre documentação:** este arquivo descreve a arquitetura em nível macro (visão geral, alto nível). Para regras de negócio, contrato de payloads, schema do banco (Sheets) e padrões de UI/DOM que o código deve seguir, a fonte da verdade é a pasta [`specs/`](../specs/_MASTER_RULEBOOK.md) — ela é mantida em sincronia com o código atual. Este `docs/` foca em visão geral e histórico de decisões.
+
 ## 1. Visão Geral
 O projeto é uma **Overlay Application** (Aplicação de Sobreposição) injetada via **Bookmarklet**. Diferente de extensões de navegador, ela não possui armazenamento persistente próprio além do `localStorage` e roda no contexto da página alvo (CRM), compartilhando o mesmo DOM e objeto `window`.
 
@@ -15,20 +17,17 @@ O ponto de entrada é o arquivo `app.js`. Ele orquestra o "boot" da aplicação 
 2.  **Styles & Fonts:** Injeta estilos globais e a fonte Roboto/Google Sans no `<head>` via `initGlobalStylesAndFont`.
 3.  **Audio Engine:** Inicializa o `SoundManager` e adiciona listeners globais para feedback tátil (sons de hover/click).
 4.  **Data Fetching:** Dispara a busca assíncrona de dicas e broadcasts (`DataService.fetchTips`).
-5.  **Module Init:** Instancia cada módulo (Notes, Email, Script, etc.), que retornam suas funções de controle (ex: `toggleNotes`).
+5.  **Module Init:** Instancia cada módulo (Notes, Email, Call Script, Timezone, BAU Central, Minha Biblioteca, Configurações, etc.), que retornam suas funções de controle (ex: `toggleNotes`).
 6.  **Command Center:** Injeta a pílula flutuante principal, passando as funções de controle dos módulos para os botões.
 
 ## 3. Fluxo de Dados (Backend Serverless)
-Como não possuímos um backend tradicional, utilizamos o **Google Apps Script** como API.
+Como não possuímos um backend tradicional, utilizamos o **Google Apps Script** como API. O código-fonte do backend vive em [`gas-backend/`](../gas-backend/) neste mesmo repositório, sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp) (fluxo de deploy separado do build do front-end — veja `docs/WORKFLOW.md`). O banco de dados é uma planilha Google Sheets (ver `specs/data-models/db-schema.md`).
 
-* **Interface:** `src/modules/shared/data-service.js`.
-* **Leitura (GET via JSONP):** Para evitar bloqueios de CORS em requisições GET, utilizamos a técnica de **JSONP**.
-    * O script cria uma tag `<script>` apontando para a macro do Google.
-    * A macro retorna o JSON embrulhado em uma função de callback (`cw_cb_12345(...)`).
-    * O frontend executa essa função e resolve a Promise com os dados.
-* **Escrita (POST no-cors):** Para logs e envio de broadcasts.
-    * Utilizamos `fetch` com `mode: 'no-cors'`.
-    * **Limitação:** Não recebemos resposta de sucesso/erro (Opaque Response), mas os dados são processados pelo servidor.
+* **Interface (front-end):** `src/modules/shared/data-service.js`.
+* **Roteamento (back-end):** `gas-backend/Código.js`, função `doGet(e)` — despacha por `op` (`op=broadcast`, `op=create_bau`, `op=get_user_profile`, etc.) para os módulos correspondentes (`BAU_API.js`, `BAUForm.js`...).
+* **Todas as chamadas (leitura e escrita) usam JSONP**, não `fetch`: o front cria uma tag `<script src="...&callback=cw_cb_XXXX">`, o backend devolve o JSON embrulhado nessa função de callback (`cw_cb_XXXX(...)`), e o front resolve a Promise quando a função global é chamada. Isso evita bloqueios de CORS, mas significa que toda operação (inclusive escritas como `new_broadcast` ou `create_bau`) passa pela URL como query string.
+* **TL Dashboard (`gas-backend/TLDashboard.html`):** é servido diretamente pelo `doGet` (`?page=tl`) como uma página HTML Service própria, separada da API JSONP acima. As ações dessa página (`getPendingBAUCases`, `updateBAUCaseStatus`) usam a ponte nativa `google.script.run`, que roda no contexto autenticado de quem carregou a página — não passam pelo `op=` do roteador JSONP.
+* **Acesso:** o Web App do Apps Script está configurado com `access: "DOMAIN"` (`gas-backend/appsscript.json`) — só usuários autenticados do mesmo domínio Google Workspace conseguem chamar a API, não é público na internet.
 
 ## 4. Design System & UI
 A interface não usa frameworks (React/Vue). É construída com **Vanilla JS** e **CSS-in-JS**.

--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -1,1 +1,11 @@
 # Business Rules
+
+Este arquivo estava vazio (só o título). As regras de negócio do projeto hoje vivem em [`specs/`](../specs/_MASTER_RULEBOOK.md), que é a fonte da verdade ativa e mantida em sincronia com o código:
+
+* [`specs/_MASTER_RULEBOOK.md`](../specs/_MASTER_RULEBOOK.md) — filosofia do projeto, stack permitida, padrões de nomenclatura.
+* [`specs/workflow/bau-lifecycle.md`](../specs/workflow/bau-lifecycle.md) — ciclo de vida e regras de status do fluxo BAU.
+* [`specs/workflow/scraping-rules.md`](../specs/workflow/scraping-rules.md) — regras de extração de dados do CRM.
+* [`specs/data-models/db-schema.md`](../specs/data-models/db-schema.md) e [`api-payloads.md`](../specs/data-models/api-payloads.md) — contrato de dados entre front-end e backend.
+* [`specs/ui-ux/design-system.md`](../specs/ui-ux/design-system.md) e [`dom-standards.md`](../specs/ui-ux/dom-standards.md) — regras visuais e de interação obrigatórias.
+
+Se este arquivo voltar a ser necessário como um resumo de negócio separado (não técnico), vale escrevê-lo a partir do conteúdo de `specs/` em vez de do zero, para não divergir.

--- a/docs/CORE_MODULES.md
+++ b/docs/CORE_MODULES.md
@@ -1,13 +1,17 @@
 # 🧩 Módulos Core - Análise Profunda
 
 ## 1. Case Notes (`src/modules/notes/`)
-O módulo mais complexo, responsável pela geração de notas padronizadas.
+O módulo mais complexo, responsável pela geração de notas padronizadas. Já foi decomposto em subpastas:
+* `core/` — `notes-state.js` (estado do formulário), `form-builder.js` (construção dos campos dinâmicos), `output-generator.js` (montagem do HTML final).
+* `ui/` — `notes-popup.js` (janela/popup).
+* `data/` — `notes-data.js` (templates/tasks/traduções), `screenshot-rules.js`.
+* `components/`, `drafts/`, `automation/` — subcomponentes visuais, sistema de rascunhos e o scraper de Speakeasy ID.
 
 ### Componentes Principais:
-* **`notes-data.js`**: O "Banco de Dados". Contém os templates de texto (`SUBSTATUS_TEMPLATES`), tarefas (`TASKS_DB`) e traduções. É aqui que você edita o texto das notas.
+* **`data/notes-data.js`**: O "Banco de Dados". Contém os templates de texto (`SUBSTATUS_TEMPLATES`), tarefas (`TASKS_DB`) e traduções. É aqui que você edita o texto das notas.
 * **`notes-bridge.js`**: A ponte com o CRM. Contém a função crítica `ensureNoteCardIsOpen`.
     * *Lógica:* Tenta encontrar o botão de "Nova Nota" por ícones ou seletores específicos. Após clicar, entra em um loop de verificação (`while`) monitorando o DOM até que um novo editor de texto (`contenteditable`) apareça na tela.
-* **`step-tasks.js`**: O seletor visual de tarefas. Gerencia contadores, seleção de marcas (Ads, Analytics) e exibe inputs condicionais de screenshots.
+* **`components/step-tasks.js`**: O seletor visual de tarefas. Gerencia contadores, seleção de marcas (Ads, Analytics) e exibe inputs condicionais de screenshots.
 
 ### Fluxo de Geração:
 1.  Usuário seleciona Status/Substatus.
@@ -15,8 +19,8 @@ O módulo mais complexo, responsável pela geração de notas padronizadas.
 3.  O texto é montado substituindo placeholders (`{CAMPO}`) no template.
 4.  O HTML final é inserido no editor do CRM via `document.execCommand('insertHTML')` para garantir que o Angular do CRM reconheça a mudança.
 
-## 2. Quick Email (`src/modules/quick-email/`)
-Automação de e-mails com detecção de contexto.
+## 2. Email Assistant (`src/modules/email-assistant/`)
+Automação de e-mails com detecção de contexto. Templates vêm de `email-data.js` (array de objetos com placeholders declarados) em vez de hardcoded por template — inclui também os atalhos "Smart CR" ligados aos `SUBSTATUS_SHORTCODES` do Case Notes.
 
 ### O Problema do "Rascunho Fantasma"
 O CRM frequentemente mantém rascunhos sujos em memória.
@@ -40,3 +44,12 @@ Responsável por "ler" a tela e extrair informações contextuais (Nome do Clien
 A "Pílula" flutuante.
 * Implementa uma física de arraste customizada que "imanta" o widget nas bordas laterais ao soltar (`onMouseUp`), garantindo que ele nunca fique no meio do texto.
 * Gerencia o estado de "Processamento" (animação das bolinhas do Google) quando uma automação longa está rodando.
+
+## 5. BAU Central (`src/modules/bau-form/`)
+Wizard de escalação de caso para BAU. `bau-form-config.js` declara os passos e campos do formulário como dados (`FORM_CONFIG`), e `bau-form-assistant.js` monta o DOM a partir dessa config — inclui dashboard dos próprios casos, fluxo de edição e ramificação Abertura vs. Descarte. Consome `sendBAUEscalation`/`readAgentBAU`/`updateBAUEscalation` de `shared/data-service.js`. Ver `specs/workflow/bau-lifecycle.md` para as regras de status.
+
+## 6. Minha Biblioteca (`src/modules/personal-library/`)
+Snippets pessoais (notas, e-mails, textos gerais). `snippet-service.js` usa uma estratégia *cache-first*: lê do `localStorage` imediatamente e sincroniza com a planilha em segundo plano, com uma trava (`isMutating`) para evitar sobrescrever uma edição em andamento.
+
+## 7. Configurações (`src/modules/configs/`)
+Perfil do agente (papel/segmento/idioma, vindo de `fetchUserProfile` no backend), preferências de som e link de feedback.

--- a/docs/TL_DASHBOARD_DIAGNOSTIC.md
+++ b/docs/TL_DASHBOARD_DIAGNOSTIC.md
@@ -1,5 +1,7 @@
 # Diagnóstico do TL Dashboard
 
+> ⚠️ **Status: Backlog / não implementado.** Apesar do nome, este arquivo não descreve o comportamento atual do TL Dashboard — é uma lista de melhorias propostas que ainda não foram construídas. Confirme no código (`gas-backend/BAU_Dashboard.js`, `gas-backend/TLDashboard.html`) antes de assumir que algo aqui já existe.
+
 Para que o TL Dashboard reflita essas edições em tempo real, as seguintes alterações no arquivo **TLDashboard.html** serão necessárias no futuro:
 
 1.  **Auto-Refresh (Polling):** Implementar um mecanismo de atualização automática utilizando `setInterval` que execute a função `loadCases()` em intervalos regulares (ex: a cada 3 ou 5 minutos), garantindo que a lista de casos pendentes esteja sempre sincronizada sem depender exclusivamente do clique manual em "Sincronizar".

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -4,16 +4,21 @@ Como o projeto roda injetado em um ambiente de produção de terceiros, **não e
 
 ## 1. O Ciclo de Desenvolvimento
 1.  **Código:** Edite os arquivos na pasta `src/`.
-2.  **Build:** O projeto usa `esbuild` para empacotar os módulos em um único arquivo.
-    * Comando: `npm install` (primeira vez)
-    * O GitHub Actions roda o build automaticamente no Push.
+2.  **Build:** O projeto usa `esbuild` para empacotar os módulos em um único arquivo (`npm install` na primeira vez).
+    * `npm run build` → `dist/bundle.js` (minificado, produção).
+    * `npm run dev` → `dist/bundle-dev.js` (sem minificação, debug).
+    * O GitHub Actions roda o build automaticamente a cada push (`.github/workflows/deploy.yml`), não é necessário rodar manualmente antes de commitar.
 3.  **Deploy:**
-    * Commits na branch `main` geram o `dist/bundle.js` (Produção).
-    * Commits na branch `refactor-structure` geram o `dist/bundle-dev.js` (Desenvolvimento).
+    * Commits na branch `main` geram o `dist/bundle.js` (Produção), publicado via GitHub Pages.
+    * Commits na branch `refactor-structure` geram o `dist/bundle-dev.js` (Desenvolvimento) — na prática, essa é a branch usada no dia a dia; `main` só recebe merge quando algo está pronto para produção.
 4.  **Teste:**
     * Vá até o CRM.
     * Use o **Bookmarklet de DEV** (veja `README.md`) para injetar a versão de teste.
     * O console do navegador mostrará "✅ TechSol DEV carregado!".
+5.  **Backend (Google Apps Script):** o código em `gas-backend/` é sincronizado com o projeto Apps Script via `clasp push` (fluxo manual, não passa pelo GitHub Actions). Alterações lá exigem visibilidade cuidadosa do impacto — mais de um módulo do front-end depende do contrato de payload descrito em `specs/data-models/`.
+
+## 1.1 Visual/Portfolio (opcional)
+O script `generate-portfolio.py` (Playwright) abre `mock-crm.html` — um HTML estático que imita o layout do CRM alvo — injeta o bundle e grava os prints/vídeo usados no `README.md`. Não é um ambiente de teste funcional (não substitui testar no CRM real), serve só para gerar material visual. Rodar com `npm run portfolio` (requer `pip install playwright` + `playwright install` previamente).
 
 ## 2. Adicionando Novos Recursos
 ### Criar um Novo Módulo


### PR DESCRIPTION
## Summary
Documentação estava bem defasada em relação ao código atual. Corrigido, arquivo por arquivo:

- **README.md**: versão do rodapé (v2.5 → v5.2) e placeholder de mantenedor não preenchido; lista de funcionalidades só cobria 3 dos ~9 módulos que existem hoje; seção "Desenvolvimento Local" não mencionava `mock-crm.html`/`generate-portfolio.py` nem os scripts reais do `npm`; adicionados screenshots do BAU/Configs que já existiam em `docs/media/` mas não apareciam em lugar nenhum.
- **docs/ARCHITECTURE.md**: corrigida a descrição do fluxo de escrita (dizia `fetch(mode: no-cors)`, o código real usa JSONP pra tudo); adicionados ponteiros pra `gas-backend/`, a restrição de acesso `DOMAIN` do Apps Script, e a diferença entre a API JSONP e o TL Dashboard (autenticado via `google.script.run`, não passa pelo roteador `op=`).
- **docs/CORE_MODULES.md**: referência a `quick-email/` (não existe mais, virou `email-assistant/`) corrigida; seção de Case Notes atualizada pra estrutura atual (`core/`, `ui/`, `data/`); adicionadas seções pros 3 módulos que não existiam quando o arquivo foi escrito (BAU Central, Minha Biblioteca, Configurações).
- **docs/WORKFLOW.md**: comandos reais (`npm run build`/`npm run dev`) no lugar de "esbuild faz sua mágica"; adicionado o passo de deploy do backend via `clasp` (não documentado em lugar nenhum antes); nota sobre o pipeline visual do `mock-crm.html`.
- **docs/BUSINESS_RULES.md**: era um stub vazio (só o título). Virou um ponteiro pra `specs/`, que já cobre essa base e está em sincronia com o código — preferi isso a inventar regras de negócio que eu não sei de verdade.
- **docs/TL_DASHBOARD_DIAGNOSTIC.md**: apesar do nome, é uma lista de melhorias propostas, não uma descrição do comportamento atual. Adicionei um aviso de status no topo pra não ser confundido com doc de estado atual — conteúdo original mantido.

Também deixei registrado que `specs/` (pasta adicionada depois) é hoje a fonte da verdade ativa pra regras de negócio/contrato de API/padrões de UI, e `docs/` foca em visão arquitetural de alto nível — um ponteiro no topo do `ARCHITECTURE.md` deixa isso claro pra quem chegar no projeto agora.

## Por que
Parte da limpeza pedida: documentação, branches (já feito) e arquitetura geral do repositório.

## O que revisar
- Só arquivos `.md`, nenhuma mudança de código.
- Vale conferir se o texto do "Mantenedor" no README está do jeito que você quer.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)