### PR TITLE
refactor(call-script): modernize styling architecture + fix real data/logic bugs

### DIFF
--- a/src/modules/call-script/call-script-assistant.js
+++ b/src/modules/call-script/call-script-assistant.js
@@ -1,71 +1,91 @@
 // src/modules/call-script/call-script-assistant.js
 
 import {
-  styleSelect,
   stylePopup,
-  styleCredit,
-  typeBtnStyle,
-  getRandomGoogleStyle,
   styleResizeHandle,
   makeResizable,
-  showToast // Importando showToast para feedback de cópia
+  showToast
 } from "../shared/utils.js";
 import { SoundManager } from "../shared/sound-manager.js";
 
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
-import { getPageData } from "../shared/page-data.js"; 
+import { getPageData } from "../shared/page-data.js";
 
 import { csaChecklistData } from "./call-script-data.js";
 
-export function initCallScriptAssistant() {
-  const CURRENT_VERSION = "v3.0.0";
+const COLORS = {
+    bgApp: "#F5F5F7",
+    bgSurface: "#FFFFFF",
+    borderSubtle: "rgba(0, 0, 0, 0.07)",
+    primary: "#007AFF",
+    primaryBg: "rgba(0, 122, 255, 0.1)",
+    textPrimary: "#1D1D1F",
+    textSecondary: "#6E6E73",
+    danger: "#D93025",
+    dangerBg: "#FCE8E6",
+    success: "#34A853",
+    successBg: "#E6F4EA"
+};
 
-  const COLORS = {
-      bgApp: "#F5F5F7",
-      bgSurface: "#FFFFFF",
-      borderSubtle: "rgba(0, 0, 0, 0.07)",
-      primary: "#007AFF",
-      primaryBg: "rgba(0, 122, 255, 0.1)",
-      textPrimary: "#1D1D1F",
-      textSecondary: "#6E6E73",
-      shadowCard: "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02)",
-      success: "#34A853"
-  };
+const GROUP_TITLES = {
+    inicio: { PT: "Abertura", ES: "Apertura" },
+    meio: { PT: "Implementação (Tag Support)", ES: "Implementación" },
+    fim: { PT: "Fechamento", ES: "Cierre" }
+};
 
-  // --- ESTILOS INJETADOS (Animações Locais) ---
-  const localStyleId = 'csa-local-styles';
-  if (!document.getElementById(localStyleId)) {
-      const s = document.createElement('style');
-      s.id = localStyleId;
-      s.innerHTML = `
-        @keyframes csa-pulse-green {
+// --- FOLHA DE ESTILOS DEDICADA ---
+// Substitui os três mecanismos que coexistiam aqui antes: um objeto `styles`
+// JS aplicado via Object.assign(el.style, ...), um <style> só de animações, e
+// dezenas de style="..." hardcoded dentro do template do banner de contexto
+// (que também vazavam cores/fonte do Google numa paleta que é deliberadamente
+// Apple-inspired). Tudo consolidado numa única injeção, como no padrão
+// adotado pela Minha Biblioteca.
+function injectStyles() {
+    if (document.getElementById('csa-styles-v2')) return;
+    const style = document.createElement('style');
+    style.id = 'csa-styles-v2';
+    style.textContent = `
+        #call-script-popup { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+
+        /* --- BANNER DE CONTEXTO --- */
+        .csa-context-banner {
+            padding: 20px 20px 16px 20px;
+            background: ${COLORS.bgSurface};
+            border-bottom: 1px solid #F1F3F4;
+            display: flex; flex-direction: column; gap: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.02);
+            position: relative; z-index: 5;
+        }
+        .csa-ctx-top { display: flex; justify-content: space-between; align-items: center; }
+        .csa-ctx-name-wrap { display: flex; align-items: center; gap: 10px; }
+        .csa-ctx-name { font-size: 16px; font-weight: 500; color: ${COLORS.textPrimary}; }
+        .csa-live-badge {
+            font-size: 10px; font-weight: 700; color: ${COLORS.primary}; background: ${COLORS.primaryBg};
+            padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
+        }
+        .csa-live-dot {
+            width: 8px; height: 8px; background: #10B981; border-radius: 50%;
+            animation: csaPulseGreen 2s infinite;
+        }
+        @keyframes csaPulseGreen {
             0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
             70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
             100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
         }
-        .csa-live-dot {
-            width: 8px; height: 8px; 
-            background: #10B981; border-radius: 50%;
-            animation: csa-pulse-green 2s infinite;
-        }
+
+        .csa-ctx-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
         .csa-data-pill {
-            background: #F8F9FA; border: 1px solid transparent;
-            border-radius: 10px; padding: 8px 12px;
+            background: #F8F9FA; border: 1px solid transparent; border-radius: 10px; padding: 8px 12px;
             cursor: pointer; position: relative; overflow: hidden;
             transition: all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1);
         }
-        .csa-data-pill:hover {
-            background: #FFFFFF; border-color: #DADCE0;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-            transform: translateY(-1px);
-        }
+        .csa-data-pill:hover { background: ${COLORS.bgSurface}; border-color: #DADCE0; box-shadow: 0 2px 8px rgba(0,0,0,0.05); transform: translateY(-1px); }
         .csa-data-pill:active { transform: scale(0.98); }
-        
-        .csa-data-pill.copied {
-            background: #E6F4EA !important;
-            border-color: #34A853 !important;
-        }
+        .csa-data-pill.copied { background: ${COLORS.successBg} !important; border-color: ${COLORS.success} !important; }
+        .csa-pill-label { font-size: 9px; font-weight: 700; color: ${COLORS.textSecondary}; text-transform: uppercase; margin-bottom: 2px; letter-spacing: 0.5px; }
+        .csa-data-value { font-size: 13px; color: ${COLORS.textPrimary}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .csa-data-value.mono { font-family: 'SF Mono', 'Roboto Mono', monospace; font-weight: 500; color: ${COLORS.primary}; }
         .csa-copy-hint {
             position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
             font-size: 10px; color: #1E8E3E; font-weight: 700; text-transform: uppercase;
@@ -74,115 +94,121 @@ export function initCallScriptAssistant() {
         .csa-data-pill.copied .csa-copy-hint { opacity: 1; }
         .csa-data-pill.copied .csa-data-value { opacity: 0.3; }
 
-        /* Segmented Control (Tabs) */
-        .csa-segmented-control {
-            display: flex;
-            background: #E3E3E8;
-            padding: 2px;
-            border-radius: 10px;
-            gap: 2px;
-            position: relative;
-            margin-bottom: 16px;
+        /* --- MENSAGEM AM (opções extras) --- */
+        .csa-more-options { margin-top: 8px; }
+        .csa-toggle-options-btn {
+            width: 100%; background: transparent; border: none; padding: 4px 0;
+            display: flex; align-items: center; justify-content: center; cursor: pointer;
+            color: #9AA0A6; transition: color 0.2s;
         }
-        .csa-segmented-control button {
-            flex: 1;
-            border: none;
-            background: transparent;
-            padding: 8px 4px;
-            font-size: 12px;
-            font-weight: 600;
-            border-radius: 8px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            color: #6E6E73;
-            position: relative;
-            z-index: 2;
+        .csa-options-arrow { transition: transform 0.3s ease; }
+        .csa-options-arrow.expanded { transform: rotate(180deg); }
+        .csa-options-content {
+            max-height: 0; overflow: hidden; opacity: 0; padding: 0 4px;
+            transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s ease, margin-top 0.4s ease;
         }
-        .csa-segmented-control button.active {
-            color: #1D1D1F;
-        }
-        .csa-segmented-indicator {
-            position: absolute;
-            top: 2px;
-            left: 2px;
-            bottom: 2px;
-            background: #FFFFFF;
-            border-radius: 8px;
-            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-            z-index: 1;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-        }
+        .csa-options-content.expanded { max-height: 400px; opacity: 1; margin-top: 8px; }
 
-        /* Strikethrough Animation */
-        .csa-item-text {
-            position: relative;
-            display: inline-block;
-            transition: color 0.3s ease;
+        .csa-am-card { padding: 12px; background: #F8F9FA; border: 1px solid #DADCE0; border-radius: 12px; margin-bottom: 8px; }
+        .csa-am-btn {
+            width: 100%; background: ${COLORS.bgSurface}; border: 1px solid #DADCE0; border-radius: 10px; padding: 10px;
+            display: flex; align-items: center; gap: 12px; cursor: pointer; box-sizing: border-box;
+            transition: all 0.2s ease; box-shadow: 0 1px 2px rgba(0,0,0,0.02);
         }
-        .csa-item-text.completed {
-            color: #6E6E73;
-        }
-        .csa-item-text::after {
-            content: '';
-            position: absolute;
-            left: 0;
-            top: 50%;
-            width: 0;
-            height: 1.5px;
-            background: #6E6E73;
-            transition: width 0.3s ease;
-        }
-        .csa-item-text.completed::after {
-            width: 100%;
-        }
+        .csa-am-btn:hover { border-color: ${COLORS.primary}; box-shadow: 0 2px 8px rgba(0,0,0,0.05); }
+        .csa-am-icon { background: ${COLORS.primaryBg}; border-radius: 6px; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+        .csa-am-btn-text { text-align: left; }
+        .csa-am-btn-title { font-size: 11px; font-weight: 700; color: #3C4043; }
+        .csa-am-btn-sub { font-size: 10px; color: ${COLORS.textSecondary}; }
 
-        /* Shimmer Progress Bar */
-        @keyframes shimmer {
-            0% { background-position: -200% 0; }
-            100% { background-position: 200% 0; }
+        .csa-am-review-container { display: none; max-height: 0; opacity: 0; overflow: hidden; margin-top: 0; transition: all 0.3s ease; }
+        .csa-am-review-container.visible { display: block; max-height: 300px; opacity: 1; margin-top: 12px; }
+        .csa-am-message-area {
+            width: 100%; height: 120px; border: 1px solid #DADCE0; border-radius: 8px; padding: 10px;
+            font-family: inherit; font-size: 13px; color: #3C4043; outline: none; resize: none;
+            box-sizing: border-box; background: ${COLORS.bgSurface}; line-height: 1.4;
         }
+        .csa-am-copy-final {
+            width: 100%; margin-top: 8px; padding: 10px; background: ${COLORS.primary}; color: white; border: none;
+            border-radius: 8px; font-weight: 600; font-size: 13px; cursor: pointer; transition: background 0.2s;
+        }
+        .csa-am-copy-final.copied-flash { background: ${COLORS.success}; }
+
+        /* --- BARRA DE PROGRESSO --- */
+        .csa-progress-container { height: 6px; background: ${COLORS.borderSubtle}; width: 100%; position: relative; overflow: hidden; }
         .csa-progress-fill {
-            background: linear-gradient(90deg, #007AFF, #00C6FF, #007AFF);
+            height: 100%; width: 0%; border-radius: 0 3px 3px 0;
+            transition: width 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+            background: linear-gradient(90deg, ${COLORS.primary}, #00C6FF, ${COLORS.primary});
             background-size: 200% 100%;
-            animation: shimmer 2s infinite linear;
+            animation: csaShimmer 2s infinite linear;
         }
-      `;
-      document.head.appendChild(s);
-  }
+        .csa-progress-fill.complete { background: ${COLORS.success}; animation: none; }
+        @keyframes csaShimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
 
-  const styles = {
-    // Barra de Progresso
-    progressBarContainer: { height: "6px", background: COLORS.borderSubtle, width: "100%", position: "relative", overflow: "hidden" },
-    progressBarFill: { height: "100%", width: "0%", transition: "width 0.5s cubic-bezier(0.25, 0.8, 0.25, 1)", borderRadius: "0 3px 3px 0" },
+        /* --- SEGMENTED CONTROL (Tipo / Idioma) --- */
+        .csa-content-area { padding: 16px; overflow-y: auto; flex-grow: 1; background: ${COLORS.bgApp}; scroll-behavior: smooth; }
+        .csa-controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
+        .csa-segmented-control { display: flex; background: #E3E3E8; padding: 2px; border-radius: 10px; gap: 2px; position: relative; margin-bottom: 16px; }
+        .csa-segmented-control button {
+            flex: 1; border: none; background: transparent; padding: 8px 4px; font-size: 12px; font-weight: 600;
+            border-radius: 8px; cursor: pointer; transition: color 0.3s ease; color: ${COLORS.textSecondary};
+            position: relative; z-index: 2;
+        }
+        .csa-segmented-control button.active { color: ${COLORS.textPrimary}; }
+        .csa-segmented-indicator {
+            position: absolute; top: 2px; left: 2px; bottom: 2px; background: ${COLORS.bgSurface};
+            border-radius: 8px; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            z-index: 1; box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
 
-    contentArea: { padding: "16px", overflowY: "auto", flexGrow: "1", background: COLORS.bgApp, scrollBehavior: "smooth" },
+        /* --- CARDS DO CHECKLIST --- */
+        .csa-card { background: ${COLORS.bgSurface}; border: 1px solid ${COLORS.borderSubtle}; border-radius: 12px; padding: 16px; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.02); }
+        .csa-card.done { box-shadow: inset 4px 0 0 ${COLORS.success}, 0 1px 3px rgba(0,0,0,0.05); }
+        .csa-card-title { font-size: 11px; font-weight: 700; color: ${COLORS.textSecondary}; text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 12px; display: flex; align-items: center; justify-content: space-between; user-select: none; }
+        .csa-card-counter { font-size: 11px; opacity: 0.7; font-weight: 500; background: #f1f3f4; padding: 2px 8px; border-radius: 10px; }
+        .csa-card-counter.done { opacity: 1; color: #1e8e3e; background: ${COLORS.successBg}; }
 
-    // Cards do Script
-    card: { background: COLORS.bgSurface, border: `1px solid ${COLORS.borderSubtle}`, borderRadius: "12px", padding: "16px", marginBottom: "16px", transition: "transform 0.2s ease, box-shadow 0.2s ease", boxShadow: COLORS.shadowCard },
-    cardTitle: { fontSize: "11px", fontWeight: "700", color: COLORS.textSecondary, textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: "12px", display: "flex", alignItems: "center", justifyContent: "space-between", userSelect: "none" },
+        .csa-item-row { display: flex; align-items: flex-start; padding: 10px 8px; cursor: pointer; border-radius: 10px; transition: background 0.2s ease; color: ${COLORS.textPrimary}; font-size: 14px; line-height: 1.5; margin-bottom: 2px; }
+        .csa-item-row:not(.completed):hover { background: rgba(0, 0, 0, 0.03); }
+        .csa-item-row:not(.completed):hover .csa-checkbox { border-color: ${COLORS.primary}; }
+        .csa-item-row.completed { background: rgba(0, 0, 0, 0.02); }
 
-    itemRow: { display: "flex", alignItems: "flex-start", padding: "10px 8px", cursor: "pointer", borderRadius: "10px", transition: "all 0.2s ease", color: COLORS.textPrimary, fontSize: "14px", lineHeight: "1.5", marginBottom: "2px" },
-    itemCompleted: { background: "rgba(0, 0, 0, 0.02)" },
+        .csa-checkbox {
+            min-width: 20px; height: 20px; border-radius: 50%; border: 2px solid ${COLORS.borderSubtle};
+            margin-right: 12px; margin-top: 1px; display: flex; align-items: center; justify-content: center;
+            transition: border-color 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), transform 0.15s ease;
+            background: #fff;
+        }
+        .csa-checkbox.checked { background: ${COLORS.primary}; border-color: ${COLORS.primary}; }
+        .csa-checkbox.pulse { transform: scale(1.15); }
 
-    checkbox: { minWidth: "20px", height: "20px", borderRadius: "50%", border: `2px solid ${COLORS.borderSubtle}`, marginRight: "12px", marginTop: "1px", display: "flex", alignItems: "center", justifyContent: "center", transition: "all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1)", background: "#fff" },
-    
-    // Footer
-    footer: { padding: "12px 16px", borderTop: "1px solid #F1F3F4", background: "#fff", display: "flex", justifyContent: "space-between", alignItems: "center" },
-    resetBtn: { background: "transparent", border: "none", color: "#d93025", fontSize: "12px", fontWeight: "600", cursor: "pointer", padding: "6px 12px", borderRadius: "20px", transition: "background 0.2s ease", display: "flex", alignItems: "center", gap: "4px" },
+        .csa-item-text { position: relative; display: inline-block; flex: 1; transition: color 0.3s ease; }
+        .csa-item-text.completed { color: ${COLORS.textSecondary}; }
+        .csa-item-text::after { content: ''; position: absolute; left: 0; top: 50%; width: 0; height: 1.5px; background: ${COLORS.textSecondary}; transition: width 0.3s ease; }
+        .csa-item-text.completed::after { width: 100%; }
 
-    // Context Banner (HD Style)
-    contextBanner: {
-        padding: "20px 20px 16px 20px",
-        background: "#FFFFFF",
-        borderBottom: "1px solid #F1F3F4",
-        display: "flex",
-        flexDirection: "column",
-        gap: "12px",
-        boxShadow: "0 4px 20px rgba(0,0,0,0.02)",
-        position: "relative",
-        zIndex: "5"
-    }
-  };
+        .csa-empty-state { padding: 30px; text-align: center; color: #bdc1c6; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+        .csa-empty-state-icon { font-size: 24px; }
+
+        /* --- FOOTER --- */
+        .csa-footer { padding: 12px 16px; border-top: 1px solid #F1F3F4; background: ${COLORS.bgSurface}; display: flex; justify-content: space-between; align-items: center; }
+        .csa-credit { font-size: 10px; color: #bdc1c6; }
+        .csa-reset-btn {
+            background: transparent; border: none; color: ${COLORS.danger}; font-size: 12px; font-weight: 600;
+            cursor: pointer; padding: 6px 12px; border-radius: 20px; transition: background 0.2s ease, transform 0.15s ease;
+            display: flex; align-items: center; gap: 4px;
+        }
+        .csa-reset-btn:hover { background: ${COLORS.dangerBg}; }
+        .csa-reset-btn:active { transform: scale(0.9); }
+    `;
+    document.head.appendChild(style);
+}
+
+export function initCallScriptAssistant() {
+  const CURRENT_VERSION = "v3.1.0";
+
+  injectStyles();
 
   const csaCompletedTasks = {};
   let csaCurrentLang = "PT";
@@ -210,17 +236,14 @@ export function initCallScriptAssistant() {
           const elName = csaPopup.querySelector('#cw-ctx-name');
           const elCid = csaPopup.querySelector('#cw-ctx-cid');
           const elEmail = csaPopup.querySelector('#cw-ctx-email');
-          // const elCaseId = csaPopup.querySelector('#cw-ctx-message');
 
-          
           if(elName) elName.textContent = data.advertiserName || "Cliente Desconhecido";
-          
-          
+
           if(elCid) {
               const cidTxt = data.cid || "---";
               if (elCid.textContent !== cidTxt) elCid.textContent = cidTxt;
           }
-          
+
           if(elEmail) {
               const emailTxt = data.clientEmail || "Não encontrado";
               if (elEmail.textContent !== emailTxt) {
@@ -228,7 +251,6 @@ export function initCallScriptAssistant() {
                   elEmail.title = emailTxt;
               }
           }
-
       });
   }
 
@@ -249,9 +271,7 @@ export function initCallScriptAssistant() {
 
       if (area) area.value = message;
       if (container) {
-          container.style.display = 'block';
-          container.style.maxHeight = '300px';
-          container.style.opacity = '1';
+          container.classList.add('visible');
           container.scrollIntoView({ behavior: 'smooth', block: 'end' });
       }
     });
@@ -260,10 +280,10 @@ export function initCallScriptAssistant() {
   function toggleVisibility() {
     csaVisible = !csaVisible;
     toggleGenieAnimation(csaVisible, csaPopup, 'cw-btn-script');
-    
+
     if (csaVisible) {
-        updateContextData(); 
-        if (!monitorInterval) monitorInterval = setInterval(updateContextData, 2000); 
+        updateContextData();
+        if (!monitorInterval) monitorInterval = setInterval(updateContextData, 2000);
     } else {
         if (monitorInterval) { clearInterval(monitorInterval); monitorInterval = null; }
     }
@@ -275,55 +295,53 @@ export function initCallScriptAssistant() {
   );
   csaPopup.appendChild(csaHeader);
 
-  // === BANNER DE CONTEXTO (ESTILO GOOGLE CARDS) ===
+  // === BANNER DE CONTEXTO ===
   const contextBanner = document.createElement("div");
-  Object.assign(contextBanner.style, styles.contextBanner);
-  
+  contextBanner.className = "csa-context-banner";
+
   contextBanner.innerHTML = `
-      <div style="display:flex; justify-content:space-between; align-items:center;">
-          <div style="display:flex; align-items:center; gap:10px;">
+      <div class="csa-ctx-top">
+          <div class="csa-ctx-name-wrap">
               <div class="csa-live-dot" title="Monitoramento Ativo"></div>
-              <span id="cw-ctx-name" style="font-family:'Google Sans'; font-size:16px; font-weight:500; color:#202124;">Carregando...</span>
+              <span id="cw-ctx-name" class="csa-ctx-name">Carregando...</span>
           </div>
-          <div style="font-size:10px; font-weight:700; color:#1A73E8; background:#E8F0FE; padding:2px 8px; border-radius:4px; text-transform:uppercase;">Live</div>
+          <div class="csa-live-badge">Live</div>
       </div>
-      
-      <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 10px;">
+
+      <div class="csa-ctx-grid">
           <div class="csa-data-pill" id="cw-pill-cid">
-              <div style="font-size:9px; font-weight:700; color:#5F6368; text-transform:uppercase; margin-bottom:2px; letter-spacing:0.5px;">CID (Conta)</div>
-              <div id="cw-ctx-cid" class="csa-data-value" style="font-family:'Roboto Mono', monospace; font-size:13px; font-weight:500; color:#1A73E8;">---</div>
+              <div class="csa-pill-label">CID (Conta)</div>
+              <div id="cw-ctx-cid" class="csa-data-value mono">---</div>
               <div class="csa-copy-hint">Copiado!</div>
           </div>
-          
+
           <div class="csa-data-pill" id="cw-pill-email">
-              <div style="font-size:9px; font-weight:700; color:#5F6368; text-transform:uppercase; margin-bottom:2px; letter-spacing:0.5px;">Email de Contato</div>
-              <div id="cw-ctx-email" class="csa-data-value" style="font-family:'Roboto', sans-serif; font-size:13px; color:#3C4043; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">---</div>
+              <div class="csa-pill-label">Email de Contato</div>
+              <div id="cw-ctx-email" class="csa-data-value">---</div>
               <div class="csa-copy-hint">Copiado!</div>
           </div>
       </div>
 
-      <div id="csa-more-options" style="margin-top: 8px;">
-          <button id="csa-toggle-options" style="width: 100%; background: transparent; border: none; padding: 4px 0; display: flex; align-items: center; justify-content: center; cursor: pointer; color: #9AA0A6; transition: color 0.2s;">
-              <svg id="csa-options-arrow" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="transition: transform 0.3s ease;"><polyline points="6 9 12 15 18 9"></polyline></svg>
+      <div class="csa-more-options">
+          <button id="csa-toggle-options" class="csa-toggle-options-btn">
+              <svg id="csa-options-arrow" class="csa-options-arrow" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
           </button>
 
-          <div id="csa-options-content" style="max-height: 0; overflow: hidden; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); opacity: 0; padding: 0 4px;">
-              <div style="padding: 12px; background: #F8F9FA; border: 1px solid #DADCE0; border-radius: 12px; margin-bottom: 8px;">
-                  <button id="cw-pill-message" style="width: 100%; background: #FFFFFF; border: 1px solid #DADCE0; border-radius: 10px; padding: 10px; display: flex; align-items: center; gap: 12px; cursor: pointer; transition: all 0.2s; box-shadow: 0 1px 2px rgba(0,0,0,0.02);">
-                      <div style="background: #E8F0FE; border-radius: 6px; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#1A73E8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+          <div id="csa-options-content" class="csa-options-content">
+              <div class="csa-am-card">
+                  <button id="cw-pill-message" class="csa-am-btn">
+                      <div class="csa-am-icon">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${COLORS.primary}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
                       </div>
-                      <div style="text-align: left;">
-                          <div style="font-size:11px; font-weight:700; color:#3C4043;">Mensagem AM</div>
-                          <div style="font-size:10px; color:#5F6368;">Gerar aviso de insucesso</div>
+                      <div class="csa-am-btn-text">
+                          <div class="csa-am-btn-title">Mensagem AM</div>
+                          <div class="csa-am-btn-sub">Gerar aviso de insucesso</div>
                       </div>
                   </button>
 
-                  <div id="cw-am-review-container" style="display: none; transition: all 0.3s ease; opacity: 0; max-height: 0; overflow: hidden; margin-top: 12px;">
-                      <textarea id="cw-am-message-area" style="width: 100%; height: 120px; border: 1px solid #DADCE0; border-radius: 8px; padding: 10px; font-family: 'Roboto', sans-serif; font-size: 13px; color: #3C4043; outline: none; resize: none; box-sizing: border-box; background: #FFFFFF; line-height: 1.4;"></textarea>
-                      <button id="cw-am-copy-final" style="width: 100%; margin-top: 8px; padding: 10px; background: #007AFF; color: white; border: none; border-radius: 8px; font-weight: 600; font-size: 13px; cursor: pointer; transition: background 0.2s;">
-                          Copiar Mensagem Final
-                      </button>
+                  <div id="cw-am-review-container" class="csa-am-review-container">
+                      <textarea id="cw-am-message-area" class="csa-am-message-area"></textarea>
+                      <button id="cw-am-copy-final" class="csa-am-copy-final">Copiar Mensagem Final</button>
                   </div>
               </div>
           </div>
@@ -337,19 +355,14 @@ export function initCallScriptAssistant() {
   let optionsExpanded = false;
   optionsBtn.onclick = () => {
       optionsExpanded = !optionsExpanded;
-      optionsArrow.style.transform = optionsExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
-      optionsContent.style.maxHeight = optionsExpanded ? '400px' : '0';
-      optionsContent.style.opacity = optionsExpanded ? '1' : '0';
-      optionsContent.style.marginTop = optionsExpanded ? '8px' : '0';
+      optionsArrow.classList.toggle('expanded', optionsExpanded);
+      optionsContent.classList.toggle('expanded', optionsExpanded);
       SoundManager.playClick();
   };
 
   const messageBtn = contextBanner.querySelector('#cw-pill-message');
   const finalCopyBtn = contextBanner.querySelector('#cw-am-copy-final');
   const messageArea = contextBanner.querySelector('#cw-am-message-area');
-
-  messageBtn.onmouseenter = () => { messageBtn.style.borderColor = "#007AFF"; messageBtn.style.boxShadow = "0 2px 8px rgba(0,0,0,0.05)"; };
-  messageBtn.onmouseleave = () => { messageBtn.style.borderColor = "#DADCE0"; messageBtn.style.boxShadow = "0 1px 2px rgba(0,0,0,0.02)"; };
 
   messageBtn.addEventListener('click', () => {
     populateMessageArea();
@@ -361,65 +374,59 @@ export function initCallScriptAssistant() {
           showToast("Mensagem copiada!");
           SoundManager.playSuccess();
 
-          finalCopyBtn.style.background = "#34A853";
+          finalCopyBtn.classList.add('copied-flash');
           finalCopyBtn.textContent = "Copiado!";
           setTimeout(() => {
-              finalCopyBtn.style.background = "#1A73E8";
+              finalCopyBtn.classList.remove('copied-flash');
               finalCopyBtn.textContent = "Copiar Mensagem Final";
           }, 2000);
       }
   });
-  
+
   // Lógica de Cópia (Click to Copy)
   const setupCopy = (id, textId) => {
       const pill = contextBanner.querySelector(id);
       const textEl = contextBanner.querySelector(textId);
-      
+
       pill.onclick = () => {
           const text = textEl.textContent;
           if (!text || text.includes("---") || text.includes("Não encontrado")) return;
-          
+
           navigator.clipboard.writeText(text);
           SoundManager.playSuccess();
-          
+
           pill.classList.add("copied");
           setTimeout(() => pill.classList.remove("copied"), 1500);
       };
   };
-  
-  // Configura depois de inserir no DOM (no final da função)
+
   csaPopup.appendChild(contextBanner);
 
   // 2. PROGRESS BAR
   const progressContainer = document.createElement("div");
-  Object.assign(progressContainer.style, styles.progressBarContainer);
+  progressContainer.className = "csa-progress-container";
   const progressFill = document.createElement("div");
   progressFill.className = "csa-progress-fill";
-  Object.assign(progressFill.style, styles.progressBarFill);
   progressContainer.appendChild(progressFill);
   csaPopup.appendChild(progressContainer);
 
   // 3. CONTEÚDO
   const csaContent = document.createElement("div");
   csaContent.id = "csa-content";
-  Object.assign(csaContent.style, styles.contentArea);
+  csaContent.className = "csa-content-area";
   csaPopup.appendChild(csaContent);
 
   // 4. FOOTER
   const footer = document.createElement("div");
-  Object.assign(footer.style, styles.footer);
+  footer.className = "csa-footer";
   const credit = document.createElement("span");
+  credit.className = "csa-credit";
   credit.textContent = "by lucaste@";
-  Object.assign(credit.style, { fontSize: "10px", color: "#bdc1c6" });
-  
+
   const resetBtn = document.createElement("button");
+  resetBtn.className = "csa-reset-btn";
   resetBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path><path d="M3 3v5h5"></path></svg> Resetar Script`;
-  Object.assign(resetBtn.style, styles.resetBtn);
-  resetBtn.onmouseenter = () => resetBtn.style.background = "#fce8e6";
-  resetBtn.onmouseleave = () => resetBtn.style.background = "transparent";
   resetBtn.onclick = () => {
-    resetBtn.style.transform = "scale(0.9)";
-    setTimeout(() => resetBtn.style.transform = "scale(1)", 150);
     for (let key in csaCompletedTasks) delete csaCompletedTasks[key];
     csaBuildChecklist();
   };
@@ -428,9 +435,9 @@ export function initCallScriptAssistant() {
   footer.appendChild(resetBtn);
   csaPopup.appendChild(footer);
 
-  // 5. CONTROLES (MODERN TABS)
+  // 5. CONTROLES (SEGMENTED TABS)
   const csaControlsDiv = document.createElement("div");
-  Object.assign(csaControlsDiv.style, { display: "flex", flexDirection: "column", gap: "8px", marginBottom: "16px" });
+  csaControlsDiv.className = "csa-controls";
 
   // Type Selector (BAU/LT)
   const typeControl = document.createElement("div");
@@ -441,14 +448,13 @@ export function initCallScriptAssistant() {
       <button data-type="LT">LT</button>
   `;
 
-  // Language Selector (PT/ES/EN)
+  // Language Selector (PT/ES)
   const langControl = document.createElement("div");
   langControl.className = "csa-segmented-control";
   langControl.innerHTML = `
-      <div class="csa-segmented-indicator" id="lang-indicator" style="width: calc(33.33% - 2px); transform: translateX(0px);"></div>
+      <div class="csa-segmented-indicator" id="lang-indicator" style="width: calc(50% - 2px); transform: translateX(0px);"></div>
       <button class="active" data-lang="PT">PT</button>
       <button data-lang="ES">ES</button>
-      <button data-lang="EN">EN</button>
   `;
 
   csaControlsDiv.appendChild(typeControl);
@@ -476,7 +482,7 @@ export function initCallScriptAssistant() {
       btn.onclick = () => {
           langButtons.forEach(b => b.classList.remove('active'));
           btn.classList.add('active');
-          langIndicator.style.transform = `translateX(${idx * (langControl.offsetWidth / 3 - 1)}px)`;
+          langIndicator.style.transform = `translateX(${idx * (langControl.offsetWidth / 2 - 2)}px)`;
           csaCurrentLang = btn.dataset.lang;
           SoundManager.playClick();
           csaBuildChecklist();
@@ -499,7 +505,81 @@ export function initCallScriptAssistant() {
   setupCopy('#cw-pill-cid', '#cw-ctx-cid');
   setupCopy('#cw-pill-email', '#cw-ctx-email');
 
-  function formatScriptText(text) { return text; }
+  // Converte quebras de linha do texto-fonte (usadas em itens com sub-listas,
+  // ex: "ES LT" inicio) em <br>, já que \n dentro de innerHTML é ignorado pelo HTML.
+  function formatScriptText(text) {
+      return text.replace(/\n/g, '<br>');
+  }
+
+  function createChecklistItemRow(combinedKey, groupKey, itemText, index) {
+    const key = `${combinedKey}-${groupKey}-${index}`;
+    const isDone = !!csaCompletedTasks[key];
+
+    const row = document.createElement("div");
+    row.className = "csa-item-row" + (isDone ? " completed" : "");
+
+    const chk = document.createElement("div");
+    chk.className = "csa-checkbox" + (isDone ? " checked" : "");
+    chk.innerHTML = isDone
+        ? `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`
+        : "";
+
+    const textSpan = document.createElement("span");
+    textSpan.className = "csa-item-text" + (isDone ? " completed" : "");
+    textSpan.innerHTML = formatScriptText(itemText);
+
+    row.onclick = () => {
+      const newState = !csaCompletedTasks[key];
+      csaCompletedTasks[key] = newState;
+      SoundManager.playClick();
+
+      row.classList.toggle("completed", newState);
+      textSpan.classList.toggle("completed", newState);
+      chk.classList.toggle("checked", newState);
+      chk.innerHTML = newState
+          ? `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`
+          : "";
+
+      if (newState) {
+          chk.classList.add("pulse");
+          setTimeout(() => chk.classList.remove("pulse"), 150);
+      }
+
+      updateProgressAndCounters(combinedKey, csaChecklistData[combinedKey]);
+    };
+
+    row.appendChild(chk);
+    row.appendChild(textSpan);
+    return { row, isDone };
+  }
+
+  function createChecklistCard(combinedKey, groupKey, items) {
+    const card = document.createElement("div");
+    card.className = "csa-card";
+
+    const cardTitle = document.createElement("div");
+    cardTitle.className = "csa-card-title";
+    cardTitle.textContent = GROUP_TITLES[groupKey][csaCurrentLang] || "";
+
+    const counter = document.createElement("span");
+    counter.className = "csa-card-counter";
+    cardTitle.appendChild(counter);
+    card.appendChild(cardTitle);
+
+    let groupDoneCount = 0;
+    items.forEach((itemText, index) => {
+      const { row, isDone } = createChecklistItemRow(combinedKey, groupKey, itemText, index);
+      if (isDone) groupDoneCount++;
+      card.appendChild(row);
+    });
+
+    const allDone = groupDoneCount === items.length && items.length > 0;
+    card.classList.toggle("done", allDone);
+    counter.classList.toggle("done", allDone);
+    counter.textContent = `${groupDoneCount}/${items.length}`;
+
+    return card;
+  }
 
   function csaBuildChecklist() {
     csaChecklistArea.innerHTML = "";
@@ -507,106 +587,26 @@ export function initCallScriptAssistant() {
     const data = csaChecklistData[combinedKey];
 
     if (!data) {
-      csaChecklistArea.innerHTML = `<div style="padding: 30px; text-align: center; color: #bdc1c6; display: flex; flex-direction: column; align-items: center; gap: 10px;"><div style="font-size: 24px;">☕</div><div>Script não configurado.</div></div>`;
+      csaChecklistArea.innerHTML = `<div class="csa-empty-state"><div class="csa-empty-state-icon">☕</div><div>Script não configurado.</div></div>`;
       progressFill.style.width = "0%";
       return;
     }
 
-    const activeColor = COLORS.primary;
     let totalItems = 0; let completedItems = 0;
     ["inicio", "meio", "fim"].forEach(k => { if (data[k]) totalItems += data[k].length; });
 
-    ["inicio", "meio", "fim"].forEach((groupKey, groupIndex) => {
+    ["inicio", "meio", "fim"].forEach(groupKey => {
       const items = data[groupKey];
       if (!items || items.length === 0) return;
 
-      const card = document.createElement("div");
-      Object.assign(card.style, styles.card);
-
-      const cardTitle = document.createElement("div");
-      Object.assign(cardTitle.style, styles.cardTitle);
-
-      let titleText = "";
-      if (groupKey === "inicio") {
-          if (csaCurrentLang.includes("ES")) titleText = "Apertura";
-          else if (csaCurrentLang.includes("EN")) titleText = "Opening";
-          else titleText = "Abertura";
-      } else if (groupKey === "meio") {
-          if (csaCurrentLang.includes("ES")) titleText = "Implementación";
-          else if (csaCurrentLang.includes("EN")) titleText = "Implementation";
-          else titleText = "Implementação (Tag Support)";
-      } else if (groupKey === "fim") {
-          if (csaCurrentLang.includes("ES")) titleText = "Cierre";
-          else if (csaCurrentLang.includes("EN")) titleText = "Closing";
-          else titleText = "Fechamento";
-      }
-
-      cardTitle.textContent = titleText;
-      const counter = document.createElement("span");
-      counter.style.fontSize = "11px"; counter.style.opacity = "0.7"; counter.style.fontWeight = "500"; counter.style.background = "#f1f3f4"; counter.style.padding = "2px 8px"; counter.style.borderRadius = "10px";
-      cardTitle.appendChild(counter);
-      card.appendChild(cardTitle);
-
-      let groupDoneCount = 0;
-
-      items.forEach((itemText, index) => {
+      items.forEach((_, index) => {
         const key = `${combinedKey}-${groupKey}-${index}`;
-        const isDone = !!csaCompletedTasks[key];
-        if (isDone) { completedItems++; groupDoneCount++; }
-
-        const row = document.createElement("div");
-        Object.assign(row.style, styles.itemRow);
-
-        const chk = document.createElement("div");
-        Object.assign(chk.style, styles.checkbox);
-
-        const textSpan = document.createElement("span");
-        textSpan.className = "csa-item-text" + (isDone ? " completed" : "");
-        textSpan.innerHTML = formatScriptText(itemText);
-        textSpan.style.flex = "1";
-
-        if (isDone) {
-          Object.assign(row.style, styles.itemCompleted);
-          chk.style.background = activeColor; chk.style.borderColor = activeColor; chk.style.transform = "scale(1)";
-          chk.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
-        } else {
-          chk.style.background = "transparent"; chk.style.borderColor = COLORS.borderSubtle; chk.style.transform = "scale(1)";
-          chk.innerHTML = "";
-        }
-
-        row.onclick = () => {
-          const newState = !csaCompletedTasks[key];
-          csaCompletedTasks[key] = newState;
-          SoundManager.playClick();
-
-          if (newState) {
-            chk.style.transform = "scale(1.15)"; setTimeout(() => chk.style.transform = "scale(1)", 150);
-            Object.assign(row.style, styles.itemCompleted);
-            textSpan.classList.add("completed");
-            chk.style.background = activeColor; chk.style.borderColor = activeColor;
-            chk.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
-          } else {
-            row.style.background = "transparent";
-            textSpan.classList.remove("completed");
-            chk.style.background = "transparent"; chk.style.borderColor = COLORS.borderSubtle; chk.innerHTML = "";
-          }
-          updateProgressAndCounters(combinedKey, data);
-        };
-
-        row.onmouseenter = () => { if (!csaCompletedTasks[key]) { row.style.background = "rgba(0, 0, 0, 0.03)"; chk.style.borderColor = activeColor; } };
-        row.onmouseleave = () => { if (!csaCompletedTasks[key]) { row.style.background = "transparent"; chk.style.borderColor = COLORS.borderSubtle; } };
-
-        row.appendChild(chk); row.appendChild(textSpan);
-        card.appendChild(row);
+        if (csaCompletedTasks[key]) completedItems++;
       });
 
-      if (groupDoneCount === items.length && items.length > 0) {
-        counter.style.color = "#1e8e3e"; counter.style.background = "#e6f4ea";
-        card.style.boxShadow = "inset 4px 0 0 #1e8e3e, 0 1px 3px rgba(0,0,0,0.05)";
-      }
-      counter.textContent = `${groupDoneCount}/${items.length}`;
-      csaChecklistArea.appendChild(card);
+      csaChecklistArea.appendChild(createChecklistCard(combinedKey, groupKey, items));
     });
+
     updateProgressUI(totalItems, completedItems);
   }
 
@@ -624,13 +624,7 @@ export function initCallScriptAssistant() {
   function updateProgressUI(total, completed) {
     const pct = total === 0 ? 0 : (completed / total) * 100;
     progressFill.style.width = `${pct}%`;
-    if (pct === 100) {
-        progressFill.style.background = COLORS.success;
-        progressFill.classList.remove("csa-progress-fill"); // Stop shimmer when 100%
-    } else {
-        progressFill.style.background = ""; // Revert to gradient shimmer
-        progressFill.classList.add("csa-progress-fill");
-    }
+    progressFill.classList.toggle("complete", pct === 100);
   }
 
   csaBuildChecklist();

--- a/src/modules/call-script/call-script-data.js
+++ b/src/modules/call-script/call-script-data.js
@@ -1,5 +1,16 @@
 // src/modules/call-script/call-script-data.js
 
+// Seção "meio" (Implementação via Tag Support) é palavra-por-palavra igual entre
+// BAU e LT em PT — extraída pra uma constante única pra não divergir por acidente
+// se um dia precisar editar só uma cópia e esquecer da outra.
+const TAG_SUPPORT_STEPS_PT = [
+    "Ofertar Implementação via Tag Support (Acesso Temporário)",
+    "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+    "Confirmar recebimento do acesso",
+    "Iniciar Configuração (Aviso de silêncio ~10min)",
+    "[Caso Recuse] Seguir com Compartilhamento de Tela"
+];
+
 export const csaChecklistData = {
     "PT BAU": {
         inicio: [
@@ -12,13 +23,7 @@ export const csaChecklistData = {
             "Pedir para fechar conteúdo sensível (antes de compartilhar)",
             "Validar Backup e Acessos Admin"
         ],
-        meio: [
-            "Ofertar Implementação via Tag Support (Acesso Temporário)",
-            "Enviar e orientar aceite do email 'Consentimento e autorização...'",
-            "Confirmar recebimento do acesso",
-            "Iniciar Configuração (Aviso de silêncio ~10min)",
-            "[Caso Recuse] Seguir com Compartilhamento de Tela"
-        ],
+        meio: TAG_SUPPORT_STEPS_PT,
         fim: [
             "Resumo da chamada (o que foi feito e como funciona)",
             "Oferecer ajuda adicional / Abrir para dúvidas",
@@ -41,13 +46,7 @@ export const csaChecklistData = {
             "Por favor, feche todo e qualquer conteúdo confidencial e sensível (conversas, dados pessoais importantes, etc).",
             "Possui o backup do seu site e todos os acessos às ferramentas do Google?"
         ],
-        meio: [
-            "Ofertar Implementação via Tag Support (Acesso Temporário)",
-            "Enviar e orientar aceite do email 'Consentimento e autorização...'",
-            "Confirmar recebimento do acesso",
-            "Iniciar Configuração (Aviso de silêncio ~10min)",
-            "[Caso Recuse] Seguir com Compartilhamento de Tela"
-        ],
+        meio: TAG_SUPPORT_STEPS_PT,
         fim: [
             "Resumo da chamada (o que foi feito e como funciona)",
             "Oferecer ajuda adicional / Abrir para dúvidas",
@@ -59,6 +58,11 @@ export const csaChecklistData = {
             "Despedida"
         ]
     },
+    // ⚠️ PENDENTE: "ES BAU" e "ES LT" não têm seção `meio` (Implementação/Tag
+    // Support) — não é proposital, é conteúdo real que ainda falta receber.
+    // Enquanto isso, o card de Implementação simplesmente não aparece pra ES
+    // (mesmo comportamento de hoje). Não inventar texto aqui — assim que o
+    // conteúdo real chegar, adicionar `meio: [...]` nos dois abaixo.
     "ES BAU": {
         inicio: ["Introducción (Nombre y Equipo).", "La llamada puede ser grabada con fines de entrenamiento y calidad de acuerdo con nuestra política de privacidad.", "Informar sitio web registrado en el caso.", "Confirmación: Solicitar al Anunciante que confirme los 10 dígitos del CID el email del anunciante.", "Confirmaciones: Tarea, AM", "Informar el tiempo que va a durar la reunión.", "Confirmación: Copia de seguridad y acceso de ADM", "Cerrar contenido sensible antes de compartir la pantalla.", ],
         fim: ["Resumen de la llamada.", "Ayuda adicional.", "Cerrar la pantalla compartida.", "Próximos pasos (¿Cuánto tiempo seguirá el caso?)", "Encuesta de Satisfacción.", "Estaré monitoreando su caso durante XX días para asegurarme de que todo esté funcionando correctamente. Durante este tiempo, nuestro equipo de calidad podría realizar una prueba de conversión para validar la implementación. ¿Estás de acuerdo con esta prueba para garantizar la efectividad de la implementación? Perfecto, ¡gracias!", ]
@@ -66,9 +70,5 @@ export const csaChecklistData = {
     "ES LT": {
         inicio: ["Presentación (Nombre y equipo).", "Informar al cliente sobre la llamada grabada.", "Tiempo de duración de la llamada.", "Solicitar al anunciante que confirme lo siguiente: \n A) 10 dígitos de la cuenta \n B) Correo electrónico \n C) Número de teléfono y \n D) Nombre del sitio web.", "autenticar la cuenta del anunciante en el cases, si corresponde.", "Términos y condiciones.", "Informar las Task solicitadas y AM.", "Cerrar contenido sensible.", "Confirmación de copia de seguridad y acceso de administrador a las herramientas.", "Resumen de llamada."],
         fim: ["Ofrecer ayuda adicional.", "Dejar de compartir la pantalla.", "Pasos siguientes (Si se le hará seguimiento al caso).", "Encuesta de Satisfacción.", "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días."]
-    },
-    "EN BAU": {
-        inicio: ["Example 1", "Example 2"],
-        fim: ["Example 3", "Example 4"]
     }
 };


### PR DESCRIPTION
## Contexto

Varredura em todos os módulos pra achar o próximo com mais gargalo (depois da Minha Biblioteca) apontou `call-script/` como um dos dois piores, com bugs reais afetando ligações ao vivo hoje. Direção confirmada: remover o inglês do módulo inteiramente (não tinha conteúdo real, só placeholder), manter a seção "meio" do ES ausente por enquanto (conteúdo real vem depois).

## Bugs reais corrigidos

1. **"EN BAU" tinha texto placeholder literal** (`"Example 1"`, `"Example 2"`...) e **não existia "EN LT"** — selecionar Inglês + LT no app ao vivo caía silenciosamente em "Script não configurado.". Inglês removido do módulo inteiramente (seletor de idioma agora só PT/ES).
2. **Quebra de linha quebrada**: o item de abertura do "ES LT" tem uma sub-lista com `
` embutido, que nunca virava quebra de linha visual porque estava sendo jogado direto num `.innerHTML` sem processamento. `formatScriptText()` era um no-op (`return text`) — agora faz a conversão `
` → `<br>` de verdade.
3. **Vazamento de paleta**: o banner de contexto tinha cores/fonte do Google (`Google Sans`, `#1A73E8`, `#E8F0FE`) hardcoded no HTML, mesmo o módulo sendo deliberadamente "Apple Inspired" (`#007AFF`). Corrigido pra usar a paleta do módulo consistentemente.
4. **Duplicação de dado**: a seção `meio` (Tag Support) de "PT BAU" e "PT LT" era idêntica palavra-por-palavra — extraída pra uma constante única.

## Modernização de arquitetura

Consolidei os três mecanismos de estilo que coexistiam no arquivo (objeto `styles` JS + `Object.assign(el.style,...)`, um `<style>` só de animação, e dezenas de `style="..."` hardcoded no template do banner) numa única folha de estilo dedicada (`injectStyles()`), mesmo padrão adotado na Minha Biblioteca. Estados que eram setados via JS diretamente no `.style` (checkbox marcado, item completo, accordion aberto, painel "Mensagem AM" visível) agora são só `classList.toggle(...)`, com os hovers migrados pra CSS `:hover`.

Também quebrei `csaBuildChecklist()` (que tinha ~107 linhas misturando estado vazio + construção de card + construção de item) em duas funções auxiliares (`createChecklistCard`/`createChecklistItemRow`), e removi 4 imports mortos (`styleSelect`, `styleCredit`, `typeBtnStyle`, `getRandomGoogleStyle`) que não eram usados em lugar nenhum do arquivo.

## O que NÃO mudou

- Nenhuma mudança de UX/interação — mesmo banner de contexto com polling ao vivo, mesmas abas segmentadas, mesmo checklist com barra de progresso e reset. É modernização de arquitetura + fix de bug, não redesign.
- Texto real dos scripts em PT/ES não foi tocado.
- Seção `meio` do ES continua ausente (comportamento atual preservado), só documentada como pendência conhecida no código — aguardando o conteúdo real.

## Verificação

- `esbuild src/app.js --bundle --minify` passa sem erro.
- Sem acesso pra testar visualmente no CRM neste ambiente — pontos específicos pra conferir:
  1. Seletor de idioma mostra só PT/ES (sem EN), indicador desliza certo entre os dois.
  2. Alternar BAU/LT em PT e ES (checklist, progresso, reset) continua funcionando.
  3. O item de "ES LT" com a lista A)/B)/C)/D) agora quebra linha corretamente.
  4. Banner de contexto (nome/CID/email ao vivo, cópia por clique, "Mensagem AM") visualmente igual, só com cores Apple consistentes.
  5. Botão "Resetar Script" e barra de progresso com shimmer continuam funcionando.
