### PR TITLE
fix(gas-backend): BAU edit data bug + codify weekly backup trigger

### DIFF
--- a/gas-backend/BAU_API.js
+++ b/gas-backend/BAU_API.js
@@ -64,6 +64,22 @@ function getAgentCases(ss, userEmail) {
     const status = String(row[3]);
     
     if (rowEmail === userEmail.toLowerCase().trim()) {
+      // Coluna 16 guarda "Motivo | Descrição" mesclados (ver handleBAUEscalation
+      // e update_bau_case) só para o fluxo BAU — o fluxo DISCARD nunca mescla,
+      // grava só a descrição pura. Desfazemos a mesma mescla aqui, senão o
+      // formulário de edição nunca consegue pré-preencher o dropdown de motivo
+      // e acaba jogando a string inteira ("Motivo | Descrição") no campo de texto.
+      const rawDescription = String(row[16] || "");
+      const isDiscardFlow = status === 'PENDING_TL_DISCARD' || status === 'DISCARDED';
+      let nonImplementationReason = "";
+      let description = rawDescription;
+
+      if (!isDiscardFlow && rawDescription.includes(" | ")) {
+        const descParts = rawDescription.split(" | ");
+        nonImplementationReason = descParts[0] || "";
+        description = descParts.slice(1).join(" | ") || "";
+      }
+
       myCases.push({
         id: String(row[0]),
         date: row[1] instanceof Date ? row[1].toISOString() : String(row[1]),
@@ -81,11 +97,12 @@ function getAgentCases(ss, userEmail) {
         salesProgram: String(row[13] || ""),
         reason: String(row[14] || ""),
         task: String(row[15] || ""),
-        description: String(row[16] || ""),
+        nonImplementationReason: nonImplementationReason,
+        description: description,
         availability: row[17] instanceof Date ? row[17].toISOString() : String(row[17] || "")
       });
-      
-      if (myCases.length >= 30) break; 
+
+      if (myCases.length >= 30) break;
     }
   }
   return { status: 'success', cases: myCases };

--- a/gas-backend/Backup.js
+++ b/gas-backend/Backup.js
@@ -51,3 +51,35 @@ function runWeeklyBackup() {
     console.log("ℹ️ Nenhum caso finalizado precisava de backup hoje.");
   }
 }
+
+/**
+ * ⚠️ AÇÃO MANUAL NECESSÁRIA — rode esta função UMA VEZ pelo editor do Apps Script
+ * (seleciona "setupWeeklyBackupTrigger" no dropdown de funções → Executar).
+ *
+ * Não existia nenhum gatilho (Trigger) configurado por código pra runWeeklyBackup
+ * em nenhum lugar do projeto — ela só executava se alguém tivesse configurado um
+ * acionador manualmente pela UI (Acionadores ⏰), o que não deixa rastro no código
+ * e é fácil de perder/esquecer numa reconfiguração do projeto.
+ *
+ * Essa função cria (ou recria, se já existir) um acionador baseado em tempo que
+ * roda runWeeklyBackup toda segunda-feira de madrugada, no fuso do projeto
+ * (America/Sao_Paulo, ver appsscript.json). É idempotente: rodar de novo não
+ * duplica o acionador, só substitui pelo mesmo agendamento.
+ *
+ * Criar acionadores exige uma execução autorizada interativa — não dá pra fazer
+ * isso automaticamente via `clasp push`/deploy, por isso precisa ser rodada manualmente.
+ */
+function setupWeeklyBackupTrigger() {
+  const existing = ScriptApp.getProjectTriggers().filter(
+    t => t.getHandlerFunction() === 'runWeeklyBackup'
+  );
+  existing.forEach(t => ScriptApp.deleteTrigger(t));
+
+  ScriptApp.newTrigger('runWeeklyBackup')
+    .timeBased()
+    .onWeekDay(ScriptApp.WeekDay.MONDAY)
+    .atHour(3)
+    .create();
+
+  console.log("✅ Acionador semanal configurado: runWeeklyBackup toda segunda-feira, por volta das 03h.");
+}


### PR DESCRIPTION
## 1. Bug de edição: motivo não vinha separado da descrição
O dropdown "Motivo da Não Implementação" nunca vinha pré-preenchido ao editar um caso BAU, e o campo de descrição mostrava a string mesclada inteira ("Motivo | Descrição") em vez de só a descrição.

**Causa:** `handleBAUEscalation`/`update_bau_case` mesclam `nonImplementationReason` + `description` numa única coluna da planilha ("Motivo | Descrição", documentado em `specs/data-models/db-schema.md`). `update_bau_case` já sabia desfazer essa mescla ao salvar uma edição — mas `getAgentCases` (usada pra popular a tela de edição) só devolvia a string inteira mesclada como `description`, nunca separava, e nunca devolvia `nonImplementationReason`.

**Fix:** aplica o mesmo split em `getAgentCases`, só para casos do fluxo BAU (`status !== PENDING_TL_DISCARD/DISCARDED`) — o fluxo de descarte nunca mescla esses dois campos, então dividir a string lá seria errado.

Front-end já lê `c.nonImplementationReason || ""` com segurança em todo lugar, então não precisou de nenhuma mudança do lado do cliente.

## 2. Gatilho de backup semanal (codificado, precisa de 1 passo manual seu)
Não existia **nenhum** `ScriptApp.newTrigger()` em todo o `gas-backend/` — o `runWeeklyBackup()` só rodaria se alguém tivesse configurado manualmente um acionador pela UI do Apps Script, o que não fica registrado em lugar nenhum do código (bate com a sua suspeita de que ele "não vai").

Adicionei `setupWeeklyBackupTrigger()`: cria um acionador semanal (segunda-feira, ~03h, fuso do projeto) pro `runWeeklyBackup`, apagando qualquer acionador antigo pra essa função antes (idempotente, seguro rodar de novo).

**⚠️ Isso não roda sozinho.** Criar acionador exige execução autorizada interativa, que não existe durante o deploy via `clasp push`. Depois que isso for mergeado e a implantação de dev atualizar:
1. Abra o editor do Apps Script.
2. Selecione `setupWeeklyBackupTrigger` no dropdown de funções.
3. Clique em Executar (vai pedir autorização na primeira vez).
4. Confira no painel de Acionadores (ícone de relógio) que `runWeeklyBackup` aparece agendado pra segundas-feiras.

## O que revisar
- Sintaxe validada com `node --check` nos dois arquivos — não consigo rodar/testar de verdade (APIs do Apps Script só existem lá dentro).
- Teste real pedido: editar um caso BAU pendente depois do deploy, confirmar que o dropdown de motivo vem preenchido e a descrição vem limpa.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)