### PR TITLE
fix(shared): add scoped box-sizing: border-box reset for the app

### DIFF
--- a/src/modules/shared/utils.js
+++ b/src/modules/shared/utils.js
@@ -35,6 +35,14 @@ export function initGlobalStylesAndFont() {
             --cw-ease-elastic: cubic-bezier(0.25, 0.8, 0.25, 1);
         }
 
+        /* RESET DE BOX MODEL (Escopado só ao app, nunca ao CRM host) */
+        /* Sem isso, qualquer elemento com width + padding "estoura" o container,
+           porque o padding some do cálculo em vez de ser incluído na largura. */
+        .cw-pill, .cw-pill *,
+        .cw-module-window, .cw-module-window * {
+            box-sizing: border-box;
+        }
+
         /* Rollbar e Ajustes Globais */
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
Found the likely root cause of most "content escaping its container / wrong spacing" complaints across modules: there was no box-sizing reset anywhere in the project. Any element combining a fixed or 100% width with padding (very common pattern throughout the codebase) renders wider/taller than its container, because padding gets added on top of the declared width instead of being included in it.

Confirmed zero explicit `content-box` usages anywhere in src/, so there was nothing intentionally relying on the default box model — adding border-box can only fix rendering, not break something that depended on the old behavior.

Scoped the reset to `.cw-pill` and `.cw-module-window` (and their descendants) rather than a global `*` selector — this app injects directly into the CRM's live page with no Shadow DOM/iframe isolation, so an unscoped reset would also apply to the host page's own elements. Verified every module's popup gets `.cw-module-window` (grepped all `popup.classList.add(...)` / `className = "... cw-module-window"` call sites) and the floating pill uses `.cw-pill`, so this scoping covers 100% of the app's own UI without touching anything else on the page.

Verified with esbuild --bundle --minify (build passes, no errors). Couldn't visually re-test every module in the live CRM (sandboxed session, no access) — please spot-check a few popups after this lands, especially ones with dense fixed-width layouts (BAU form steps, step-tasks screenshot cards).