### PR TITLE
fix(notes): conditional required fields, simplify SO template, UI polish

### DIFF
--- a/src/modules/notes/components/step-tasks.js
+++ b/src/modules/notes/components/step-tasks.js
@@ -294,10 +294,15 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
                 border-bottom-right-radius: 11px;
                 display: flex; align-items: center; justify-content: space-between;
                 transform: translateY(100%); transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+                visibility: hidden;
                 box-shadow: ${DS.shadowFloat}; z-index: 10;
                 margin-top: auto;
             }
-            .cw-status-bar.visible { transform: translateY(0); }
+            /* .cw-zen-container usa overflow:visible (pros cards do hero não
+               cortarem sombra/hover), então sem visibility a barra "escondida"
+               via transform continua sendo pintada logo abaixo do card,
+               encostando/sobrepondo o que vem depois no layout. */
+            .cw-status-bar.visible { transform: translateY(0); visibility: visible; }
             .cw-status-text { font-size: 13px; font-weight: 500; color: ${DS.textMain}; }
             
             .cw-footer-icons { display: flex; flex-direction: row-reverse; padding-left: 8px; }
@@ -729,6 +734,8 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
       });
     } else {
       statusBar.classList.remove("visible");
+      statusText.textContent = "";
+      footerIcons.innerHTML = "";
     }
   }
 

--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -1,5 +1,5 @@
 // src/modules/notes/core/form-builder.js
-import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations, optionalFields, requiredFields } from "../data/notes-data.js";
+import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations, getEffectiveRequiredFields, getEffectiveOptionalFields } from "../data/notes-data.js";
 import { fetchAndInsertSpeakeasyId } from "../automation/case-log-scraper.js";
 import { enableAutoBullet } from "../components/bullet-editor.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
@@ -10,6 +10,8 @@ export function buildDynamicForm(subStatusKey, container, state) {
     const templateData = SUBSTATUS_TEMPLATES[subStatusKey];
     if (!templateData) return;
 
+    const requiredNow = getEffectiveRequiredFields(templateData);
+
     state.activeFields.forEach((fieldName) => {
         if (["TAGS_IMPLEMENTED", "SCREENSHOTS_LIST", "CONSENTIU_GRAVACAO", "CASO_PORTUGAL", "label_substatus"].includes(fieldName)) return;
 
@@ -18,7 +20,7 @@ export function buildDynamicForm(subStatusKey, container, state) {
         const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;
         label.textContent = t(fieldName.toLowerCase()) !== fieldName.toLowerCase() ? t(fieldName.toLowerCase()) : fieldName.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()) + ":";
         Object.assign(label.style, { display: "flex", alignItems: "center", justifyContent: "space-between", fontSize: "13px", fontWeight: "700", color: COLORS.textSub, marginBottom: "8px", marginTop: "24px", textTransform: "uppercase", letterSpacing: "0.5px" });
-        const isRequired = requiredFields.includes(fieldName);
+        const isRequired = requiredNow.includes(fieldName);
         const labelText = document.createElement("span");
         labelText.textContent = label.textContent;
         if (isRequired) {
@@ -95,8 +97,9 @@ export function buildDynamicForm(subStatusKey, container, state) {
     // Campos opcionais do template (ver optionalFields em data/notes-data.js)
     // que ainda não estão ativos: ficam escondidos por padrão pra reduzir a
     // carga cognitiva, mas continuam a 1 clique de distância.
+    const optionalNow = getEffectiveOptionalFields(templateData);
     const hiddenOptional = (templateData.templateFields || []).filter(
-        (fieldName) => optionalFields.includes(fieldName) && !state.activeFields.includes(fieldName)
+        (fieldName) => optionalNow.includes(fieldName) && !state.activeFields.includes(fieldName)
     );
     if (hiddenOptional.length > 0) {
         const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;

--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -48,7 +48,7 @@ export const translations = {
         'speakeasy_id': '🆔 Speakeasy ID:',
         'on_call': '📞 On Call signaled on time?',
         'tasks_solicitadas': '🎯 Task(s) solicitada(s):',
-        'passos_executados': '👣 Seguimos com os passos:',
+        'passos_executados': '👣 O que foi feito:',
         'resultado': '🏆 Resultado:',
         'duvidas': '❓ Dúvidas do anunciante:',
         'problemas': '⚠️ Problema inicial:',
@@ -119,7 +119,7 @@ export const translations = {
         'speakeasy_id': '🆔 Speakeasy ID:',
         'on_call': '📞 On Call signaled on time?',
         'tasks_solicitadas': '🎯 Tarea(s) solicitada(s):',
-        'passos_executados': '👣 Pasos ejecutados:',
+        'passos_executados': '👣 Qué se hizo:',
         'resultado': '🏆 Resultado:',
         'duvidas': '❓ Dudas del anunciante:',
         'problemas': '⚠️ Problema inicial:',
@@ -340,6 +340,24 @@ export const optionalFields = ['GTM_GA4_VERIFICADO', 'MULTIPLE_CIDS'];
 // visualmente em core/form-builder.js.
 export const requiredFields = ['REASON_COMMENTS'];
 
+// requiredFields/optionalFields acima são a regra padrão (mesma pra todo
+// template). Alguns campos precisam de uma regra sensível ao template atual
+// — hoje só GTM_GA4_VERIFICADO, que vira obrigatório quando o template exige
+// tarefa implementada (requiresTasks), já que não faz sentido pular a
+// verificação de GTM/GA4 quando algo foi de fato implementado. Um template
+// também pode declarar `extraOptionalFields` pra esconder por padrão um
+// campo que só faz sentido pra ele (ver SO_Implementation_Only).
+export function getEffectiveRequiredFields(templateData) {
+    const fields = [...requiredFields];
+    if (templateData?.requiresTasks) fields.push('GTM_GA4_VERIFICADO');
+    return fields;
+}
+export function getEffectiveOptionalFields(templateData) {
+    const base = [...optionalFields, ...(templateData?.extraOptionalFields || [])];
+    const required = getEffectiveRequiredFields(templateData);
+    return base.filter(f => !required.includes(f));
+}
+
 // ==================================================================
 //               NOVA ESTRUTURA: SUBSTATUS_TEMPLATES
 // ==================================================================
@@ -445,10 +463,15 @@ export const SUBSTATUS_TEMPLATES = {
 
     // --- SO (Solution Offered) ---
     'SO_Implementation_Only': {
-        status: 'SO', 
+        status: 'SO',
         name: 'SO - Implementation Only',
         requiresTasks: true,
-        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'TASKS_SOLICITADAS', 'TASKS_IMPLEMENTADAS_CALL', 'PASSOS_EXECUTADOS', 'RESULTADO', 'PROXIMOS_PASSOS', 'CONSIDERACOES', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS'],
+        // TASKS_SOLICITADAS/TASKS_IMPLEMENTADAS_CALL removidos: redundantes
+        // com o que já aparece a partir das tarefas marcadas no catálogo
+        // (TAGS_IMPLEMENTED). PROXIMOS_PASSOS só faz sentido quando o caso
+        // tem acompanhamento, então fica em extraOptionalFields.
+        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'PASSOS_EXECUTADOS', 'RESULTADO', 'PROXIMOS_PASSOS', 'CONSIDERACOES', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS'],
+        extraOptionalFields: ['PROXIMOS_PASSOS'],
         fieldPrefixes: {
             'REASON_COMMENTS': 'Task implementada com sucesso.'
         }

--- a/src/modules/notes/drafts/draft-ui.js
+++ b/src/modules/notes/drafts/draft-ui.js
@@ -89,7 +89,9 @@ export function createDraftsManager(callbacks) {
     historyBtnWrapper.style.cssText = "position: relative; cursor: pointer; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s; margin-right: 8px;";
     
     // Ícone de Relógio/Histórico
-    historyBtnWrapper.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:#5f6368"><path d="M3 3v5h5"></path><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"></path><path d="M12 7v5l4 2"></path></svg>`;
+    // Cor alinhada com o botão de Split & Transfer ao lado (createSplitToggleButton
+    // em notes-assistant.js), que usa #9AA0A6 — convenção dos ícones do header.
+    historyBtnWrapper.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:#9AA0A6"><path d="M3 3v5h5"></path><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"></path><path d="M12 7v5l4 2"></path></svg>`;
     
     // Badge Vermelho (Contador)
     const badge = document.createElement("div");

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -21,8 +21,8 @@ import {
     scenarioSnippets,
     textareaListFields,
     TASKS_DB,
-    optionalFields,
-    requiredFields
+    getEffectiveRequiredFields,
+    getEffectiveOptionalFields
 } from "./data/notes-data.js";
 import {
     copyHtmlToClipboard,
@@ -463,11 +463,12 @@ export function initCaseNotesAssistant() {
         actionsSection.style.display = "grid";
 
         // 1. Initialize Active Fields from Template
-        // Campos em optionalFields começam escondidos (baixo valor por
-        // padrão) — o agente adiciona pelo "+ adicionar campo" se precisar.
+        // Campos opcionais (sensíveis ao template — ver getEffectiveOptionalFields)
+        // começam escondidos — o agente adiciona pelo "+ adicionar campo" se precisar.
         if (templateData && templateData.templateFields) {
+            const optionalNow = getEffectiveOptionalFields(templateData);
             notesState.setActiveFields(
-                templateData.templateFields.filter((f) => !optionalFields.includes(f))
+                templateData.templateFields.filter((f) => !optionalNow.includes(f))
             );
         }
 
@@ -573,7 +574,7 @@ export function initCaseNotesAssistant() {
         div.className = "cw-actions-section";
         div.style.cssText = `
             display: grid;
-            grid-template-columns: 1fr 1fr;
+            grid-template-columns: repeat(3, 1fr);
             gap: 8px;
             padding: 10px;
             margin-top: 16px;
@@ -624,7 +625,7 @@ export function initCaseNotesAssistant() {
 
         const emailRow = document.createElement("div");
         emailRow.id = "email-automation-toggle-row";
-        emailRow.style.cssText = "grid-column: span 2; display: none; align-items: center; justify-content: center; padding-bottom: 6px; border-bottom: 1px solid rgba(0,0,0,0.05); margin-bottom: 2px;";
+        emailRow.style.cssText = "grid-column: 1 / -1; display: none; align-items: center; justify-content: center; padding-bottom: 6px; border-bottom: 1px solid rgba(0,0,0,0.05); margin-bottom: 2px;";
         emailRow.innerHTML = `
             <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 10.5px; font-weight: 600; color: ${COLORS.textSub};">
                 <input type="checkbox" id="email-automation-checkbox" checked style="width: 13px; height: 13px; accent-color: ${COLORS.primary};">
@@ -651,7 +652,7 @@ export function initCaseNotesAssistant() {
         const btnGenerate = document.createElement("button");
         btnGenerate.className = "cw-btn-primary js-btn-generate";
         btnGenerate.textContent = t('preencher');
-        btnGenerate.style.cssText = `width: 100%; height: 38px; background: ${COLORS.primary}; color: #fff; border: none; border-radius: 10px; font-weight: 600; cursor: pointer; grid-column: span 2; font-size: 12.5px; box-shadow: 0 4px 10px rgba(26, 115, 232, 0.2); margin-top: 0px;`;
+        btnGenerate.style.cssText = `width: 100%; height: 38px; background: ${COLORS.primary}; color: #fff; border: none; border-radius: 10px; font-weight: 600; cursor: pointer; grid-column: 1 / -1; font-size: 12.5px; box-shadow: 0 4px 10px rgba(26, 115, 232, 0.2); margin-top: 0px;`;
         btnGenerate.onclick = () => handleGenerate();
 
         div.appendChild(emailRow);
@@ -684,7 +685,9 @@ export function initCaseNotesAssistant() {
             return;
         }
 
-        const missingRequired = requiredFields.filter((fieldName) => {
+        const templateData = SUBSTATUS_TEMPLATES[notesState.currentSubStatus];
+
+        const missingRequired = getEffectiveRequiredFields(templateData).filter((fieldName) => {
             if (!notesState.activeFields.includes(fieldName)) return false;
             const value = notesState.formData[`field-${fieldName}`];
             return !value || !value.trim();
@@ -694,7 +697,6 @@ export function initCaseNotesAssistant() {
             return;
         }
 
-        const templateData = SUBSTATUS_TEMPLATES[notesState.currentSubStatus];
         if (templateData?.requiresTasks && stepTasks.getCheckedElements().length === 0) {
             showToast("Selecione ao menos uma tarefa antes de gerar a nota.", { error: true });
             return;


### PR DESCRIPTION
## Resumo

Rodada final dos ajustes que você pediu pra fechar o notes/ por agora. 6 itens, 2 de regra de negócio + 4 de UX/visual.

### 1. GTM/GA4 Verificado obrigatório quando há tarefa implementada
Passa a ser obrigatório (asterisco vermelho, bloqueia Gerar se vazio) especificamente nos 4 templates com `requiresTasks: true` (SO Implementation/Education/Troubleshooting Only, NI Awaiting Validation). Em todo o resto continua escondido/opcional como na PR anterior.

### 2. Campos simplificados em "SO - Implementation Only"
Remove Tasks Solicitadas e Tasks Implementadas na Call (redundante com o catálogo de tarefas marcado). "Seguimos com os passos" virou "O que foi feito". Próximos Passos agora é opcional (só aparece quando o caso realmente tem acompanhamento).

### 3+4. Sobreposição do Acesso Rápido + ícone de tarefa "grudado" (mesma causa raiz)
`.cw-zen-container` usa `overflow: visible` e a barra de status usa transform pra "esconder" — sem clipping, o conteúdo continuava sendo pintado por baixo do card mesmo escondido, encostando no toggle de email. Corrigido com `visibility` na barra de status, e o branch de zero tarefas em `updateUI()` agora realmente limpa o texto/ícones em vez de só esconder a classe visual.

### 5. Menu de botões do rodapé
Guardar/Limpar/Copiar/Gerar num grid de 2 colunas deixava "Copiar" sozinho numa linha com espaço vazio do lado. Trocado pra 3 colunas simétricas + Gerar full-width embaixo.

### 6. Ícone de rascunho — melhor esforço
Não achei nenhuma regra de opacidade reduzida no ícone de histórico. O que encontrei foi uma cor destoante da convenção dos outros ícones do header (#5f6368 vs #9AA0A6 do Split & Transfer ao lado) — padronizei pra isso. Se não for exatamente o elemento que você via apagado, me manda um print que ajusto certo.

## Teste

- [ ] `esbuild` roda sem erro (já validado localmente)
- [ ] SO Implementation/Education/Troubleshooting Only e NI Awaiting Validation: GTM/GA4 Verificado obrigatório. Outros substatus: continua opcional.
- [ ] SO Implementation Only: campos removidos/renomeados/opcionais conforme acima.
- [ ] Selecionar tarefas sem marcar nenhuma: Acesso Rápido não encosta mais no toggle de email.
- [ ] Marcar e desmarcar uma tarefa: contador e ícone somem de verdade.
- [ ] Rodapé com 3 botões simétricos + Gerar embaixo.
- [ ] Ícone de histórico no header com a cor mais clara.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)