### PR TITLE
ci: add timestamp/commit to deploy description + Actions job summary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,8 +94,35 @@ jobs:
       # SCRIPT_ID usado em src/modules/shared/data-service.js nesta branch —
       # se ele for rotacionado algum dia, atualize os dois em conjunto).
       # A implantação de produção (usada pela `main`) continua manual, de propósito.
+      #
+      # A descrição da implantação (com data/hora + commit) fica visível em
+      # "Gerenciar implantações" no editor do Apps Script, e o mesmo resumo
+      # também vai pro Job Summary desta execução do Actions — assim dá pra
+      # confirmar "a implantação de dev está na versão de tal commit, feita
+      # às tal hora" sem precisar adivinhar ou disparar uma automação manual
+      # só pra checar.
       - name: Promover implantação de desenvolvimento
         if: github.ref == 'refs/heads/refactor-structure'
+        env:
+          DEPLOYMENT_ID: "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg"
         run: |
           cd gas-backend
-          clasp deploy -i "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg" -d "Auto-deploy via GitHub Actions ($GITHUB_SHA)"
+
+          TIMESTAMP="$(date -u +'%Y-%m-%d %H:%M UTC')"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          DESCRIPTION="Deploy automático - $TIMESTAMP - commit $SHORT_SHA"
+
+          DEPLOY_OUTPUT="$(clasp deploy -i "$DEPLOYMENT_ID" -d "$DESCRIPTION")"
+          echo "$DEPLOY_OUTPUT"
+
+          {
+            echo "## 🚀 Implantação de desenvolvimento atualizada"
+            echo ""
+            echo "- **Quando:** $TIMESTAMP"
+            echo "- **Commit:** \`$SHORT_SHA\` ($GITHUB_SHA)"
+            echo "- **Deployment ID:** \`$DEPLOYMENT_ID\`"
+            echo ""
+            echo '```'
+            echo "$DEPLOY_OUTPUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Resumo
Continuação do #206, resolvendo o "como eu tenho certeza absoluta que a implantação foi atualizada" sem precisar configurar nenhuma infraestrutura nova (nada de e-mail/Slack):

- A descrição passada pro `clasp deploy` (`-d`) agora inclui data/hora (UTC) e o commit curto, não só o `$GITHUB_SHA` cru. Essa descrição aparece em **"Gerenciar implantações"** no editor do Apps Script — então abrir essa tela já responde "quando foi a última atualização, de qual commit", sem precisar cruzar informação em lugar nenhum.
- A mesma informação (data/hora, commit, deployment ID, saída bruta do `clasp`) agora também vai pro **Job Summary** dessa execução do Actions — aparece direto na página do run, sem precisar nem abrir o Apps Script pra confirmar que o deploy passou.

## Sobre o número de versão ("31", "32"...)
Isso vai continuar incrementando a cada deploy, e tudo bem — é normal, nada no front-end depende desse número. O que importa é o **Deployment ID ficar estável**, e isso o `-i` já garante (confirmado: o ID que apareceu no log depois do merge do #206 bateu com o que está hardcoded em `data-service.js`).

## O que revisar
- Só o workflow (`deploy.yml`), sem mudança de comportamento do app.
- YAML validado com `js-yaml`.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)