### PR TITLE
refactor(broadcast): consolidate styling, split renderFeed(), fix empty-state bug

### DIFF
--- a/src/modules/broadcast/broadcast-assistant.js
+++ b/src/modules/broadcast/broadcast-assistant.js
@@ -11,73 +11,143 @@ import {
 import { SoundManager } from "../shared/sound-manager.js";
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
-import { BROADCAST_MESSAGES, setBroadcastMessages } from "./broadcast-data.js"; 
+import { BROADCAST_MESSAGES, setBroadcastMessages } from "./broadcast-data.js";
 import { DataService } from "../shared/data-service.js";
 import { getAgentEmail } from "../shared/page-data.js";
-import { objectToCss } from "../shared/dom-utils.js";
 import { ADMINS } from "../shared/config.js";
 
 // --- CONFIGURAÇÃO ---
-const POLL_TIME_MS = 60 * 1000; 
+const POLL_TIME_MS = 60 * 1000;
 
-// Inicializa estado global
-window._cwIsAdmin = false;
-window._cwCurrentUser = null;
+const TYPE_CONFIG = {
+    critical: { icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>` },
+    info: { icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>` },
+    success: { icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>` }
+};
 
-export function initBroadcastAssistant() {
-  const CURRENT_VERSION = "v4.9";
-  let visible = false;
-  let pollInterval = null;
-  let currentEditingId = null;
-
-  // --- HELPERS ---
-  function formatFriendlyDate(dateInput) {
-      if (!dateInput) return "";
-      try {
-          const date = new Date(dateInput);
-          if (isNaN(date.getTime())) return String(dateInput); 
-          return date.toLocaleString('pt-BR', {
-              day: '2-digit', month: '2-digit', year: 'numeric',
-              hour: '2-digit', minute: '2-digit'
-          }).replace(',', ' às'); 
-      } catch (e) { return String(dateInput); }
-  }
-
-  // --- ESTILOS CSS INJETADOS ---
-  if (!document.getElementById('cw-broadcast-hd-css')) {
-      const s = document.createElement("style");
-      s.id = 'cw-broadcast-hd-css';
-      s.innerHTML = `
-        @keyframes cw-pulse {
+// --- FOLHA DE ESTILOS DEDICADA ---
+// Substitui os 4 mecanismos de estilo que coexistiam aqui (classes injetadas,
+// objeto JS aplicado via Object.assign, objectToCss() embutido em template
+// literals do widget BAU, e style="..." cru no HTML do editor) por um só
+// bloco de classes reais — mesmo padrão já usado em personal-library/
+// call-script/configs.
+function injectStyles() {
+    if (document.getElementById('cw-broadcast-styles')) return;
+    const style = document.createElement("style");
+    style.id = 'cw-broadcast-styles';
+    style.textContent = `
+        @keyframes cw-bc-pulse {
             0% { transform: scale(0.95); box-shadow: 0 0 0 0 rgba(147, 51, 234, 0.7); }
             70% { transform: scale(1); box-shadow: 0 0 0 6px rgba(147, 51, 234, 0); }
             100% { transform: scale(0.95); box-shadow: 0 0 0 0 rgba(147, 51, 234, 0); }
         }
-        
-        .cw-btn-interactive {
-            transition: transform 0.1s ease, background 0.2s ease;
-            cursor: pointer; user-select: none;
-        }
+
+        .cw-btn-interactive { transition: transform 0.1s ease, background 0.2s ease; cursor: pointer; user-select: none; }
         .cw-btn-interactive:active { transform: scale(0.96); }
 
-        /* Overlay do Editor */
+        /* --- BUSCA --- */
+        .cw-bc-search-wrap { position: relative; padding: 12px 24px 0 24px; flex-shrink: 0; background: #FAFAFA; }
+        .cw-bc-search-icon { position: absolute; left: 36px; top: 50%; transform: translateY(-50%); color: #80868b; pointer-events: none; display: flex; }
+        .cw-bc-search-input {
+            width: 100%; box-sizing: border-box; height: 36px; padding: 0 34px 0 34px;
+            border-radius: 10px; border: 1px solid #DADCE0; background: #fff;
+            font-size: 13px; font-family: 'Google Sans', Roboto, sans-serif; color: #202124; outline: none;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+        .cw-bc-search-input::placeholder { color: #9aa0a6; }
+        .cw-bc-search-input:focus { border-color: #1a73e8; box-shadow: 0 0 0 3px rgba(26,115,232,0.14); }
+        .cw-bc-search-clear {
+            position: absolute; right: 30px; top: 50%; transform: translateY(-50%);
+            width: 20px; height: 20px; border-radius: 50%; display: none;
+            align-items: center; justify-content: center; color: #80868b; cursor: pointer;
+        }
+        .cw-bc-search-clear:hover { background: rgba(0,0,0,0.06); }
+        .cw-bc-search-clear.visible { display: flex; }
+
+        /* --- FEED --- */
+        .cw-bc-feed { padding: 20px 24px 80px 24px; overflow-y: auto; flex-grow: 1; background: #F8F9FA; display: flex; flex-direction: column; gap: 20px; }
+
+        .cw-bc-card {
+            background: #FFFFFF; border-radius: 16px; border: 1px solid rgba(0,0,0,0.12);
+            box-shadow: 0 4px 12px rgba(60,64,67,0.08);
+            overflow: hidden; transition: all 0.3s ease; position: relative; width: 100%; box-sizing: border-box; flex-shrink: 0;
+        }
+        .cw-bc-card.history {
+            border: 1px solid rgba(0,0,0,0.05); box-shadow: none; opacity: 0.6; filter: grayscale(0.8);
+            margin-bottom: 16px;
+        }
+
+        .cw-bc-card-head { padding: 16px 20px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #F1F3F4; }
+        .cw-bc-type-tag { display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.6px; padding: 4px 8px; border-radius: 6px; }
+        .cw-bc-type-tag.critical { color: #991B1B; background: #FEF2F2; }
+        .cw-bc-type-tag.info { color: #1E40AF; background: #EFF6FF; }
+        .cw-bc-type-tag.success { color: #166534; background: #F0FDF4; }
+        .cw-bc-date-tag { font-size: 11px; color: #5f6368; font-weight: 500; }
+        .cw-bc-card-content { padding: 16px 20px 20px 20px; }
+        .cw-bc-msg-title { font-size: 16px; font-weight: 700; color: #202124; margin-bottom: 8px; line-height: 1.4; }
+        .cw-bc-msg-body { font-size: 14px; color: #3c4043; line-height: 1.6; white-space: pre-wrap; word-break: break-word; }
+        /* Global (não escopado a .cw-bc-msg-body): parseMessageText() é usada
+           tanto nos cards normais quanto no texto do widget BAU. */
+        .cw-bc-link { color: #1967d2; text-decoration: none; font-weight: 500; }
+        .cw-bc-msg-meta { font-size: 11px; color: #9aa0a6; margin-top: 12px; display: flex; align-items: center; gap: 6px; }
+
+        .cw-bc-dismiss-btn {
+            width: 28px; height: 28px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.1);
+            background: #fff; color: #5f6368; cursor: pointer; display: flex; align-items: center; justify-content: center;
+            transition: all 0.2s ease; margin-left: 12px;
+        }
+        .cw-bc-dismiss-btn:hover { color: #1e8e3e; background: #e6f4ea; border-color: #1e8e3e; }
+
+        .cw-card-actions { display: flex; justify-content: flex-end; gap: 12px; padding: 12px 20px; background: #F8F9FA; border-top: 1px solid #F1F3F4; }
+        .cw-action-btn { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer; border: 1px solid transparent; background: transparent; transition: all 0.2s; }
+        .cw-action-btn.edit { color: #1967D2; }
+        .cw-action-btn.edit:hover { background: #E8F0FE; }
+        .cw-action-btn.delete { color: #D93025; }
+        .cw-action-btn.delete:hover { background: #FCE8E6; }
+
+        .cw-bc-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 60px 0; color: #BDC1C6; gap: 16px; text-align: center; }
+        .cw-bc-history-divider { display: flex; align-items: center; justify-content: center; margin: 20px 0; cursor: pointer; color: #1a73e8; font-size: 13px; font-weight: 500; gap: 8px; padding: 8px 16px; border-radius: 20px; background: #E8F0FE; }
+        .cw-bc-history-container { display: none; flex-direction: column; gap: 16px; opacity: 0.8; }
+
+        /* --- WIDGET BAU (destaque proposital, paleta roxa própria) --- */
+        .cw-bc-bau { margin: 16px 24px 0 24px; padding: 16px; background: #F3E8FD; border: 1px solid #D8B4FE; border-radius: 16px; display: flex; flex-direction: column; gap: 12px; box-shadow: 0 4px 12px rgba(147, 51, 234, 0.1); }
+        .cw-bc-bau-header { display: flex; align-items: center; justify-content: space-between; gap: 2px; margin-bottom: 8px; }
+        .cw-bc-bau-timestamp { font-size: 10px; opacity: 0.7; color: #7E22CE; }
+        .cw-bc-live-indicator { display: flex; align-items: center; gap: 8px; }
+        .cw-bc-pulse-dot { width: 8px; height: 8px; border-radius: 50%; background: #9333EA; box-shadow: 0 0 0 0 rgba(147, 51, 234, 0.7); animation: cw-bc-pulse 2s infinite; }
+        .cw-bc-bau-label { font-size: 11px; font-weight: 800; color: #7E22CE; text-transform: uppercase; letter-spacing: 0.8px; }
+        .cw-bc-bau-slots { display: flex; justify-content: space-between; align-items: center; }
+        .cw-bc-bau-slots-row { flex: 1; display: flex; gap: 8px; }
+        .cw-bc-bau-slot { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: rgba(255,255,255,0.5); border-radius: 8px; flex: 1; justify-content: center; }
+        .cw-bc-bau-flag { font-size: 18px; line-height: 1; }
+        .cw-bc-bau-date { font-size: 16px; font-weight: 700; color: #581C87; letter-spacing: -0.5px; }
+        .cw-bc-bau-actions { display: flex; gap: 8px; margin-left: 12px; align-items: center; }
+        .cw-bc-bau-toggle-btn { background: rgba(255,255,255,0.7); border: 1px solid rgba(139, 92, 246, 0.4); border-radius: 12px; padding: 8px 12px; color: #6D28D9; font-size: 12px; font-weight: 600; }
+        .cw-bc-bau-edit-btn { border: 1px solid rgba(139, 92, 246, 0.2); background: rgba(255,255,255,0.5); border-radius: 12px; padding: 8px; color: #6D28D9; display: flex; align-items: center; justify-content: center; }
+        .cw-bc-bau-edit-btn.compact { border: none; border-radius: 6px; padding: 6px; }
+        .cw-bc-bau-full { display: none; margin-top: 12px; padding-top: 12px; border-top: 1px dashed rgba(139, 92, 246, 0.3); font-size: 13px; line-height: 1.5; color: #581C87; }
+        .cw-bc-bau-plain { display: flex; justify-content: space-between; align-items: flex-start; }
+        .cw-bc-bau-plain-text { font-size: 13px; color: #581C87; line-height: 1.5; flex: 1; }
+
+        /* --- EDITOR --- */
         .cw-editor-overlay {
-            position: absolute; inset: 0; 
-            background: rgba(255, 255, 255, 0.98); 
+            position: absolute; inset: 0; background: rgba(255, 255, 255, 0.98);
             z-index: 200; display: flex; flex-direction: column;
-            transform: translateY(100%); 
-            transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+            transform: translateY(100%); transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
             box-shadow: 0 -4px 20px rgba(0,0,0,0.1);
         }
         .cw-editor-overlay.active { transform: translateY(0); }
+        .cw-bc-editor-body { flex: 1; overflow-y: auto; padding: 24px; }
+        .cw-bc-editor-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+        .cw-bc-editor-title { font-size: 20px; font-weight: 700; color: #202124; }
+        .cw-bc-editor-field { margin-bottom: 20px; }
+        .cw-bc-field-label { font-size: 12px; font-weight: 700; color: #5f6368; margin-bottom: 8px; display: block; }
+        .cw-bc-editor-foot { padding: 16px 24px; border-top: 1px solid #F1F3F4; background: #fff; display: flex; justify-content: flex-end; gap: 12px; }
 
-        /* Inputs HD */
         .cw-hd-input {
-            width: 100%; padding: 12px 14px;
-            border: 1px solid #DADCE0; border-radius: 12px;
+            width: 100%; padding: 12px 14px; border: 1px solid #DADCE0; border-radius: 12px;
             font-size: 14px; color: #202124; background: #FFF;
-            transition: border 0.2s, box-shadow 0.2s;
-            box-sizing: border-box; outline: none; font-family: 'Google Sans', Roboto, sans-serif;
+            transition: border 0.2s, box-shadow 0.2s; box-sizing: border-box; outline: none; font-family: 'Google Sans', Roboto, sans-serif;
         }
         .cw-hd-input:focus { border-color: #1a73e8; box-shadow: 0 0 0 3px rgba(26,115,232,0.1); }
         .cw-hd-input::placeholder { color: #9AA0A6; }
@@ -86,115 +156,109 @@ export function initBroadcastAssistant() {
         .cw-radio-option {
             flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px;
             padding: 12px; border-radius: 12px; border: 1px solid #E0E0E0;
-            font-size: 13px; font-weight: 600; cursor: pointer;
-            transition: all 0.2s; position: relative; color: #5F6368;
+            font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; position: relative; color: #5F6368;
         }
         .cw-radio-option:hover { background: #F8F9FA; }
         .cw-radio-option input { position: absolute; opacity: 0; }
-        
         .cw-radio-option.info.checked { background: #E8F0FE; color: #1967D2; border-color: #1967D2; }
         .cw-radio-option.critical.checked { background: #FEE2E2; color: #B91C1C; border-color: #EF4444; }
         .cw-radio-option.success.checked { background: #DCFCE7; color: #15803D; border-color: #22C55E; }
-        
-        .cw-card-actions {
-            display: flex; justify-content: flex-end; gap: 12px;
-            padding: 12px 20px; background: #F8F9FA;
-            border-top: 1px solid #F1F3F4;
+
+        .cw-bc-btn-secondary { padding: 10px 20px; background: white; border: 1px solid #dadce0; color: #5f6368; border-radius: 24px; font-weight: 600; font-size: 13px; }
+        .cw-bc-btn-primary { padding: 10px 24px; background: #1a73e8; color: white; border: none; border-radius: 24px; font-weight: 600; box-shadow: 0 4px 12px rgba(26,115,232,0.3); font-size: 13px; }
+        .cw-bc-editor-close { background: none; border: none; color: #5f6368; padding: 8px; }
+    `;
+    document.head.appendChild(style);
+}
+
+// --- PARSERS & UTILS (puros, sem dependência de closure) ---
+
+function formatFriendlyDate(dateInput) {
+    if (!dateInput) return "";
+    try {
+        const date = new Date(dateInput);
+        if (isNaN(date.getTime())) return String(dateInput);
+        return date.toLocaleString('pt-BR', {
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit'
+        }).replace(',', ' às');
+    } catch (e) { return String(dateInput); }
+}
+
+function parseMessageText(rawText) {
+    if (!rawText || typeof rawText !== 'string') return "";
+    let html = rawText;
+    html = html.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" class="cw-bc-link">$1</a>');
+    html = html.replace(/\*\*(.*?)\*\*/g, '<b>$1</b>');
+    html = html.replace(/_(.*?)_/g, '<i>$1</i>');
+    html = html.replace(/\n/g, '<br>');
+    html = parseEmojiCodes(html);
+    return html;
+}
+
+// Extrai os slots de disponibilidade (bandeira + data) do texto do aviso de
+// "Disponibilidade BAU". Mesma heurística de sempre (regex de data +
+// keyword-sniffing de região/país, com "memória" do último contexto visto
+// pra linhas de data sem bandeira própria) — só isolada do renderFeed() pra
+// ficar testável/legível separadamente, o comportamento não muda.
+function extractBauSlots(text) {
+    const extractedSlots = [];
+    const lines = (text || "").split('\n');
+    const dateRegex = /\d{1,2}\/\d{1,2}/;
+    let currentContextFlag = "📅";
+
+    lines.forEach(line => {
+        if (/🇧🇷|🇵🇹|PT|BR|BRASIL|BRAZIL|PORTUGAL|LISBOA/i.test(line)) {
+            currentContextFlag = "🇧🇷";
+        } else if (/🇪🇸|🇲🇽|ES|LATAM|ESPANHA|SPAIN|MEXICO|MÉXICO/i.test(line)) {
+            currentContextFlag = "🇪🇸";
         }
-        .cw-action-btn {
-            display: flex; align-items: center; gap: 6px;
-            padding: 6px 12px; border-radius: 8px;
-            font-size: 12px; font-weight: 600; cursor: pointer;
-            border: 1px solid transparent; background: transparent;
-            transition: all 0.2s;
+
+        const dateMatch = line.match(dateRegex);
+        if (dateMatch) {
+            const date = dateMatch[0];
+            let lineFlag = currentContextFlag;
+            if (/🇧🇷|🇵🇹|PT|BR/i.test(line)) lineFlag = "🇧🇷";
+            else if (/🇪🇸|🇲🇽|ES|LATAM/i.test(line)) lineFlag = "🇪🇸";
+
+            const exists = extractedSlots.some(s => s.flag === lineFlag && s.date === date);
+            if (!exists) extractedSlots.push({ flag: lineFlag, date });
         }
-        .cw-action-btn.edit { color: #1967D2; }
-        .cw-action-btn.edit:hover { background: #E8F0FE; }
-        .cw-action-btn.delete { color: #D93025; }
-        .cw-action-btn.delete:hover { background: #FCE8E6; }
-      `;
-      document.head.appendChild(s);
-  }
+    });
 
-  // --- ESTILOS JS ---
-  const styles = {
-      feedContainer: { padding: "20px 24px 80px 24px", overflowY: "auto", flexGrow: "1", background: "#F8F9FA", display: "flex", flexDirection: "column", gap: "20px" },
-      
-      // CARD (Fundo Branco Puro + Contraste)
-      card: { 
-          background: "#FFFFFF", // Fundo Branco
-          borderRadius: "16px", 
-          border: "1px solid rgba(0,0,0,0.12)", // Borda um pouco mais visível
-          boxShadow: "0 4px 12px rgba(60,64,67,0.08)", // Sombra para destacar do fundo cinza
-          overflow: "hidden", transition: "all 0.3s ease", position: "relative", width: "100%", boxSizing: "border-box", flexShrink: "0" 
-      },
-      cardHistory: { 
-          background: "#FFFFFF", 
-          borderRadius: "16px", 
-          border: "1px solid rgba(0,0,0,0.05)", // Borda quase invisível
-          boxShadow: "none", // Sem sombra (flat)
-          opacity: "0.6", // Transparencia para indicar inativo
-          filter: "grayscale(0.8)", // Cinza para reforçar histórico
-          marginBottom: "16px", 
-          flexShrink: "0", 
-          width: "100%", 
-          boxSizing: "border-box",
-          position: "relative"
-      },
-      
-      cardHeader: { padding: "16px 20px", display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #F1F3F4" },
-      typeTag: { display: "flex", alignItems: "center", gap: "6px", fontSize: "11px", fontWeight: "700", textTransform: "uppercase", letterSpacing: "0.6px", padding: "4px 8px", borderRadius: "6px" },
-      dateTag: { fontSize: "11px", color: "#5f6368", fontWeight: "500" },
-      cardContent: { padding: "16px 20px 20px 20px" },
-      msgTitle: { fontSize: "16px", fontWeight: "700", color: "#202124", marginBottom: "8px", lineHeight: "1.4" },
-      msgBody: { fontSize: "14px", color: "#3c4043", lineHeight: "1.6", whiteSpace: "pre-wrap", wordBreak: "break-word" },
-      msgMeta: { fontSize: "11px", color: "#9aa0a6", marginTop: "12px", display: "flex", alignItems: "center", gap: "6px" },
-      
-      dismissBtn: { width: "28px", height: "28px", borderRadius: "50%", border: "1px solid rgba(0,0,0,0.1)", background: "#fff", color: "#5f6368", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", transition: "all 0.2s ease", marginLeft: "12px" },
+    if (extractedSlots.length === 0) {
+        const anyDates = (text || "").match(/\d{1,2}\/\d{1,2}/g);
+        if (anyDates) [...new Set(anyDates)].forEach(d => extractedSlots.push({ flag: "📅", date: d }));
+    }
 
-      bauContainer: { margin: "16px 24px 0 24px", padding: "16px", background: "#F3E8FD", border: "1px solid #D8B4FE", borderRadius: "16px", display: "flex", flexDirection: "column", gap: "12px", boxShadow: "0 4px 12px rgba(147, 51, 234, 0.1)" },
-      bauHeader: { display: "flex", alignItems: "center", justifyContent: "space-between", gap:"2px" },
-      bauLabel: { fontSize: "11px", fontWeight: "800", color: "#7E22CE", textTransform: "uppercase", letterSpacing: "0.8px" },
-      liveIndicator: { display: "flex", alignItems: "center", gap: "8px" },
-      pulseDot: { width: "8px", height: "8px", borderRadius: "50%", background: "#9333EA", boxShadow: "0 0 0 0 rgba(147, 51, 234, 0.7)", animation: "cw-pulse 2s infinite" },
-      bauSlotRow: { display: "flex", alignItems: "center", gap: "10px", padding: "8px 12px", background: "rgba(255,255,255,0.5)", borderRadius: "8px", marginBottom: "4px" },
-      bauFlag: { fontSize: "18px", lineHeight: "1" },
-      bauDate: { fontSize: "16px", fontWeight: "700", color: "#581C87", letterSpacing: "-0.5px" },
-      
-      emptyState: { display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "60px 0", color: "#BDC1C6", gap: "16px", textAlign: "center" },
-      historyDivider: { display: "flex", alignItems: "center", justifyContent: "center", margin: "20px 0", cursor: "pointer", color: "#1a73e8", fontSize: "13px", fontWeight: "500", gap: "8px", padding: "8px 16px", borderRadius: "20px", background: "#E8F0FE" },
-      historyContainer: { display: "none", flexDirection: "column", gap: "16px", opacity: "0.8" }
-  };
+    return extractedSlots;
+}
 
-  const TYPE_CONFIG = {
-      critical: { color: "#991B1B", bg: "#FEF2F2", icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>` },
-      info: { color: "#1E40AF", bg: "#EFF6FF", icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>` },
-      success: { color: "#166534", bg: "#F0FDF4", icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>` }
-  };
+export function initBroadcastAssistant() {
+  const CURRENT_VERSION = "v4.9";
+  let visible = false;
+  let pollInterval = null;
+  let currentEditingId = null;
+  let searchTerm = "";
 
-  // --- PARSERS & UTILS ---
-  function parseMessageText(rawText) {
-      if (!rawText || typeof rawText !== 'string') return ""; 
-      let html = rawText;
-      html = html.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" style="color:#1967d2; text-decoration:none; font-weight:500;">$1</a>');
-      html = html.replace(/\*\*(.*?)\*\*/g, '<b>$1</b>');
-      html = html.replace(/_(.*?)_/g, '<i>$1</i>');
-      html = html.replace(/\n/g, '<br>');
-      html = parseEmojiCodes(html);
-      return html;
-  }
+  // Estado de admin — escopo do módulo em vez de window (nada mais no repo
+  // lê essas 3 variáveis; não precisavam estar globais).
+  let isAdmin = false;
+  let currentUser = null;
+  let adminRetries = 0;
+
+  injectStyles();
 
   // --- UI SETUP ---
   const popup = document.createElement("div");
   popup.id = "broadcast-popup";
   popup.classList.add("cw-module-window");
-  // Fundo do módulo: #FAFAFA
   Object.assign(popup.style, stylePopup, {
-    right: "auto", left: "50%", width: "420px", height: "680px", 
-    display: "flex", flexDirection: "column", transform: "translateX(-50%) scale(0.05)", 
+    right: "auto", left: "50%", width: "420px", height: "680px",
+    display: "flex", flexDirection: "column", transform: "translateX(-50%) scale(0.05)",
     backgroundColor: '#FAFAFA', overflow: "hidden"
   });
-  
+
   const animRefs = { popup, googleLine: null };
 
   function toggleVisibility() {
@@ -203,7 +267,7 @@ export function initBroadcastAssistant() {
     if (visible) {
       const btn = document.getElementById("cw-btn-broadcast");
       if (btn) btn.classList.remove("has-new");
-      checkForUpdates(); 
+      checkForUpdates();
     }
   }
 
@@ -211,20 +275,17 @@ export function initBroadcastAssistant() {
     popup, "Central de Avisos", CURRENT_VERSION, "Comunicação oficial da operação.",
     animRefs, () => toggleVisibility()
   );
-  
+
   const actionContainer = header.querySelector('.cw-header-actions') || header.lastElementChild;
-  let editorOverlay = null; 
+  let editorOverlay = null;
 
   function tryInjectAdminButton() {
       let email = null;
       try { email = getAgentEmail(); } catch(e) { console.warn("TechSol: Auth Pending"); }
 
       if (email) {
-          const currentUser = email.split('@')[0].toLowerCase();
-          const isAdmin = ADMINS.includes(currentUser);
-          
-          window._cwIsAdmin = isAdmin; 
-          window._cwCurrentUser = currentUser;
+          currentUser = email.split('@')[0].toLowerCase();
+          isAdmin = ADMINS.includes(currentUser);
 
           if (isAdmin && actionContainer && !actionContainer.querySelector('#cw-admin-btn')) {
               const addBtn = document.createElement("div");
@@ -232,7 +293,7 @@ export function initBroadcastAssistant() {
               addBtn.className = "cw-btn-interactive";
               addBtn.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`;
               Object.assign(addBtn.style, {
-                  width: "32px", height: "32px", borderRadius: "50%", 
+                  width: "32px", height: "32px", borderRadius: "50%",
                   display: "flex", alignItems: "center", justifyContent: "center",
                   color: "#1a73e8", background: "rgba(26, 115, 232, 0.1)",
                   marginRight: "8px"
@@ -240,21 +301,20 @@ export function initBroadcastAssistant() {
               addBtn.title = "Novo Aviso";
               addBtn.onclick = (e) => { e.stopPropagation(); openEditor(); };
               actionContainer.insertBefore(addBtn, actionContainer.firstChild);
-              
-              if(!editorOverlay) createEditorOverlay();
+
+              if (!editorOverlay) createEditorOverlay();
               renderFeed();
           }
       } else {
-          if (!window._cwAdminRetries) window._cwAdminRetries = 0;
-          if (window._cwAdminRetries < 5) {
-              window._cwAdminRetries++;
+          if (adminRetries < 5) {
+              adminRetries++;
               setTimeout(tryInjectAdminButton, 2000);
           }
       }
   }
 
   // Botão Limpar
-  if(actionContainer) {
+  if (actionContainer) {
       const markAll = document.createElement("button");
       markAll.textContent = "Limpar";
       markAll.className = "cw-btn-interactive";
@@ -264,19 +324,46 @@ export function initBroadcastAssistant() {
           SoundManager.playSuccess();
           const allIds = BROADCAST_MESSAGES.map(m => m.id);
           localStorage.setItem("cw_read_broadcasts", JSON.stringify(allIds));
-          renderFeed(); 
-          updateBadge(); 
+          renderFeed();
+          updateBadge();
       };
       actionContainer.insertBefore(markAll, actionContainer.firstChild);
   }
 
   popup.appendChild(header);
 
+  // --- BUSCA ---
+  const searchWrap = document.createElement("div");
+  searchWrap.className = "cw-bc-search-wrap";
+  const searchIcon = document.createElement("div");
+  searchIcon.className = "cw-bc-search-icon";
+  searchIcon.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`;
+  const searchInput = document.createElement("input");
+  searchInput.className = "cw-bc-search-input no-drag";
+  searchInput.type = "text";
+  searchInput.placeholder = "Buscar avisos...";
+  const searchClear = document.createElement("div");
+  searchClear.className = "cw-bc-search-clear cw-btn-interactive";
+  searchClear.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`;
+  searchWrap.append(searchIcon, searchInput, searchClear);
+  popup.appendChild(searchWrap);
+
+  searchInput.addEventListener("input", (e) => {
+      searchTerm = e.target.value;
+      searchClear.classList.toggle('visible', searchTerm.length > 0);
+      renderFeed();
+  });
+  searchClear.onclick = () => {
+      searchInput.value = "";
+      searchTerm = "";
+      searchClear.classList.remove('visible');
+      renderFeed();
+      searchInput.focus();
+  };
+
   // --- ELEMENTO DE STATUS (FIXO NO TOPO) ---
-  // Criamos aqui para garantir a ordem: Header -> Status -> BAU -> Feed
   const statusEl = document.createElement('div');
   statusEl.id = 'cw-update-status';
-  // Fundo #FAFAFA para mesclar com o módulo
   statusEl.style.cssText = "padding: 8px; text-align: center; font-size: 11px; color: #5f6368; background: #FAFAFA; border-bottom: 1px solid transparent; font-weight:500; display:none;";
   popup.appendChild(statusEl);
 
@@ -284,16 +371,16 @@ export function initBroadcastAssistant() {
   function createEditorOverlay() {
       editorOverlay = document.createElement("div");
       editorOverlay.className = "cw-editor-overlay";
-      
+
       editorOverlay.innerHTML = `
-        <div style="flex:1; overflow-y:auto; padding: 24px;">
-            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom: 24px;">
-                <span id="cw-editor-title-label" style="font-size: 20px; font-weight: 700; color: #202124;">Novo Aviso</span>
-                <button id="cw-bc-close-x" class="cw-btn-interactive" style="background:none; border:none; color:#5f6368; padding:8px;"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></button>
+        <div class="cw-bc-editor-body">
+            <div class="cw-bc-editor-head">
+                <span id="cw-editor-title-label" class="cw-bc-editor-title">Novo Aviso</span>
+                <button id="cw-bc-close-x" class="cw-btn-interactive cw-bc-editor-close"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></button>
             </div>
-            
-            <div style="margin-bottom:20px;">
-                <label style="font-size:12px; font-weight:700; color:#5f6368; margin-bottom:8px; display:block;">TIPO DO COMUNICADO</label>
+
+            <div class="cw-bc-editor-field">
+                <label class="cw-bc-field-label">TIPO DO COMUNICADO</label>
                 <div class="cw-radio-group">
                     <div class="cw-radio-option info" onclick="this.querySelector('input').click()">
                         <input type="radio" name="cw-bc-type" value="info" checked> ℹ️ Info
@@ -307,20 +394,20 @@ export function initBroadcastAssistant() {
                 </div>
             </div>
 
-            <div style="margin-bottom:20px;">
-                 <label style="font-size:12px; font-weight:700; color:#5f6368; margin-bottom:8px; display:block;">TÍTULO</label>
+            <div class="cw-bc-editor-field">
+                 <label class="cw-bc-field-label">TÍTULO</label>
                  <input id="cw-bc-title" class="cw-hd-input" placeholder="Resumo do assunto">
             </div>
 
-            <div style="margin-bottom:20px;">
-                 <label style="font-size:12px; font-weight:700; color:#5f6368; margin-bottom:8px; display:block;">MENSAGEM</label>
+            <div class="cw-bc-editor-field">
+                 <label class="cw-bc-field-label">MENSAGEM</label>
                  <textarea id="cw-bc-text" class="cw-hd-input" placeholder="Escreva os detalhes aqui... Suporta HTML e Emojis :)" style="height:160px; resize:none; line-height:1.6;"></textarea>
             </div>
         </div>
 
-        <div style="padding: 16px 24px; border-top: 1px solid #F1F3F4; background: #fff; display: flex; justify-content: flex-end; gap: 12px;">
-            <button id="cw-bc-cancel" class="cw-btn-interactive" style="padding:10px 20px; background:white; border:1px solid #dadce0; color:#5f6368; border-radius:24px; font-weight:600; font-size:13px;">Cancelar</button>
-            <button id="cw-bc-send" class="cw-btn-interactive" style="padding:10px 24px; background:#1a73e8; color:white; border:none; border-radius:24px; font-weight:600; box-shadow:0 4px 12px rgba(26,115,232,0.3); font-size:13px;">Publicar</button>
+        <div class="cw-bc-editor-foot">
+            <button id="cw-bc-cancel" class="cw-btn-interactive cw-bc-btn-secondary">Cancelar</button>
+            <button id="cw-bc-send" class="cw-btn-interactive cw-bc-btn-primary">Publicar</button>
         </div>
       `;
 
@@ -330,15 +417,15 @@ export function initBroadcastAssistant() {
               radio.parentElement.classList.add('checked');
           });
       });
-      setTimeout(() => { 
+      setTimeout(() => {
           const def = editorOverlay.querySelector('.cw-radio-option.info');
-          if(def) def.classList.add('checked');
+          if (def) def.classList.add('checked');
       }, 100);
 
       const btnCancel = editorOverlay.querySelector('#cw-bc-cancel');
       const btnCloseX = editorOverlay.querySelector('#cw-bc-close-x');
       const btnSend = editorOverlay.querySelector('#cw-bc-send');
-      
+
       btnCancel.onclick = closeEditor;
       btnCloseX.onclick = closeEditor;
       btnSend.onclick = handleSend;
@@ -347,23 +434,23 @@ export function initBroadcastAssistant() {
   }
 
   function openEditor(editData = null) {
-      if(!editorOverlay) return;
-      
+      if (!editorOverlay) return;
+
       const titleLabel = editorOverlay.querySelector('#cw-editor-title-label');
       const inputTitle = editorOverlay.querySelector('#cw-bc-title');
       const inputText = editorOverlay.querySelector('#cw-bc-text');
       const btnSend = editorOverlay.querySelector('#cw-bc-send');
-      
+
       if (editData) {
           currentEditingId = editData.id;
           titleLabel.textContent = "Editar Aviso";
           inputTitle.value = editData.title || "";
           inputText.value = editData.text || "";
           btnSend.textContent = "Salvar Alterações";
-          
+
           const type = editData.type || 'info';
           const radio = editorOverlay.querySelector(`input[name="cw-bc-type"][value="${type}"]`);
-          if(radio) radio.click();
+          if (radio) radio.click();
       } else {
           currentEditingId = null;
           titleLabel.textContent = "Novo Aviso";
@@ -371,7 +458,7 @@ export function initBroadcastAssistant() {
           inputText.value = "";
           btnSend.textContent = "Publicar";
           const infoRadio = editorOverlay.querySelector(`input[name="cw-bc-type"][value="info"]`);
-          if(infoRadio) infoRadio.click();
+          if (infoRadio) infoRadio.click();
       }
 
       editorOverlay.classList.add('active');
@@ -379,7 +466,7 @@ export function initBroadcastAssistant() {
   }
 
   function closeEditor() {
-      if(editorOverlay) editorOverlay.classList.remove('active');
+      if (editorOverlay) editorOverlay.classList.remove('active');
       currentEditingId = null;
   }
 
@@ -390,7 +477,7 @@ export function initBroadcastAssistant() {
       const typeInput = editorOverlay.querySelector('input[name="cw-bc-type"]:checked');
       const type = typeInput ? typeInput.value : 'info';
 
-      if(!inputTitle.value.trim() || !inputText.value.trim()) {
+      if (!inputTitle.value.trim() || !inputText.value.trim()) {
           showToast("Preencha todos os campos!", { error: true });
           return;
       }
@@ -411,7 +498,7 @@ export function initBroadcastAssistant() {
               title: inputTitle.value,
               text: inputText.value,
               type: type,
-              author: window._cwCurrentUser || 'admin'
+              author: currentUser || 'admin'
           });
       }
 
@@ -429,14 +516,14 @@ export function initBroadcastAssistant() {
 
   async function handleDelete(id) {
       const confirmed = await confirmDialog("Confirma a exclusão deste aviso?", { danger: true });
-      if(confirmed) {
+      if (confirmed) {
           const success = await DataService.deleteBroadcast(id);
-          if(success) {
+          if (success) {
               showToast("Aviso removido.");
               SoundManager.playClick();
               const oldMsg = BROADCAST_MESSAGES.findIndex(m => m.id === id);
-              if(oldMsg > -1) BROADCAST_MESSAGES.splice(oldMsg, 1);
-              renderFeed(); 
+              if (oldMsg > -1) BROADCAST_MESSAGES.splice(oldMsg, 1);
+              renderFeed();
               setTimeout(() => checkForUpdates(), 1500);
           } else {
               showToast("Erro ao excluir.", { error: true });
@@ -445,8 +532,7 @@ export function initBroadcastAssistant() {
   }
 
   const feed = document.createElement("div");
-  feed.className = "cw-nice-scroll";
-  Object.assign(feed.style, styles.feedContainer);
+  feed.className = "cw-nice-scroll cw-bc-feed";
   popup.appendChild(feed);
 
   async function checkForUpdates() {
@@ -461,7 +547,7 @@ export function initBroadcastAssistant() {
               setBroadcastMessages(data.broadcast);
               updateBadge();
               if (visible) {
-                  renderFeed(); 
+                  renderFeed();
                   statusEl.innerHTML = `<span style="color:#137333">✓ Atualizado</span>`;
                   setTimeout(() => { statusEl.style.display = 'none'; }, 1500);
               }
@@ -495,154 +581,112 @@ export function initBroadcastAssistant() {
       }
   }
 
-  function renderFeed() {
-      feed.innerHTML = "";
+  function matchesSearch(msg, term) {
+      if (!term) return true;
+      const haystack = `${msg.title || ""} ${msg.text || ""}`.toLowerCase();
+      return haystack.includes(term);
+  }
+
+  // Monta e insere o widget de "Disponibilidade BAU" logo após o status.
+  // Widget fica sempre visível quando existe (não é filtrado pela busca —
+  // é um card operacional fixo, não uma "mensagem" pra procurar).
+  function renderBauWidget(bauMessage) {
       const oldBau = popup.querySelector('#cw-bau-widget');
       if (oldBau) oldBau.remove();
 
-      const readMessages = JSON.parse(localStorage.getItem("cw_read_broadcasts") || "[]");
-      let allMessages = [...BROADCAST_MESSAGES].sort((a, b) => {
-          const dateA = new Date(a.date).getTime() || 0;
-          const dateB = new Date(b.date).getTime() || 0;
-          return dateB - dateA;
-      });
+      const bauWidget = document.createElement("div");
+      bauWidget.id = "cw-bau-widget";
+      bauWidget.className = "cw-bc-bau";
 
-      // 1. WIDGET BAU
-      const bauIndex = allMessages.findIndex(m => m.title && m.title.toLowerCase().includes("disponibilidade bau"));
-      
-      if (bauIndex !== -1) {
-          const bauMessage = allMessages[bauIndex];
-          allMessages.splice(bauIndex, 1);
+      const extractedSlots = extractBauSlots(bauMessage.text);
 
-          const bauWidget = document.createElement("div");
-          bauWidget.id = "cw-bau-widget";
-          Object.assign(bauWidget.style, styles.bauContainer);
+      let contentHTML = "";
+      let buttonsHTML = `<button id="cw-bau-toggle-btn" class="cw-btn-interactive cw-bc-bau-toggle-btn">Detalhes</button>`;
 
-          const extractedSlots = [];
-          const lines = (bauMessage.text || "").split('\n');
-          const dateRegex = /\d{1,2}\/\d{1,2}/;
-          
-          // Variável de "Memória" (Estado atual)
-          let currentContextFlag = "📅"; 
-
-          lines.forEach(line => {
-             // 1. Tenta detectar o contexto (Região/País) na linha, mesmo sem data
-             // Roda antes de checar a data para atualizar o "cabeçalho" atual
-             if (/🇧🇷|🇵🇹|PT|BR|BRASIL|BRAZIL|PORTUGAL|LISBOA/i.test(line)) {
-                 currentContextFlag = "🇧🇷";
-             } else if (/🇪🇸|🇲🇽|ES|LATAM|ESPANHA|SPAIN|MEXICO|MÉXICO/i.test(line)) {
-                 currentContextFlag = "🇪🇸";
-             }
-
-             // 2. Procura a data
-             const dateMatch = line.match(dateRegex);
-             
-             if (dateMatch) {
-                 const date = dateMatch[0];
-                 
-                 // Se na PRÓPRIA linha da data tiver uma bandeira específica, ela vence.
-                 // Se não, usa a bandeira que estava na memória (do cabeçalho anterior).
-                 let lineFlag = currentContextFlag;
-                 
-                 // (Opcional) Reforço: Se a linha atual tiver explicitamente outra flag, atualiza
-                 if (/🇧🇷|🇵🇹|PT|BR/i.test(line)) lineFlag = "🇧🇷";
-                 else if (/🇪🇸|🇲🇽|ES|LATAM/i.test(line)) lineFlag = "🇪🇸";
-
-                 const exists = extractedSlots.some(s => s.flag === lineFlag && s.date === date);
-                 if (!exists) extractedSlots.push({ flag: lineFlag, date });
-             }
-          });
-
-          if (extractedSlots.length === 0) {
-             const anyDates = (bauMessage.text || "").match(/\d{1,2}\/\d{1,2}/g);
-             if (anyDates) [...new Set(anyDates)].forEach(d => extractedSlots.push({ flag: "📅", date: d }));
-          }
-
-          let contentHTML = "";
-          // Botões no rodapé do BAU
-          let buttonsHTML = `<button id="cw-bau-toggle-btn" class="cw-btn-interactive" style="background:rgba(255,255,255,0.7); border:1px solid rgba(139, 92, 246, 0.4); border-radius:12px; padding:8px 12px; color:#6D28D9; font-size:12px; font-weight:600;">Detalhes</button>`;
-
-          if (window._cwIsAdmin) {
-              buttonsHTML = `
-                <button class="cw-bau-edit cw-btn-interactive" style="border:1px solid rgba(139, 92, 246, 0.2); background:rgba(255,255,255,0.5); border-radius:12px; padding:8px; color:#6D28D9; display:flex; align-items:center; justify-content:center;">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
-                </button>
-                ${buttonsHTML}
-              `;
-          }
-          
-          if (extractedSlots.length > 0) {
-              const slotsHTML = extractedSlots.map(slot => `
-                  <div style="${objectToCss(styles.bauSlotRow)}; margin-bottom:0; flex:1; justify-content:center;">
-                      <span style="${objectToCss(styles.bauFlag)}">${slot.flag}</span>
-                      <span style="${objectToCss(styles.bauDate)}">${slot.date}</span>
-                  </div>
-              `).join('');
-
-              contentHTML = `
-                  <div style="display:flex; justify-content:space-between; align-items:center;">
-                      <div style="flex:1; display:flex; gap:8px;">${slotsHTML}</div>
-                      <div style="display:flex; gap:8px; margin-left:12px; align-items:center;">
-                          ${buttonsHTML}
-                      </div>
-                  </div>
-                  <div id="cw-bau-full" style="display:none; margin-top:12px; padding-top:12px; border-top:1px dashed rgba(139, 92, 246, 0.3); font-size:13px; line-height:1.5; color:#581C87;">${parseMessageText(bauMessage.text)}</div>
-              `;
-          } else {
-              contentHTML = `
-                <div style="display:flex; justify-content:space-between; align-items:start;">
-                    <div style="font-size:13px; color:#581C87; line-height:1.5; flex:1;">${parseMessageText(bauMessage.text)}</div>
-                    ${window._cwIsAdmin ? `<div style="margin-left:12px;"><button class="cw-bau-edit cw-btn-interactive" style="border:none; background:rgba(255,255,255,0.5); border-radius:6px; padding:6px; color:#6D28D9;">✏️</button></div>` : ''}
-                </div>
-              `;
-          }
-
-          bauWidget.innerHTML = `
-              <div style="${objectToCss(styles.bauHeader)}; margin-bottom:8px;">
-                  <div style="${objectToCss(styles.liveIndicator)}">
-                      <div style="${objectToCss(styles.pulseDot)}"></div>
-                      <span style="${objectToCss(styles.bauLabel)}">Disponibilidade BAU</span>
-                  </div>
-                  <div style="font-size:10px; opacity:0.7; color:#7E22CE;">${formatFriendlyDate(bauMessage.date)}</div>
-              </div>
-              ${contentHTML}
+      if (isAdmin) {
+          buttonsHTML = `
+            <button class="cw-bau-edit cw-btn-interactive cw-bc-bau-edit-btn">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+            </button>
+            ${buttonsHTML}
           `;
-
-          // BAU is inserted after STATUS (cw-update-status)
-          statusEl.after(bauWidget);
-
-          const toggleBtn = bauWidget.querySelector('#cw-bau-toggle-btn');
-          const fullText = bauWidget.querySelector('#cw-bau-full');
-          if (toggleBtn && fullText) {
-              toggleBtn.onclick = () => {
-                  const isHidden = fullText.style.display === "none";
-                  fullText.style.display = isHidden ? "block" : "none";
-                  toggleBtn.textContent = isHidden ? "Ocultar" : "Detalhes";
-              };
-          }
-          if(window._cwIsAdmin) {
-              const editBtn = bauWidget.querySelector('.cw-bau-edit');
-              if(editBtn) editBtn.onclick = () => openEditor(bauMessage);
-          }
       }
 
-      // 2. LISTA
-      const sortedMessages = allMessages.sort((a, b) => {
+      if (extractedSlots.length > 0) {
+          const slotsHTML = extractedSlots.map(slot => `
+              <div class="cw-bc-bau-slot">
+                  <span class="cw-bc-bau-flag">${slot.flag}</span>
+                  <span class="cw-bc-bau-date">${slot.date}</span>
+              </div>
+          `).join('');
+
+          contentHTML = `
+              <div class="cw-bc-bau-slots">
+                  <div class="cw-bc-bau-slots-row">${slotsHTML}</div>
+                  <div class="cw-bc-bau-actions">${buttonsHTML}</div>
+              </div>
+              <div id="cw-bau-full" class="cw-bc-bau-full">${parseMessageText(bauMessage.text)}</div>
+          `;
+      } else {
+          contentHTML = `
+            <div class="cw-bc-bau-plain">
+                <div class="cw-bc-bau-plain-text">${parseMessageText(bauMessage.text)}</div>
+                ${isAdmin ? `<div style="margin-left:12px;"><button class="cw-bau-edit cw-btn-interactive cw-bc-bau-edit-btn compact">✏️</button></div>` : ''}
+            </div>
+          `;
+      }
+
+      bauWidget.innerHTML = `
+          <div class="cw-bc-bau-header">
+              <div class="cw-bc-live-indicator">
+                  <div class="cw-bc-pulse-dot"></div>
+                  <span class="cw-bc-bau-label">Disponibilidade BAU</span>
+              </div>
+              <div class="cw-bc-bau-timestamp">${formatFriendlyDate(bauMessage.date)}</div>
+          </div>
+          ${contentHTML}
+      `;
+
+      statusEl.after(bauWidget);
+
+      const toggleBtn = bauWidget.querySelector('#cw-bau-toggle-btn');
+      const fullText = bauWidget.querySelector('#cw-bau-full');
+      if (toggleBtn && fullText) {
+          toggleBtn.onclick = () => {
+              const isHidden = fullText.style.display === "none" || !fullText.style.display;
+              fullText.style.display = isHidden ? "block" : "none";
+              toggleBtn.textContent = isHidden ? "Ocultar" : "Detalhes";
+          };
+      }
+      if (isAdmin) {
+          const editBtn = bauWidget.querySelector('.cw-bau-edit');
+          if (editBtn) editBtn.onclick = () => openEditor(bauMessage);
+      }
+  }
+
+  // Monta a lista de mensagens não-lidas + histórico colapsável de lidas.
+  function renderMessageList(messages, readMessages, hasBauWidget) {
+      const sortedMessages = messages.sort((a, b) => {
           const aRead = readMessages.includes(a.id);
           const bRead = readMessages.includes(b.id);
           return aRead === bRead ? 0 : aRead ? 1 : -1;
       });
 
-      if (sortedMessages.length === 0 && !bauIndex) {
+      const isSearching = searchTerm.trim().length > 0;
+
+      if (sortedMessages.length === 0 && !hasBauWidget) {
            const empty = document.createElement("div");
-           Object.assign(empty.style, styles.emptyState);
-           empty.innerHTML = `
-            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path><path d="M9 12l2 2 4-4"></path></svg>
-            <div style="font-weight:500;">Tudo lido!</div>
-           `;
+           empty.className = "cw-bc-empty";
+           empty.innerHTML = isSearching
+               ? `<div style="font-weight:500;">Nada encontrado.</div>`
+               : `
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path><path d="M9 12l2 2 4-4"></path></svg>
+                <div style="font-weight:500;">Tudo lido!</div>
+               `;
            feed.appendChild(empty);
+           return;
       }
-      
+
       const unreadMsgs = sortedMessages.filter(m => !readMessages.includes(m.id));
       const readMsgs = sortedMessages.filter(m => readMessages.includes(m.id));
 
@@ -650,11 +694,11 @@ export function initBroadcastAssistant() {
 
       if (readMsgs.length > 0) {
           const divider = document.createElement("div");
-          Object.assign(divider.style, styles.historyDivider);
+          divider.className = "cw-bc-history-divider";
           divider.innerHTML = `<span>Histórico (${readMsgs.length})</span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>`;
-          
+
           const historyContainer = document.createElement("div");
-          Object.assign(historyContainer.style, styles.historyContainer);
+          historyContainer.className = "cw-bc-history-container";
           readMsgs.forEach(msg => historyContainer.appendChild(createCard(msg, true)));
 
           let isHistoryOpen = false;
@@ -669,33 +713,58 @@ export function initBroadcastAssistant() {
       }
   }
 
+  function renderFeed() {
+      feed.innerHTML = "";
+      const oldBau = popup.querySelector('#cw-bau-widget');
+      if (oldBau) oldBau.remove();
+
+      const readMessages = JSON.parse(localStorage.getItem("cw_read_broadcasts") || "[]");
+      let allMessages = [...BROADCAST_MESSAGES].sort((a, b) => {
+          const dateA = new Date(a.date).getTime() || 0;
+          const dateB = new Date(b.date).getTime() || 0;
+          return dateB - dateA;
+      });
+
+      // 1. WIDGET BAU (nunca filtrado pela busca)
+      const bauIndex = allMessages.findIndex(m => m.title && m.title.toLowerCase().includes("disponibilidade bau"));
+      let hasBauWidget = false;
+      if (bauIndex !== -1) {
+          const bauMessage = allMessages[bauIndex];
+          allMessages.splice(bauIndex, 1);
+          renderBauWidget(bauMessage);
+          hasBauWidget = true;
+      }
+
+      // 2. LISTA (filtrada pela busca, se houver termo)
+      const term = searchTerm.trim().toLowerCase();
+      const filteredMessages = allMessages.filter(m => matchesSearch(m, term));
+      renderMessageList(filteredMessages, readMessages, hasBauWidget);
+  }
+
   function createCard(msg, isHistory) {
     const card = document.createElement("div");
-    Object.assign(card.style, isHistory ? styles.cardHistory : styles.card);
+    card.className = "cw-bc-card" + (isHistory ? " history" : "");
     const theme = TYPE_CONFIG[msg.type] || TYPE_CONFIG.info;
 
     // Header
     const cardHead = document.createElement("div");
-    Object.assign(cardHead.style, styles.cardHeader);
-    
+    cardHead.className = "cw-bc-card-head";
+
     const typeLabel = document.createElement("div");
-    Object.assign(typeLabel.style, styles.typeTag, { color: theme.color, background: theme.bg });
+    typeLabel.className = "cw-bc-type-tag " + (TYPE_CONFIG[msg.type] ? msg.type : 'info');
     typeLabel.innerHTML = `${theme.icon} <span>${msg.type}</span>`;
-    
+
     const dateLabel = document.createElement("span");
-    Object.assign(dateLabel.style, styles.dateTag);
+    dateLabel.className = "cw-bc-date-tag";
     dateLabel.textContent = formatFriendlyDate(msg.date);
 
     cardHead.appendChild(typeLabel);
-    
+
     // Dismiss
     if (!isHistory) {
         const dismissBtn = document.createElement("button");
-        dismissBtn.className = "cw-btn-interactive";
-        Object.assign(dismissBtn.style, styles.dismissBtn);
+        dismissBtn.className = "cw-btn-interactive cw-bc-dismiss-btn";
         dismissBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
-        dismissBtn.onmouseenter = () => { dismissBtn.style.color = "#1e8e3e"; dismissBtn.style.background = "#e6f4ea"; dismissBtn.style.borderColor = "#1e8e3e"; };
-        dismissBtn.onmouseleave = () => { dismissBtn.style.color = "#5f6368"; dismissBtn.style.background = "#fff"; dismissBtn.style.borderColor = "rgba(0,0,0,0.1)"; };
         dismissBtn.onclick = (e) => {
             e.stopPropagation();
             SoundManager.playClick();
@@ -705,31 +774,31 @@ export function initBroadcastAssistant() {
                 const currentRead = JSON.parse(localStorage.getItem("cw_read_broadcasts") || "[]");
                 currentRead.push(msg.id);
                 localStorage.setItem("cw_read_broadcasts", JSON.stringify(currentRead));
-                renderFeed(); 
-                updateBadge(); 
+                renderFeed();
+                updateBadge();
             }, 200);
         };
         cardHead.appendChild(dismissBtn);
     } else {
         cardHead.appendChild(dateLabel);
     }
-    
+
     // Content
     const bodyContainer = document.createElement("div");
-    Object.assign(bodyContainer.style, styles.cardContent);
-    
+    bodyContainer.className = "cw-bc-card-content";
+
     const title = document.createElement("div");
-    Object.assign(title.style, styles.msgTitle);
+    title.className = "cw-bc-msg-title";
     title.textContent = msg.title;
-    
+
     const text = document.createElement("div");
-    Object.assign(text.style, styles.msgBody);
+    text.className = "cw-bc-msg-body";
     text.innerHTML = parseMessageText(msg.text);
-    
+
     const meta = document.createElement("div");
-    Object.assign(meta.style, styles.msgMeta);
+    meta.className = "cw-bc-msg-meta";
     meta.innerHTML = `Publicado por <b>${msg.author || 'Sistema'}</b>`;
-    if(!isHistory) meta.innerHTML += ` • ${formatFriendlyDate(msg.date)}`;
+    if (!isHistory) meta.innerHTML += ` • ${formatFriendlyDate(msg.date)}`;
 
     bodyContainer.appendChild(title);
     bodyContainer.appendChild(text);
@@ -739,10 +808,10 @@ export function initBroadcastAssistant() {
     card.appendChild(bodyContainer);
 
     // --- CRUD FOOTER (Admin) ---
-    if (window._cwIsAdmin) {
+    if (isAdmin) {
         const cardActions = document.createElement("div");
         cardActions.className = "cw-card-actions";
-        
+
         const btnEdit = document.createElement("button");
         btnEdit.className = "cw-action-btn edit";
         btnEdit.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg> Editar`;
@@ -767,7 +836,7 @@ export function initBroadcastAssistant() {
       setBroadcastMessages(cachedData);
       renderFeed();
   }
-  
+
   setTimeout(tryInjectAdminButton, 500);
   checkForUpdates();
   if (!pollInterval) pollInterval = setInterval(checkForUpdates, POLL_TIME_MS);


### PR DESCRIPTION
## Resumo

`broadcast/` (Central de Avisos) saiu com 4/5 na varredura geral dos módulos — esse PR traz ele pro mesmo padrão de personal-library/call-script/configs.

### 1. Folha de estilo única
Substitui os 4 mecanismos de estilo que coexistiam no arquivo (classes injetadas, objeto JS via `Object.assign`, `objectToCss()` embutido em template literals do widget BAU, e `style="..."` cru no HTML do editor) por um só `injectStyles()`. A paleta roxa do widget BAU continua roxa (é destaque proposital, não bug) — só centralizada em classes nomeadas em vez de hex repetido.

### 2. `renderFeed()` quebrado em pedaços menores
Era uma função de 172 linhas fazendo ordenação + parsing/render do widget BAU + render da lista não-lida/histórico tudo junto. Agora: `extractBauSlots()` (só o parsing de data/bandeira, mesma lógica de sempre, só isolada), `renderBauWidget()`, `renderMessageList()`, e `renderFeed()` como orquestrador.

### 3. Bug real corrigido: estado vazio nunca aparecia
A checagem era `!bauIndex` — só é `true` quando `bauIndex === 0`. Como `bauIndex` é `-1` em todo dia sem widget BAU (`findIndex` não achou), `!(-1)` é `false`, então "Tudo lido!" nunca aparecia no caso comum. Trocado por um booleano explícito `hasBauWidget`.

### 4. Estado global removido
`window._cwIsAdmin`/`_cwCurrentUser`/`_cwAdminRetries` viraram variáveis de escopo do módulo — confirmei por busca no repo inteiro que nada mais lia essas 3 variáveis.

### 5. Busca adicionada
Campo de busca filtrando título/texto da lista (mesmo padrão client-side já usado em personal-library/step-tasks). O widget BAU fica de fora da busca de propósito — é um card operacional fixo, não uma mensagem pra procurar.

Nada muda nas chamadas ao `DataService`, no backend GAS, ou no comportamento real do heurístico de extração de data/bandeira do BAU — só a camada de apresentação.

## Teste

- [ ] `esbuild` roda sem erro (já validado localmente)
- [ ] Feed carrega, não-lidas primeiro, histórico colapsável funciona
- [ ] Widget BAU continua extraindo datas/bandeiras igual antes
- [ ] "Tudo lido!" aparece quando não há mensagem não-lida e não há widget BAU
- [ ] Busca filtra por título/texto
- [ ] Botão de admin (+ Novo Aviso) só aparece pra quem está em ADMINS; criar/editar/excluir aviso continua funcionando
- [ ] Badge de não-lido na pílula continua atualizando

🤖 Gerado com [Claude Code](https://claude.com/claude-code)