### PR TITLE
fix(bau-form): tasks field name mismatch, details grid overflow

### DIFF
--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -515,7 +515,7 @@ export function initBAUForm() {
                         <div class="bau-details-divider"></div>
                         <div class="bau-details-row">
                             <span class="bau-details-label">Tasks solicitadas</span>
-                            <span class="bau-details-value">${c.taskType || 'Nenhuma'}</span>
+                            <span class="bau-details-value">${c.task || c.taskType || 'Nenhuma'}</span>
                         </div>
                     </div>
 

--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -951,6 +951,13 @@ export const injectStyles = () => {
         flex-direction: column;
         gap: 12px;
         transition: transform 0.2s ease;
+        /* min-width:0 é necessário pra célula de grid poder encolher abaixo
+           do conteúdo — sem isso, um texto sem quebra (URL, ID de rastreio)
+           força a coluna a ficar larga, estoura o grid, e o pai com
+           overflow:hidden corta/sobrepõe em vez de rolar. Casos já
+           resolvidos tendem a ter os campos mais preenchidos, por isso o
+           problema aparecia mais neles. */
+        min-width: 0;
     }
 
     .bau-details-row {
@@ -974,6 +981,8 @@ export const injectStyles = () => {
         font-weight: 500;
         color: #202124;
         line-height: 1.5;
+        overflow-wrap: break-word;
+        word-break: break-word;
     }
 
     .bau-copy-btn {


### PR DESCRIPTION
## Resumo

Primeira das 3 PRs da varredura do BAU Central que voce pediu (bugs no formulario/detalhes, TL Dashboard, servico de email). Essa cobre o cliente (`bau-form-assistant.js`/`bau-form-styles.js`).

### 1. "Tasks Solicitadas" sempre "Nenhuma"
Bug de nome de campo: o formulario envia `taskType`, o backend grava e devolve como `task`, mas `openCaseDetails()` lia `c.taskType` (nunca existe) em vez de `c.task`. A tela de edicao ja fazia certo (`c.task || c.taskType`) - so a visualizacao tinha o bug. Troquei pra `c.task || c.taskType`, mesmo padrao.

### 2. Layout quebrado em casos resolvidos
`.bau-details-grid` nao tinha `min-width: 0` nas celulas do grid - por padrao um item de grid tem `min-width: auto` (~max-content), entao um texto longo e sem quebra (URL, ID de rastreamento) forcava a coluna a ficar larga e estourava o layout, que o container cortava com `overflow: hidden` em vez de acomodar. Casos resolvidos tendem a ter mais campos preenchidos (texto mais longo), o que bate com o padrao que voce descreveu ("quando desco, e completamente quebrado"). Adicionei `min-width: 0` no grid e `overflow-wrap`/`word-break` no valor, pra texto longo quebrar linha em vez de estourar.

## Teste

- [ ] `esbuild` roda sem erro (ja validado localmente)
- [ ] Abrir um caso ja resolvido (aprovado ou descartado) nos detalhes: "Tasks Solicitadas" mostra o valor certo
- [ ] Mesmo caso: layout nao quebra/sobrepoe mesmo com campos longos, rolando a tela pra baixo

🤖 Gerado com [Claude Code](https://claude.com/claude-code)