### PR TITLE
fix(bau): new discard requests land in wrong TL tab, agent details incomplete

### DIFF
--- a/gas-backend/BAU_API.js
+++ b/gas-backend/BAU_API.js
@@ -9,7 +9,7 @@ function handleBAUEscalation(ss, p) {
     const timestamp = p.date || new Date().toISOString();
     const userEmail = p.user || 'anon';
     
-    const status = "PENDING_TL_CREATION"; 
+    const status = p.requestType === 'DISCARD' ? "PENDING_TL_DISCARD" : "PENDING_TL_CREATION";
 
     const novaLinha = [
       newId,                    // 1. ID

--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -507,6 +507,47 @@ export function initBAUForm() {
                         </div>
                     </div>
 
+                    <div class="bau-details-card">
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Speakeasy ID</span>
+                            <span class="bau-details-value">${c.seId || '---'}</span>
+                            <button class="bau-copy-btn" title="Copiar">${ICONS.wand}</button>
+                        </div>
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Email do Anunciante</span>
+                            <span class="bau-details-value">${c.advEmail || '---'}</span>
+                            <button class="bau-copy-btn" title="Copiar">${ICONS.wand}</button>
+                        </div>
+                    </div>
+                    <div class="bau-details-card">
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Site</span>
+                            <span class="bau-details-value">${c.site || '---'}</span>
+                            <button class="bau-copy-btn" title="Copiar">${ICONS.wand}</button>
+                        </div>
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Timezone</span>
+                            <span class="bau-details-value">${c.timezone || '---'}</span>
+                        </div>
+                    </div>
+
+                    <div class="bau-details-card full-width">
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Idioma</span>
+                            <span class="bau-details-value">${c.language || '---'}</span>
+                        </div>
+                        <div class="bau-details-divider"></div>
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">AM Responsável</span>
+                            <span class="bau-details-value">${c.amName || '---'}</span>
+                        </div>
+                        <div class="bau-details-divider"></div>
+                        <div class="bau-details-row">
+                            <span class="bau-details-label">Programa de Vendas</span>
+                            <span class="bau-details-value">${c.salesProgram || '---'}</span>
+                        </div>
+                    </div>
+
                     <div class="bau-details-card full-width">
                         <div class="bau-details-row">
                             <span class="bau-details-label">Motivo BAU</span>


### PR DESCRIPTION
## Resumo

Dois bugs que voce achou testando as duas PRs anteriores ja mergeadas (`fix/bau-form-details` e `fix/tl-dashboard-critical-bugs`).

### 1. Solicitacao de descarte de caso novo cai na aba errada do TL
`handleBAUEscalation()` (chamada quando um caso NOVO e enviado, seja BAU ou descarte) gravava o status sempre como `PENDING_TL_CREATION`, sem olhar pra `p.requestType`. A correcao anterior (`fix/tl-dashboard-critical-bugs`) so ajustou os *botoes* dentro de cada aba do Dashboard - nao mexeu em qual aba o caso cai quando e criado. Resultado: pedir descarte de um caso novo colocava ele em "Aprovacao de Criacao" em vez de "Aprovacao de Descarte". Status agora depende de `p.requestType`, igual `update_bau_case()` ja fazia pra edicoes.

### 2. Detalhes do caso (visao do agente) incompletos
Voce confirmou que "Justificativa" e "Tasks solicitadas" ja aparecem certo (fix anterior funcionando), mas a tela de detalhes de um caso que voce mesmo enviou (dentro do modulo BAU, nao o Dashboard do TL) ainda nao mostrava Speakeasy ID, Email do Anunciante, Site, Timezone, Idioma, AM Responsavel e Programa de Vendas - dados que ja vinham do backend (`getAgentCases()` ja retorna todos esses campos) mas o `openCaseDetails()` do modulo do agente nunca renderizava. Adicionei os 7 campos, seguindo o mesmo padrao visual de card/linha do resto da tela.

## Fora de escopo (de proposito)

Voce foi claro que ainda nao chegamos na parte de emails - entao o tipo/conteudo do email disparado em `handleBAUEscalation()` continua o mesmo (`AGENT_BAU_SENT` pra qualquer novo caso, incluindo descarte). Isso fica pra rodada de email service que ja estava planejada.

## Teste

- [ ] `esbuild` roda sem erro (ja validado localmente)
- [ ] Enviar uma solicitacao de descarte de um caso novo (nao edicao): cai na aba "Aprovacao de Descarte" do TL Dashboard, nao em "Aprovacao de Criacao"
- [ ] Enviar um caso BAU normal: continua caindo em "Aprovacao de Criacao" como sempre
- [ ] Abrir os detalhes de um caso que voce mesmo enviou, dentro do modulo BAU: Speakeasy ID, Email do Anunciante, Site, Timezone, Idioma, AM Responsavel e Programa de Vendas aparecem preenchidos (quando enviados) ou "---"

🤖 Gerado com [Claude Code](https://claude.com/claude-code)