### PR TITLE
security(gas-backend): restrict TL Dashboard actions to leadership roles

### DIFF
--- a/gas-backend/BAU_Dashboard.js
+++ b/gas-backend/BAU_Dashboard.js
@@ -4,6 +4,8 @@
 // =========================================================
 
 function getPendingBAUCases() {
+  assertCallerIsOverhead();
+
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const sheet = getOrCreateSheet(ss, SHEET_BAU_FORM); 
   const data = sheet.getDataRange().getValues();
@@ -35,11 +37,13 @@ function getPendingBAUCases() {
 }
 
 function updateBAUCaseStatus(id, newStatus) {
+  assertCallerIsOverhead();
+
   const lock = LockService.getScriptLock();
-  
+
   try {
-    lock.waitLock(10000); 
-    
+    lock.waitLock(10000);
+
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const sheet = getOrCreateSheet(ss, SHEET_BAU_FORM);
     const data = sheet.getDataRange().getValues();

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -182,60 +182,10 @@ function doGet(e) {
     else if (op === 'get_user_profile') {
       const userEmail = p.user || "";
       const ldap = (p.ldap || userEmail.split('@')[0]).toLowerCase().trim();
-      
+
       if (!ldap) throw new Error("LDAP/User is required");
 
-      const sheet = ss.getSheetByName(SHEET_PEOPLE);
-      
-      // Objeto de fallback super restrito (caso o LDAP não esteja na planilha)
-      let profile = {
-        ldap: ldap,
-        role: "Unknown",
-        roleCategory: "Agent", // Por segurança, desconhecidos são tratados como Agentes (sem admin)
-        segment: "PT",
-        defaultLanguage: "PT-BR",
-        isOverhead: false 
-      };
-
-      if (sheet) {
-        const data = sheet.getDataRange().getValues();
-        
-        // Pula o cabeçalho (i=1) e varre a lista
-        for (let i = 1; i < data.length; i++) {
-          const rowLdap = String(data[i][0]).toLowerCase().trim();
-          
-          if (rowLdap === ldap) {
-            const role = String(data[i][1] || "").trim();
-            const roleCategory = String(data[i][2] || "").trim();
-            const segment = String(data[i][3] || "").trim();
-            
-            // Regra 1: Permissões (Overhead). Bloqueia APENAS Agent e Apprentice.
-            const catLower = roleCategory.toLowerCase();
-            const isOverhead = !(catLower.includes('agent') || catLower.includes('apprentice'));
-            
-            // Regra 2: Idiomas. Staff = PT. PT = PT. ES = ES.
-            let lang = "PT-BR"; // Padrão
-            const segLower = segment.toLowerCase();
-            if (segLower === 'es') {
-              lang = "ES";
-            } else if (segLower === 'en') {
-              lang = "EN";
-            }
-            
-            profile = {
-              ldap: ldap,
-              role: role,                 // Capturado exato para a futura Badge
-              roleCategory: roleCategory,
-              segment: segment,
-              defaultLanguage: lang,
-              isOverhead: isOverhead
-            };
-            break; // Achou o usuário, para o loop
-          }
-        }
-      }
-      
-      result = { status: 'success', profile: profile };
+      result = { status: 'success', profile: getUserProfileByLdap(ldap) };
     }
 
   } catch (err) {
@@ -255,6 +205,84 @@ function doGet(e) {
 // =========================================================
 //  FUNÇÕES AUXILIARES (HELPERS)
 // =========================================================
+
+// Busca o perfil (papel/segmento/permissão) de um LDAP na planilha "People".
+// Extraído do handler de 'get_user_profile' para poder ser reaproveitado
+// pela checagem de permissão (assertCallerIsOverhead).
+function getUserProfileByLdap(ldap) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(SHEET_PEOPLE);
+
+  // Objeto de fallback super restrito (caso o LDAP não esteja na planilha)
+  let profile = {
+    ldap: ldap,
+    role: "Unknown",
+    roleCategory: "Agent", // Por segurança, desconhecidos são tratados como Agentes (sem admin)
+    segment: "PT",
+    defaultLanguage: "PT-BR",
+    isOverhead: false
+  };
+
+  if (sheet) {
+    const data = sheet.getDataRange().getValues();
+
+    // Pula o cabeçalho (i=1) e varre a lista
+    for (let i = 1; i < data.length; i++) {
+      const rowLdap = String(data[i][0]).toLowerCase().trim();
+
+      if (rowLdap === ldap) {
+        const role = String(data[i][1] || "").trim();
+        const roleCategory = String(data[i][2] || "").trim();
+        const segment = String(data[i][3] || "").trim();
+
+        // Regra 1: Permissões (Overhead). Bloqueia APENAS Agent e Apprentice.
+        const catLower = roleCategory.toLowerCase();
+        const isOverhead = !(catLower.includes('agent') || catLower.includes('apprentice'));
+
+        // Regra 2: Idiomas. Staff = PT. PT = PT. ES = ES.
+        let lang = "PT-BR"; // Padrão
+        const segLower = segment.toLowerCase();
+        if (segLower === 'es') {
+          lang = "ES";
+        } else if (segLower === 'en') {
+          lang = "EN";
+        }
+
+        profile = {
+          ldap: ldap,
+          role: role,                 // Capturado exato para a futura Badge
+          roleCategory: roleCategory,
+          segment: segment,
+          defaultLanguage: lang,
+          isOverhead: isOverhead
+        };
+        break; // Achou o usuário, para o loop
+      }
+    }
+  }
+
+  return profile;
+}
+
+// Garante que quem está chamando (identidade real, vinda de Session.getActiveUser(),
+// não de um parâmetro enviado pelo cliente) tem papel de liderança (isOverhead).
+// Lança erro se não tiver — para ser usada no início de ações restritas ao TL,
+// chamadas via google.script.run a partir do TLDashboard.html.
+function assertCallerIsOverhead() {
+  const email = Session.getActiveUser().getEmail();
+  const ldap = email ? email.split('@')[0].toLowerCase().trim() : "";
+
+  if (!ldap) {
+    throw new Error("Não foi possível identificar o usuário autenticado.");
+  }
+
+  const profile = getUserProfileByLdap(ldap);
+  if (!profile.isOverhead) {
+    throw new Error("Acesso negado: esta ação é restrita à liderança (TL).");
+  }
+
+  return profile;
+}
 
 function handleLog(p) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();


### PR DESCRIPTION
## ⚠️ Este PR NÃO segue o fluxo normal de deploy — leia antes de mergear

`gas-backend/` não é buildado/deployado pelo GitHub Actions deste repo. Depois de mergear (ou até antes, pra testar), você precisa rodar `clasp push` a partir de `gas-backend/` manualmente pra essa mudança valer no Apps Script real. Eu não tenho acesso pra fazer isso nem pra testar — só revisei o código e validei a sintaxe com `node --check`.

## O problema
`getPendingBAUCases()` e `updateBAUCaseStatus()` (chamadas do `TLDashboard.html` via `google.script.run`) não tinham **nenhuma** checagem de permissão. Como o webapp só exige login no domínio (não um papel específico), qualquer pessoa autenticada do domínio que soubesse a URL `?page=tl` conseguia listar os casos BAU pendentes de qualquer agente e aprovar/descartar/criar qualquer um deles — não só quem é Team Lead de verdade.

## O fix
- Adicionei `assertCallerIsOverhead()`, que lê a identidade real de quem chamou via `Session.getActiveUser().getEmail()` — essa é a identidade autenticada de verdade pra chamadas `google.script.run` (diferente do parâmetro `user`/`ldap` que os endpoints JSONP recebem do cliente, esse não dá pra falsificar) — busca o papel dela na planilha "People" e lança erro se não for liderança (mesma flag `isOverhead` que `get_user_profile` já expõe pro front-end).
- Chamada logo no início das duas funções do TL Dashboard, antes de ler ou escrever qualquer dado.
- Extraí a busca na planilha "People" (antes só existia dentro do handler de `get_user_profile`) pra uma função `getUserProfileByLdap(ldap)` reaproveitada nos dois lugares.
- Confirmei que isso degrada bem: os dois pontos de chamada no `TLDashboard.html` já têm `.withFailureHandler()` registrado, então um erro vira um toast ("Falha ao processar ação"/"Erro ao sincronizar"), não quebra a tela.
- Confirmei que `Session.getActiveUser()` já é usado com sucesso nesse mesmo deployment: `sendDynamicTechSolEmail()` já depende dele pra atribuir o e-mail do TL, e `Teste.js` tem um teste (`testLdapAttribution`) específico pra esse caminho.

## O que NÃO entrou aqui (fica pra depois)
Os endpoints JSONP (`read_agent_bau`, `update_bau`, `get_user_snippets` etc.) ainda confiam no parâmetro `user`/`ldap` que o próprio cliente envia, sem verificar contra uma sessão real — isso é um caminho de código diferente (JSONP via tag `<script>`, não `google.script.run`) sem um equivalente direto ao `Session.getActiveUser()` disponível do mesmo jeito. Corrigir isso é um trabalho separado, maior.

## Test plan (precisa ser feito por você, manualmente)
- [ ] `clasp push` a partir de `gas-backend/`
- [ ] Testar como agente comum (não-liderança): confirmar que abrir `?page=tl` agora falha graciosamente em vez de mostrar/permitir ações nos casos
- [ ] Testar como TL de verdade: confirmar que o dashboard continua funcionando normalmente

🤖 Gerado com [Claude Code](https://claude.com/claude-code)