### PR TITLE
fix(notes): conditional required fields, simplify SO template, UI polish

### DIFF
--- a/src/modules/notes/drafts/draft-ui.js
+++ b/src/modules/notes/drafts/draft-ui.js
@@ -89,9 +89,13 @@ export function createDraftsManager(callbacks) {
     historyBtnWrapper.style.cssText = "position: relative; cursor: pointer; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s; margin-right: 8px;";
     
     // Ícone de Relógio/Histórico
-    // Cor alinhada com o botão de Split & Transfer ao lado (createSplitToggleButton
+    // Cor base alinhada com o botão de Split & Transfer ao lado (createSplitToggleButton
     // em notes-assistant.js), que usa #9AA0A6 — convenção dos ícones do header.
+    // Fica azul (COLORS.primary) quando existe pelo menos um rascunho guardado,
+    // pra ser um sinal de verdade e não só uma cor estática igual sempre teve
+    // rascunho ou não (updateBadge() troca essa cor junto com o contador).
     historyBtnWrapper.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:#9AA0A6"><path d="M3 3v5h5"></path><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"></path><path d="M12 7v5l4 2"></path></svg>`;
+    const historyIconSvg = historyBtnWrapper.querySelector('svg');
     
     // Badge Vermelho (Contador)
     const badge = document.createElement("div");
@@ -110,6 +114,8 @@ export function createDraftsManager(callbacks) {
 
         // Update Pill Badge (Global)
         updateNotesBadge(count > 0);
+
+        historyIconSvg.style.color = count > 0 ? COLORS.primary : "#9AA0A6";
 
         if (count > 0) {
             badge.style.display = "block";


### PR DESCRIPTION
## Resumo

Rodada final dos ajustes pra fechar o notes/ por agora. 6 itens originais + 1 adicionado depois de testar (o ícone de rascunho precisava fazer mais que só mudar de cor estática).

### 1. GTM/GA4 Verificado obrigatório quando há tarefa implementada
Passa a ser obrigatório (asterisco vermelho, bloqueia Gerar se vazio) especificamente nos 4 templates com `requiresTasks: true` (SO Implementation/Education/Troubleshooting Only, NI Awaiting Validation). Em todo o resto continua escondido/opcional como na PR anterior.

### 2. Campos simplificados em "SO - Implementation Only"
Remove Tasks Solicitadas e Tasks Implementadas na Call (redundante com o catálogo de tarefas marcado). "Seguimos com os passos" virou "O que foi feito". Próximos Passos agora é opcional (só aparece quando o caso realmente tem acompanhamento) — fica reduzido a "O que foi feito" + "Resultado" por padrão, com Acompanhamento como opção de 1 clique.

### 3+4. Sobreposição do Acesso Rápido + ícone de tarefa "grudado" (mesma causa raiz)
`.cw-zen-container` usa `overflow: visible` e a barra de status usa transform pra "esconder" — sem clipping, o conteúdo continuava sendo pintado por baixo do card mesmo escondido, encostando/sobrepondo o toggle de email logo abaixo. Corrigido com `visibility` na barra de status, e o branch de zero tarefas em `updateUI()` agora realmente limpa o texto/ícones em vez de só esconder a classe visual.

### 5. Menu de botões do rodapé
Guardar/Limpar/Copiar/Gerar num grid de 2 colunas deixava "Copiar" sozinho numa linha com espaço vazio do lado. Trocado pra 3 colunas simétricas + Gerar full-width embaixo.

### 6. Ícone de rascunho — cor + estado
Primeiro ajuste foi só alinhar a cor com o resto dos ícones do header (#9AA0A6, mesma convenção do Split & Transfer ao lado). Depois de testar, ficou claro que o pedido real era o ícone refletir se existe rascunho guardado, não só ficar consistente — agora ele fica azul (mesma cor do contador vermelho ao lado) quando `DraftService.getCount() > 0`, e cinza neutro quando não tem nada guardado.

## Teste

- [ ] `esbuild` roda sem erro (já validado localmente)
- [ ] SO Implementation/Education/Troubleshooting Only e NI Awaiting Validation: GTM/GA4 Verificado obrigatório. Outros substatus: continua opcional.
- [ ] SO Implementation Only: só "O que foi feito" + "Resultado" aparecem por padrão; Próximos Passos/Acompanhamento vira chip opcional.
- [ ] Selecionar tarefas sem marcar nenhuma: Acesso Rápido não encosta mais no toggle de email.
- [ ] Marcar e desmarcar uma tarefa: contador e ícone somem de verdade.
- [ ] Rodapé com 3 botões simétricos + Gerar embaixo.
- [ ] Ícone de histórico: cinza sem rascunho, azul quando existe pelo menos um guardado.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)