### PR TITLE
fix(personal-library): card menu renders behind neighboring cards

### DIFF
--- a/src/modules/personal-library/personal-library-assistant.js
+++ b/src/modules/personal-library/personal-library-assistant.js
@@ -117,6 +117,11 @@ function injectStyles() {
             transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), border-color 0.35s ease;
             display: flex; flex-direction: column;
         }
+        /* isolation:isolate dá a cada card seu próprio contexto de empilhamento,
+           então um z-index alto só no .cw-lib-menu não basta pra ele ficar
+           acima do card da linha seguinte (que vem depois no DOM e por isso
+           pinta por cima por padrão) — precisa levantar o card inteiro. */
+        .cw-lib-card.menu-open { z-index: 5; }
         .cw-lib-card::before {
             content: ''; position: absolute; inset: 0; z-index: -1; border-radius: inherit;
             background: linear-gradient(135deg, rgba(138,180,248,0.16), rgba(197,138,249,0.16), rgba(242,139,130,0.16));
@@ -411,6 +416,7 @@ export function initPersonalLibrary() {
         if (openMenuCard) {
             const menu = openMenuCard.querySelector('.cw-lib-menu');
             if (menu) menu.classList.remove('open');
+            openMenuCard.classList.remove('menu-open');
             openMenuCard = null;
         }
     }
@@ -494,6 +500,7 @@ export function initPersonalLibrary() {
             closeCardMenu();
             if (!isOpen) {
                 menu.classList.add('open');
+                card.classList.add('menu-open');
                 openMenuCard = card;
             }
         };


### PR DESCRIPTION
## Resumo

Follow-up do PR anterior (que corrigiu o menu invisível). Agora o menu aparece, mas fica atrás de um card vizinho quando tem um logo abaixo na grade.

Causa: `.cw-lib-card` tem `isolation: isolate` — cada card ganha seu próprio contexto de empilhamento. Um z-index alto só no `.cw-lib-menu` não adianta contra um card vizinho que vem depois no DOM (ex: o da linha seguinte), porque a comparação de z-index acontece entre os CARDS (contextos de empilhamento), não entre o menu e o card vizinho diretamente.

Fix: quando o menu de um card abre, o card inteiro ganha uma classe `.menu-open` com `z-index: 5`, subindo ele (e o menu dentro dele) acima dos vizinhos.

## Teste

- [ ] `esbuild` roda sem erro (já validado localmente)
- [ ] Abrir o menu "⋮" de um card que tem outro card logo abaixo: o menu aparece por cima, não por trás

🤖 Gerado com [Claude Code](https://claude.com/claude-code)