### PR TITLE
ci: auto-promote the dev Apps Script deployment on refactor-structure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,3 +85,17 @@ jobs:
         run: |
           cd gas-backend
           clasp push -f
+
+      # --- PROMOÇÃO AUTOMÁTICA DA IMPLANTAÇÃO (Apenas na refactor-structure) ---
+      # `clasp push` só atualiza o HEAD do projeto (visível no editor); a URL
+      # de produção (/exec) fica travada numa versão até alguém promover uma
+      # implantação existente pra uma versão nova. Aqui automatizamos essa
+      # promoção só pro deployment de desenvolvimento (o ID abaixo é o mesmo
+      # SCRIPT_ID usado em src/modules/shared/data-service.js nesta branch —
+      # se ele for rotacionado algum dia, atualize os dois em conjunto).
+      # A implantação de produção (usada pela `main`) continua manual, de propósito.
+      - name: Promover implantação de desenvolvimento
+        if: github.ref == 'refs/heads/refactor-structure'
+        run: |
+          cd gas-backend
+          clasp deploy -i "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg" -d "Auto-deploy via GitHub Actions ($GITHUB_SHA)"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ O front-end injeta em cima do CRM real, então não existe um "localhost" tradic
 3.  Rode `npm run build` (gera `dist/bundle.js`, minificado) ou `npm run dev` (gera `dist/bundle-dev.js`, sem minificação). O GitHub Actions roda o build automaticamente a cada push — veja `docs/WORKFLOW.md`.
 4.  Use o **Bookmarklet de Dev** para testar as alterações em tempo real no ambiente de produção.
 
-**Backend (Google Apps Script):** o código do backend vive em `gas-backend/` e é sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp) (`clasp push`/`clasp pull`), separado do pipeline de build do front-end.
+**Backend (Google Apps Script):** o código do backend vive em `gas-backend/` e é sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp). O `clasp push` já é automático — roda no mesmo `.github/workflows/deploy.yml`, num job separado do build do front-end, a cada push em `main` ou `refactor-structure`. A **promoção da implantação de desenvolvimento** (o que torna o código novo realmente ativo na URL usada pelo bookmarklet de dev) também é automática, só na `refactor-structure`. A implantação de **produção** (usada pela `main`) continua sendo promovida manualmente, de propósito.
 
 -----
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,13 +21,14 @@ O ponto de entrada é o arquivo `app.js`. Ele orquestra o "boot" da aplicação 
 6.  **Command Center:** Injeta a pílula flutuante principal, passando as funções de controle dos módulos para os botões.
 
 ## 3. Fluxo de Dados (Backend Serverless)
-Como não possuímos um backend tradicional, utilizamos o **Google Apps Script** como API. O código-fonte do backend vive em [`gas-backend/`](../gas-backend/) neste mesmo repositório, sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp) (fluxo de deploy separado do build do front-end — veja `docs/WORKFLOW.md`). O banco de dados é uma planilha Google Sheets (ver `specs/data-models/db-schema.md`).
+Como não possuímos um backend tradicional, utilizamos o **Google Apps Script** como API. O código-fonte do backend vive em [`gas-backend/`](../gas-backend/) neste mesmo repositório, sincronizado com o projeto Apps Script via [`clasp`](https://github.com/google/clasp) (job próprio dentro do mesmo `.github/workflows/deploy.yml`, separado do build do front-end — veja `docs/WORKFLOW.md` para o detalhe de push vs. promoção de implantação). O banco de dados é uma planilha Google Sheets (ver `specs/data-models/db-schema.md`).
 
 * **Interface (front-end):** `src/modules/shared/data-service.js`.
 * **Roteamento (back-end):** `gas-backend/Código.js`, função `doGet(e)` — despacha por `op` (`op=broadcast`, `op=create_bau`, `op=get_user_profile`, etc.) para os módulos correspondentes (`BAU_API.js`, `BAUForm.js`...).
 * **Todas as chamadas (leitura e escrita) usam JSONP**, não `fetch`: o front cria uma tag `<script src="...&callback=cw_cb_XXXX">`, o backend devolve o JSON embrulhado nessa função de callback (`cw_cb_XXXX(...)`), e o front resolve a Promise quando a função global é chamada. Isso evita bloqueios de CORS, mas significa que toda operação (inclusive escritas como `new_broadcast` ou `create_bau`) passa pela URL como query string.
 * **TL Dashboard (`gas-backend/TLDashboard.html`):** é servido diretamente pelo `doGet` (`?page=tl`) como uma página HTML Service própria, separada da API JSONP acima. As ações dessa página (`getPendingBAUCases`, `updateBAUCaseStatus`) usam a ponte nativa `google.script.run`, que roda no contexto autenticado de quem carregou a página — não passam pelo `op=` do roteador JSONP.
 * **Acesso:** o Web App do Apps Script está configurado com `access: "DOMAIN"` (`gas-backend/appsscript.json`) — só usuários autenticados do mesmo domínio Google Workspace conseguem chamar a API, não é público na internet.
+* **Dev vs. Produção são implantações (deployments) diferentes**, não uma só compartilhada: `main` e `refactor-structure` têm cada uma seu próprio `SCRIPT_ID`/deployment ID hardcoded em `data-service.js` (URLs `.../s/{id}/exec` distintas). Ambas compartilham o mesmo código-fonte (`gas-backend/`) e o mesmo projeto Apps Script, mas cada implantação fica travada na versão em que foi promovida por último — ver `docs/WORKFLOW.md`.
 
 ## 4. Design System & UI
 A interface não usa frameworks (React/Vue). É construída com **Vanilla JS** e **CSS-in-JS**.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -15,7 +15,11 @@ Como o projeto roda injetado em um ambiente de produção de terceiros, **não e
     * Vá até o CRM.
     * Use o **Bookmarklet de DEV** (veja `README.md`) para injetar a versão de teste.
     * O console do navegador mostrará "✅ TechSol DEV carregado!".
-5.  **Backend (Google Apps Script):** o código em `gas-backend/` é sincronizado com o projeto Apps Script via `clasp push` (fluxo manual, não passa pelo GitHub Actions). Alterações lá exigem visibilidade cuidadosa do impacto — mais de um módulo do front-end depende do contrato de payload descrito em `specs/data-models/`.
+5.  **Backend (Google Apps Script):** o código em `gas-backend/` é sincronizado com o projeto Apps Script pelo job `deploy-backend-gas` (mesmo `deploy.yml`, job separado do front-end), rodando `clasp push -f` a cada push em `main` ou `refactor-structure`.
+    * **Importante:** `clasp push` só atualiza o HEAD do projeto (o que aparece no editor do Apps Script) — a URL de produção (`.../exec`) fica travada numa versão até alguém *promover* uma implantação existente pra uma versão nova.
+    * Na `refactor-structure`, essa promoção também é automática (step "Promover implantação de desenvolvimento", via `clasp deploy -i <deploymentId>`), então o deployment de dev fica sempre sincronizado com o HEAD.
+    * Na `main`, a promoção da implantação de **produção** continua manual, de propósito (via Apps Script UI: Implantar → Gerenciar implantações → Nova versão, ou `clasp deploy -i <deploymentId-de-produção>`) — assim um push não vira produção sem alguém decidir isso explicitamente.
+    * Alterações no backend exigem visibilidade cuidadosa do impacto — mais de um módulo do front-end depende do contrato de payload descrito em `specs/data-models/`.
 
 ## 1.1 Visual/Portfolio (opcional)
 O script `generate-portfolio.py` (Playwright) abre `mock-crm.html` — um HTML estático que imita o layout do CRM alvo — injeta o bundle e grava os prints/vídeo usados no `README.md`. Não é um ambiente de teste funcional (não substitui testar no CRM real), serve só para gerar material visual. Rodar com `npm run portfolio` (requer `pip install playwright` + `playwright install` previamente).


### PR DESCRIPTION
## Resumo
`clasp push` só atualiza o HEAD do projeto Apps Script (o que aparece no editor) — não atualiza a URL de produção (`/exec`), que fica travada numa versão até alguém promover manualmente uma implantação existente pra versão nova. O job `deploy-backend-gas` já existia e já fazia o push automaticamente, mas nunca fazia essa promoção — daí a confusão de sempre precisar gerar implantação nova na mão.

Adicionei um step `clasp deploy -i <deploymentId>`, rodando só na `refactor-structure` (`if: github.ref == refs/heads/refactor-structure`). O ID usado é o mesmo `SCRIPT_ID` hardcoded em `src/modules/shared/data-service.js` nessa branch — confirmei que `main` e `refactor-structure` apontam pra implantações diferentes do Apps Script (SCRIPT_IDs diferentes), então essa mudança não tem como afetar a implantação de produção que a `main` usa. A promoção de produção continua manual, por escolha sua (já que a `refactor-structure` é onde você pode errar à vontade, e a `main` só recebe o que já foi validado lá).

## Correção de documentação
No PR #204 eu tinha escrito que o deploy do backend era "manual, não passa pelo GitHub Actions" — isso estava errado (o push já era automático). Corrigi `README.md`, `docs/WORKFLOW.md` e `docs/ARCHITECTURE.md`, e documentei o fato de `main`/`refactor-structure` usarem implantações separadas (não estava escrito em lugar nenhum antes).

## ⚠️ Não consigo testar isso sozinho
Não tenho acesso ao projeto Apps Script nem ao secret `CLASPRC_JSON`. Validei só a sintaxe do YAML (`js-yaml`). Depois de mergear, acompanhe a execução do Actions no próximo push pra `refactor-structure` e confirme que o step "Promover implantação de desenvolvimento" passa.

## Test plan
- [x] YAML validado com `js-yaml`
- [ ] Confirmar que o job `deploy-backend-gas` roda com sucesso no Actions após o merge
- [ ] Confirmar que o código novo (ex: o fix de segurança do TL Dashboard) está de fato ativo na URL de dev depois disso

🤖 Gerado com [Claude Code](https://claude.com/claude-code)