### PR TITLE
feat(notes): validate required fields, hide low-value fields by default

### DIFF
--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -1,5 +1,5 @@
 // src/modules/notes/core/form-builder.js
-import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations } from "../data/notes-data.js";
+import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations, optionalFields, requiredFields } from "../data/notes-data.js";
 import { fetchAndInsertSpeakeasyId } from "../automation/case-log-scraper.js";
 import { enableAutoBullet } from "../components/bullet-editor.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
@@ -18,8 +18,15 @@ export function buildDynamicForm(subStatusKey, container, state) {
         const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;
         label.textContent = t(fieldName.toLowerCase()) !== fieldName.toLowerCase() ? t(fieldName.toLowerCase()) : fieldName.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()) + ":";
         Object.assign(label.style, { display: "flex", alignItems: "center", justifyContent: "space-between", fontSize: "13px", fontWeight: "700", color: COLORS.textSub, marginBottom: "8px", marginTop: "24px", textTransform: "uppercase", letterSpacing: "0.5px" });
+        const isRequired = requiredFields.includes(fieldName);
         const labelText = document.createElement("span");
         labelText.textContent = label.textContent;
+        if (isRequired) {
+            const asterisk = document.createElement("span");
+            asterisk.textContent = " *";
+            asterisk.style.color = COLORS.error;
+            labelText.appendChild(asterisk);
+        }
         label.innerHTML = "";
         label.appendChild(labelText);
 
@@ -33,20 +40,22 @@ export function buildDynamicForm(subStatusKey, container, state) {
             label.appendChild(btnSearch);
         }
 
-        const btnDelete = document.createElement('button');
-        btnDelete.innerHTML = "✕";
-        btnDelete.style.cssText = `font-size: 14px; background: ${COLORS.bgInput}; border: none; color: ${COLORS.textSub}; cursor: pointer; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-left: auto; transition: all 0.2s ${EASE};`;
-        btnDelete.onmouseenter = () => { btnDelete.style.background = COLORS.error; btnDelete.style.color = COLORS.surface; };
-        btnDelete.onmouseleave = () => { btnDelete.style.background = COLORS.bgInput; btnDelete.style.color = COLORS.textSub; };
-        btnDelete.onclick = async (e) => {
-            e.preventDefault();
-            const confirmed = await confirmDialog(`Tem certeza que deseja remover o campo "${labelText.textContent.replace(':', '')}"?`);
-            if (confirmed) {
-                state.removeField(fieldName);
-                buildDynamicForm(subStatusKey, container, state);
-            }
-        };
-        label.appendChild(btnDelete);
+        if (!isRequired) {
+            const btnDelete = document.createElement('button');
+            btnDelete.innerHTML = "✕";
+            btnDelete.style.cssText = `font-size: 14px; background: ${COLORS.bgInput}; border: none; color: ${COLORS.textSub}; cursor: pointer; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-left: auto; transition: all 0.2s ${EASE};`;
+            btnDelete.onmouseenter = () => { btnDelete.style.background = COLORS.error; btnDelete.style.color = COLORS.surface; };
+            btnDelete.onmouseleave = () => { btnDelete.style.background = COLORS.bgInput; btnDelete.style.color = COLORS.textSub; };
+            btnDelete.onclick = async (e) => {
+                e.preventDefault();
+                const confirmed = await confirmDialog(`Tem certeza que deseja remover o campo "${labelText.textContent.replace(':', '')}"?`);
+                if (confirmed) {
+                    state.removeField(fieldName);
+                    buildDynamicForm(subStatusKey, container, state);
+                }
+            };
+            label.appendChild(btnDelete);
+        }
         let field;
         if (textareaListFields.includes(fieldName)) {
             field = document.createElement("textarea"); field.classList.add("bullet-textarea", "cw-textarea");
@@ -81,5 +90,38 @@ export function buildDynamicForm(subStatusKey, container, state) {
 
         container.appendChild(consentLabel);
         container.appendChild(consentSelect);
+    }
+
+    // Campos opcionais do template (ver optionalFields em data/notes-data.js)
+    // que ainda não estão ativos: ficam escondidos por padrão pra reduzir a
+    // carga cognitiva, mas continuam a 1 clique de distância.
+    const hiddenOptional = (templateData.templateFields || []).filter(
+        (fieldName) => optionalFields.includes(fieldName) && !state.activeFields.includes(fieldName)
+    );
+    if (hiddenOptional.length > 0) {
+        const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;
+        const addWrap = document.createElement("div");
+        Object.assign(addWrap.style, { display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "24px" });
+
+        hiddenOptional.forEach((fieldName) => {
+            const rawLabel = t(fieldName.toLowerCase()) !== fieldName.toLowerCase()
+                ? t(fieldName.toLowerCase())
+                : fieldName.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()) + ":";
+
+            const chip = document.createElement('button');
+            chip.type = 'button';
+            chip.textContent = `+ ${rawLabel.replace(/:$/, '')}`;
+            chip.style.cssText = `font-size: 12px; font-weight: 600; color: ${COLORS.primary}; background-color: ${COLORS.primaryBg}; border: none; border-radius: ${RADIUS.pill}; padding: 6px 14px; cursor: pointer; transition: all 0.2s ${EASE};`;
+            chip.onmouseenter = () => chip.style.backgroundColor = "#d2e3fc";
+            chip.onmouseleave = () => chip.style.backgroundColor = COLORS.primaryBg;
+            chip.onclick = (e) => {
+                e.preventDefault();
+                state.addFieldAt(fieldName, state.activeFields.length);
+                buildDynamicForm(subStatusKey, container, state);
+            };
+            addWrap.appendChild(chip);
+        });
+
+        container.appendChild(addWrap);
     }
 }

--- a/src/modules/notes/core/notes-state.js
+++ b/src/modules/notes/core/notes-state.js
@@ -7,7 +7,6 @@ export class NotesState {
         this.visible = false; this.isSplitView = false; this.currentStatus = "";
         this.currentSubStatus = ""; this.formData = {}; this.activeTasks = [];
         this.screenshotsData = {}; this.tagSupportState = null; this.isDirty = false;
-        this.excludedFields = new Set();
         this.activeFields = [];
         const savedFavorites = typeof localStorage !== 'undefined' ? localStorage.getItem('cw-notes-favorites') : null;
         this.favorites = new Set(JSON.parse(savedFavorites || '[]'));
@@ -68,17 +67,6 @@ export class NotesState {
     toggleForcedScreenshot(taskKey, val) {
         if (val) this.forcedScreenshots.add(taskKey);
         else this.forcedScreenshots.delete(taskKey);
-        this.isDirty = true;
-        this.notify();
-    }
-    setExcludedFields(fieldsArray) {
-        this.excludedFields = new Set(fieldsArray);
-        this.isDirty = true;
-        this.notify();
-    }
-    toggleFieldExclusion(fieldId, isExcluded) {
-        if (isExcluded) this.excludedFields.add(fieldId);
-        else this.excludedFields.delete(fieldId);
         this.isDirty = true;
         this.notify();
     }

--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -328,6 +328,18 @@ export const TASKS_DB = {
     }
 };
 
+// Campos presentes em quase todo template (17 dos 18) mas de baixo valor por
+// padrão — em vez de aparecer sempre pra todo mundo, ficam escondidos até o
+// agente clicar pra adicionar (buildDynamicForm em core/form-builder.js).
+// Não é por-template de propósito: são universais o bastante pra um único
+// corte servir em qualquer substatus que os contenha.
+export const optionalFields = ['GTM_GA4_VERIFICADO', 'MULTIPLE_CIDS'];
+
+// Campo obrigatório em todo template (presente nos 18) — o motivo/narrativa
+// do caso. Validado em handleGenerate() (notes-assistant.js) e marcado
+// visualmente em core/form-builder.js.
+export const requiredFields = ['REASON_COMMENTS'];
+
 // ==================================================================
 //               NOVA ESTRUTURA: SUBSTATUS_TEMPLATES
 // ==================================================================

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -20,7 +20,9 @@ import {
     translations,
     scenarioSnippets,
     textareaListFields,
-    TASKS_DB
+    TASKS_DB,
+    optionalFields,
+    requiredFields
 } from "./data/notes-data.js";
 import {
     copyHtmlToClipboard,
@@ -461,8 +463,12 @@ export function initCaseNotesAssistant() {
         actionsSection.style.display = "grid";
 
         // 1. Initialize Active Fields from Template
+        // Campos em optionalFields começam escondidos (baixo valor por
+        // padrão) — o agente adiciona pelo "+ adicionar campo" se precisar.
         if (templateData && templateData.templateFields) {
-            notesState.setActiveFields(templateData.templateFields);
+            notesState.setActiveFields(
+                templateData.templateFields.filter((f) => !optionalFields.includes(f))
+            );
         }
 
         // 2. Adjust for Case Type (LM/BAU) and Portugal Case
@@ -491,13 +497,6 @@ export function initCaseNotesAssistant() {
 
         const mode = subStatusKey === "SO_Education_Only" ? "education" : "implementation";
         notesState.setScreenshotMode(mode);
-
-        // Auto-hide ON_CALL for LM
-        if (notesState.currentCaseType === "lm") {
-            notesState.toggleFieldExclusion("field-ON_CALL", true);
-        } else {
-            notesState.toggleFieldExclusion("field-ON_CALL", false);
-        }
 
         stepTasks.updateSubStatus(subStatusKey);
         updateTagSupport();
@@ -684,6 +683,23 @@ export function initCaseNotesAssistant() {
             showToast(t('select_substatus'), { error: true });
             return;
         }
+
+        const missingRequired = requiredFields.filter((fieldName) => {
+            if (!notesState.activeFields.includes(fieldName)) return false;
+            const value = notesState.formData[`field-${fieldName}`];
+            return !value || !value.trim();
+        });
+        if (missingRequired.length > 0) {
+            showToast(`Preencha o campo obrigatório antes de gerar: ${t(missingRequired[0].toLowerCase())}`, { error: true });
+            return;
+        }
+
+        const templateData = SUBSTATUS_TEMPLATES[notesState.currentSubStatus];
+        if (templateData?.requiresTasks && stepTasks.getCheckedElements().length === 0) {
+            showToast("Selecione ao menos uma tarefa antes de gerar a nota.", { error: true });
+            return;
+        }
+
         const html = generateOutputHtml(notesState, stepTasks, tagSupport, getEvidenceData());
 
         copyHtmlToClipboard(html);
@@ -809,7 +825,6 @@ export function initCaseNotesAssistant() {
             consent: notesState.consent,
             tagSupportUsed: notesState.tagSupportUsed,
             forcedScreenshots: [...notesState.forcedScreenshots],
-            excludedFields: [...notesState.excludedFields],
             activeFields: notesState.activeFields,
             status: notesState.currentStatus,
             subStatus: notesState.currentSubStatus,
@@ -829,7 +844,6 @@ export function initCaseNotesAssistant() {
         notesState.setCaseType(draft.currentCaseType || "bau");
         notesState.setPortugalCase(draft.isPortugalCase || false);
         notesState.setConsent(draft.consent || false);
-        notesState.setExcludedFields(draft.excludedFields || []);
         if (draft.activeFields) {
             notesState.setActiveFields(draft.activeFields);
         }


### PR DESCRIPTION
## Resumo

Terceira rodada no notes/ — dessa vez a partir de uma análise de UX/fluxo que você pediu (não só código). Objetivo: menos passos, menos carga cognitiva por nota, nas duas frentes que você confirmou.

### 1. Obrigatoriedade que hoje não existe
Nenhum campo é validado como obrigatório no fluxo principal — só imprime "N/A" se ficar vazio. `REASON_COMMENTS` (presente nos 18 templates) agora é tratado como obrigatório de verdade: asterisco vermelho no label, sem botão de remover, e `handleGenerate()` bloqueia com toast se ficar vazio.

### 2. requiresTasks finalmente funciona
Esse flag existe em 4 templates desde sempre mas nunca era lido em lugar nenhum do código. Agora bloqueia o "Gerar" se nenhuma tarefa foi marcada no catálogo, quando o template exige.

### 3. Menos campos por padrão
`GTM_GA4_VERIFICADO` e `MULTIPLE_CIDS` (presentes em 17 dos 18 templates, mesmo quando não fazem sentido pro caso) não aparecem mais automaticamente. Uma nova seção de chips "+ nome do campo" no rodapé do formulário deixa adicionar em 1 clique quando o caso realmente precisar.

### 4. Bônus: outro mecanismo morto encontrado na mesma área
`excludedFields`/`toggleFieldExclusion` em `notes-state.js` eram escritos (pra esconder ON_CALL em casos LM) mas nunca lidos em lugar nenhum — a mesma classe de bug do `requiresTasks`. O que já funciona de verdade é `adjustActiveFieldsForContext()`, que roda antes e já remove/adiciona ON_CALL corretamente. Removido o mecanismo morto.

## Fora de escopo (decisão sua, já confirmada)

- Catálogo de tarefas não muda por substatus — intencional.
- Templates fora do código (planilha/JSON) — não vale a pena agora.
- Reclassificação campo-a-campo de todos os 18 templates — esse PR faz um corte conservador (2 campos opcionais universais + 1 obrigatório universal); ir mais fundo template a template fica pra outra rodada se você quiser depois de ver isso em uso.

## Teste

- [ ] `esbuild` roda sem erro (já validado localmente)
- [ ] Selecionar qualquer substatus: GTM_GA4_VERIFICADO e MULTIPLE_CIDS não aparecem mais por padrão, mas dá pra adicionar pelos chips no rodapé do formulário
- [ ] Tentar gerar com REASON_COMMENTS vazio → toast de erro, não gera
- [ ] Selecionar um substatus com requiresTasks (ex: SO Implementation Only) sem marcar tarefa → toast de erro, não gera
- [ ] Caso LM continua escondendo ON_CALL normalmente
- [ ] Restaurar um rascunho salvo antes dessa mudança continua funcionando

🤖 Gerado com [Claude Code](https://claude.com/claude-code)