### PR TITLE
fix(personal-library): stop faking success when save silently fails

### DIFF
--- a/src/modules/personal-library/personal-library-assistant.js
+++ b/src/modules/personal-library/personal-library-assistant.js
@@ -569,43 +569,55 @@ export function initPersonalLibrary() {
     }
 
     async function handleSave() {
-        const titleInput = sheetBody.querySelector("#cw-lib-inp-title");
-        const contentInput = sheetBody.querySelector("#cw-lib-inp-content");
-
-        const title = titleInput.value.trim();
-        const content = contentInput.contentEditable === "true" ? contentInput.innerHTML : contentInput.value.trim();
-        const isCode = contentInput.getAttribute('data-is-code') === 'true';
-
-        if (!title || !content || content === '<br>') {
-            showToast("Preencha título e conteúdo.", { error: true });
-            return;
-        }
-
-        const payload = {
-            id: currentEditingId,
-            type: currentTab,
-            title, content, isCode,
-            isRich: contentInput.contentEditable === "true"
-        };
-
-        if (currentTab === 'email') {
-            const subject = sheetBody.querySelector("#cw-lib-inp-subject").value.trim();
-            if (!subject) {
-                showToast("Assunto é obrigatório para emails.", { error: true });
-                return;
-            }
-            payload.subject = subject;
-        }
-
         loadingOverlay.classList.add('active');
         saveBtn.disabled = true;
 
         try {
+            const titleInput = sheetBody.querySelector("#cw-lib-inp-title");
+            const contentInput = sheetBody.querySelector("#cw-lib-inp-content");
+
+            const title = titleInput.value.trim();
+            const content = contentInput.contentEditable === "true" ? contentInput.innerHTML : contentInput.value.trim();
+            const isCode = contentInput.getAttribute('data-is-code') === 'true';
+
+            if (!title || !content || content === '<br>') {
+                showToast("Preencha título e conteúdo.", { error: true });
+                return;
+            }
+
+            const payload = {
+                id: currentEditingId,
+                type: currentTab,
+                title, content, isCode,
+                isRich: contentInput.contentEditable === "true"
+            };
+
+            if (currentTab === 'email') {
+                const subject = sheetBody.querySelector("#cw-lib-inp-subject").value.trim();
+                if (!subject) {
+                    showToast("Assunto é obrigatório para emails.", { error: true });
+                    return;
+                }
+                payload.subject = subject;
+            }
+
             const saved = await SnippetService.save(payload);
+
+            // SnippetService.save() retorna o booleano `false` (não um objeto) quando
+            // não dá pra identificar o usuário — nesse caso NADA foi salvo, nem local
+            // nem na nuvem. `saved && saved.synced === false` cai pro `else` (sucesso)
+            // quando `saved` é `false`, escondendo essa falha por trás de um toast de
+            // sucesso falso e fechando o editor com o item perdido — era isso que
+            // fazia parecer que "nenhuma função rodava".
+            if (saved === false) {
+                showToast("Não foi possível salvar: usuário não identificado. Recarregue a página e tente de novo.", { error: true });
+                return;
+            }
+
             renderList();
             closeEditor();
 
-            if (saved && saved.synced === false) {
+            if (saved.synced === false) {
                 showToast("Salvo localmente — sem conexão com a nuvem no momento.", { error: true });
             } else {
                 showToast("Salvo e sincronizado!");


### PR DESCRIPTION
## Problema

Depois de mergear o redesign da Minha Biblioteca (#211), o botao "Salvar" parava de funcionar: o item nao aparecia na lista nem na planilha, sem nenhum erro visivel.

## Causa raiz

Em `handleSave()`, a checagem `saved && saved.synced === false` decide entre o aviso de "so salvo localmente" e o toast de sucesso. Mas `SnippetService.save()` retorna o booleano literal `false` (nao um objeto) quando o email do agente ainda nao foi capturado (`getAgentEmail()` retorna `null`) -- nesse caso a funcao retorna ANTES de gravar qualquer coisa no localStorage ou tentar a planilha.

Como `false && ...` sempre da `false`, esse caso caia no `else` (sucesso): mostrava "Salvo e sincronizado!", tocava o som de sucesso e fechava o editor -- descartando o que foi digitado, sem o item ter sido salvo em lugar nenhum. Nenhum erro aparecia porque o codigo achava que tinha dado certo.

## Fix

- Trata `saved === false` como falha real: mostra um erro claro e NAO fecha o editor nem descarta o conteudo digitado.
- Moveu o corpo inteiro de `handleSave()` para dentro do try/catch (antes a extracao de titulo/conteudo rodava fora, sem protecao) -- qualquer outra excecao agora vira um toast + console.error em vez de falhar silenciosamente como uma promise rejeitada sem handler.

## Verificacao

- `esbuild src/app.js --bundle --minify` passa sem erro.
- Nao consigo testar visualmente no CRM neste ambiente (sandbox sem acesso ao CRM real) -- pontos pra conferir no seu teste:
  1. Salvar um item normalmente (com a identidade do agente ja capturada) -- deve continuar funcionando como antes.
  2. Se alguma vez o app abrir antes da identidade do agente ser capturada (ex: splash falhou em achar o email no menu de perfil) e voce tentar salvar, agora deve aparecer um toast de erro claro em vez de sumir silenciosamente -- isso ajuda a confirmar se essa e mesmo a causa raiz que voce bateu.
