### PR TITLE
fix(tl-dashboard): status/email desync bug, optimistic UI, auto-sync

### DIFF
--- a/docs/TL_DASHBOARD_DIAGNOSTIC.md
+++ b/docs/TL_DASHBOARD_DIAGNOSTIC.md
@@ -1,13 +1,13 @@
 # Diagnóstico do TL Dashboard
 
-> ⚠️ **Status: Backlog / não implementado.** Apesar do nome, este arquivo não descreve o comportamento atual do TL Dashboard — é uma lista de melhorias propostas que ainda não foram construídas. Confirme no código (`gas-backend/BAU_Dashboard.js`, `gas-backend/TLDashboard.html`) antes de assumir que algo aqui já existe.
+> ⚠️ **Status: parcialmente implementado.** Os itens marcados ✅ abaixo já existem no código atual (`gas-backend/BAU_Dashboard.js`, `gas-backend/TLDashboard.html`). Os demais continuam sendo apenas propostas — confirme no código antes de assumir que algo aqui já existe.
 
-Para que o TL Dashboard reflita essas edições em tempo real, as seguintes alterações no arquivo **TLDashboard.html** serão necessárias no futuro:
+No arquivo **TLDashboard.html**:
 
-1.  **Auto-Refresh (Polling):** Implementar um mecanismo de atualização automática utilizando `setInterval` que execute a função `loadCases()` em intervalos regulares (ex: a cada 3 ou 5 minutos), garantindo que a lista de casos pendentes esteja sempre sincronizada sem depender exclusivamente do clique manual em "Sincronizar".
-2.  **Destaque Visual de Mudanças:** Na função `withSuccessHandler` do `loadCases`, comparar o novo array de casos com o estado anterior (`allCases`). Caso um ID existente possua dados diferentes (como mudança no `reason` ou `task`), aplicar uma classe CSS de animação (ex: um breve pulse ou glow) na linha correspondente para alertar visualmente o TL sobre a edição.
-3.  **Badge de Edição:** Adicionar uma propriedade `date_edited` ao objeto retornado pelo backend e, no frontend, exibir um pequeno ícone ou badge de "Editado" nos cards que foram modificados pelo agente após a criação inicial.
-4.  **Notificação de Sistema (Toasts):** Se o Auto-Refresh detectar que um caso foi alterado enquanto o TL estava com a aba aberta, disparar um Toast informativo: "O caso [ID] foi atualizado pelo agente".
+1.  ✅ **Auto-Refresh (Polling):** implementado — `setInterval` silencioso chamando `loadCases({ silent: true })` a cada 60s, mais um refresh ao focar a aba de novo (`visibilitychange`). Pausa enquanto qualquer modal está aberto. Sem o `setInterval` de 3-5min originalmente cogitado aqui — 60s pareceu um ponto de partida melhor para dar sensação de "tempo real"; é um valor único, fácil de ajustar se ficar muito frequente.
+2.  **Destaque Visual de Mudanças:** ainda não implementado. Continua como proposta: comparar o novo array de casos com o estado anterior (`allCases`) no `withSuccessHandler` do `loadCases`, e aplicar uma classe CSS de animação (pulse/glow) na linha correspondente quando um ID existente mudar de dados.
+3.  **Badge de Edição:** ainda não implementado. Continua como proposta: propriedade `date_edited` no objeto retornado pelo backend + badge "Editado" no frontend.
+4.  ~~Notificação de Sistema (Toasts) quando um caso é alterado enquanto a aba está aberta~~ — depende dos itens 2-3 acima (que ainda não existem), então também não implementado.
 
 No arquivo **BAU_Dashboard.js**:
-1.  Incluir a coluna de `description` (Índice 16) no objeto retornado pela função `getPendingBAUCases`, permitindo que o TL visualize detalhes adicionais que podem ter sido corrigidos durante a edição.
+1.  ✅ **Incluir a coluna de `description`** no retorno de `getPendingBAUCases` — já implementado, junto com Speakeasy ID, Adv Email, Timezone, Language, AM Name e Sales Program.

--- a/gas-backend/BAU_Dashboard.js
+++ b/gas-backend/BAU_Dashboard.js
@@ -63,7 +63,7 @@ function updateBAUCaseStatus(id, newStatus) {
           advName: rowData[7],
           caseId: rowData[4],
           site: rowData[9],
-          availability: rowData[17],
+          availability: rowData[17] instanceof Date ? rowData[17].toISOString() : String(rowData[17] || ""),
           cid: rowData[5],
           taskType: rowData[15],
           reason: rowData[14]
@@ -71,13 +71,22 @@ function updateBAUCaseStatus(id, newStatus) {
         const agentEmail = rowData[2];
         const tlEmail = Session.getActiveUser().getEmail();
 
-        if (newStatus === "CREATED") {
-          sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_BAU_CREATED', tlEmail);
-        } else if (newStatus === "DISCARDED") {
-          sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_DISCARD_DONE', tlEmail);
+        // O status já foi gravado na planilha (linha acima) antes de chegar aqui -
+        // uma falha no envio do email não pode mais derrubar a ação inteira pro
+        // cliente (google.script.run reportaria falha mesmo com o status já salvo).
+        let emailSent = true;
+        try {
+          if (newStatus === "CREATED") {
+            sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_BAU_CREATED', tlEmail);
+          } else if (newStatus === "DISCARDED") {
+            sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_DISCARD_DONE', tlEmail);
+          }
+        } catch (e) {
+          emailSent = false;
+          console.warn("Aviso: Falha ao enviar email de confirmação de status", e);
         }
-        
-        return { success: true, newStatus: newStatus };
+
+        return { success: true, newStatus: newStatus, emailSent: emailSent };
       }
     }
     throw new Error("Caso não encontrado.");

--- a/gas-backend/EmailEngine.js
+++ b/gas-backend/EmailEngine.js
@@ -61,7 +61,7 @@ function sendDynamicTechSolEmail(destinatario, data, escalacaoId, tipoEmail, aut
   }
 
   let dataFormatada = formatGASDate(data.availability);
-  let dateObj = (data.availability && !data.availability.includes('|')) ? new Date(data.availability) : null;
+  let dateObj = (data.availability && !String(data.availability).includes('|')) ? new Date(data.availability) : null;
 
   // 3. Calculadora de Urgência (Para a Liderança)
   function getUrgencyHtml(targetDate) {

--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -472,14 +472,14 @@
 
     <div class="ambient-glow"></div>
 
-    <div id="toast" class="toast">
+    <div id="toast" class="toast" role="status" aria-live="polite">
         <span class="material-symbols-rounded" id="toast-icon">check_circle</span>
         <span id="toast-message">Ação realizada com sucesso</span>
     </div>
 
     <!-- Modal Detalhes -->
     <div id="caseModal" class="modal-overlay" onclick="closeModal('caseModal')">
-        <div class="modal-content" onclick="event.stopPropagation()">
+        <div class="modal-content" role="dialog" aria-modal="true" onclick="event.stopPropagation()">
             <div class="modal-header">
                 <div style="font-size: 18px; font-weight: 500;">Detalhes da Solicitação</div>
                 <button class="btn-icon-close" onclick="closeModal('caseModal')">
@@ -492,7 +492,7 @@
 
     <!-- Modal Confirmação Customizado -->
     <div id="confirmModal" class="modal-overlay">
-        <div class="modal-content modal-confirm-content">
+        <div class="modal-content modal-confirm-content" role="dialog" aria-modal="true">
             <div class="modal-body">
                 <span class="material-symbols-rounded confirm-icon" id="confirm-icon">help</span>
                 <div id="confirm-title" style="font-size: 20px; font-weight: 500; margin-bottom: 8px;">Confirmar Ação</div>
@@ -504,7 +504,7 @@
                 </div>
             </div>
             <div class="confirm-footer">
-                <button class="btn btn-danger-outline" onclick="closeModal('confirmModal')" style="flex: 1;">Cancelar</button>
+                <button class="btn btn-danger-outline" id="confirm-cancel-btn" onclick="closeModal('confirmModal')" style="flex: 1;">Cancelar</button>
                 <button class="btn btn-primary" id="confirm-submit-btn" style="flex: 1;">Confirmar</button>
             </div>
         </div>
@@ -522,10 +522,13 @@
                 <span>TL Dashboard</span>
             </div>
         </div>
-        <button class="btn" style="background: var(--surface-level-2); border: 1px solid var(--border-subtle); color: var(--text-secondary);" onclick="loadCases()">
-            <span class="material-symbols-rounded" style="font-size: 20px;">sync</span>
-            Sincronizar
-        </button>
+        <div style="display: flex; align-items: center; gap: 16px;">
+            <span id="last-synced-label" style="font-size: 12px; color: var(--text-tertiary);"></span>
+            <button class="btn" style="background: var(--surface-level-2); border: 1px solid var(--border-subtle); color: var(--text-secondary);" onclick="loadCases()">
+                <span class="material-symbols-rounded" style="font-size: 20px;">sync</span>
+                Sincronizar
+            </button>
+        </div>
     </nav>
 
     <div class="tab-section">
@@ -558,10 +561,37 @@
     </main>
 
     <script>
-        window.onload = loadCases;
+        window.onload = () => {
+            loadCases();
+            // Sincronização automática em segundo plano: silenciosa (sem skeleton),
+            // pausa enquanto qualquer modal estiver aberto pra não puxar o tapete
+            // de uma revisão em andamento. 60s é ponto de partida, fácil de ajustar.
+            setInterval(() => loadCases({ silent: true }), 60000);
+            setInterval(updateLastSyncedLabel, 15000);
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'visible') loadCases({ silent: true });
+            });
+        };
         let allCases = [];
         let currentTab = 'CREATION';
         let loadError = false;
+        let lastSyncedAt = null;
+        let syncInFlight = false;
+
+        function isAnyModalOpen() {
+            return document.getElementById('caseModal').classList.contains('active') ||
+                document.getElementById('confirmModal').classList.contains('active');
+        }
+
+        function updateLastSyncedLabel() {
+            const label = document.getElementById('last-synced-label');
+            if (!label) return;
+            if (!lastSyncedAt) { label.textContent = ''; return; }
+            const diffSec = Math.floor((Date.now() - lastSyncedAt.getTime()) / 1000);
+            if (diffSec < 10) label.textContent = 'Sincronizado agora';
+            else if (diffSec < 60) label.textContent = `Sincronizado há ${diffSec}s`;
+            else label.textContent = `Sincronizado há ${Math.floor(diffSec / 60)}min`;
+        }
 
         function escapeHtml(str) {
             if (str === null || str === undefined) return '';
@@ -573,43 +603,62 @@
                 .replace(/'/g, '&#39;');
         }
 
-        function loadCases() {
+        function loadCases(opts = {}) {
+            const silent = !!opts.silent;
+
+            // Ticks silenciosos não competem com uma requisição já em voo, nem
+            // interrompem o TL no meio da revisão de um caso.
+            if (silent && (syncInFlight || isAnyModalOpen())) return;
+
             const container = document.getElementById('cases-container');
             const loader = document.getElementById('loader');
 
-            loadError = false;
-            loader.style.display = 'flex';
-            container.innerHTML = `
-                <div class="skeleton-row">
-                    <div class="skeleton-item" style="width: 30%; height: 24px;"></div>
-                    <div class="skeleton-item" style="width: 60%; height: 16px;"></div>
-                    <div class="skeleton-item" style="width: 40%; height: 16px;"></div>
-                </div>
-                <div class="skeleton-row">
-                    <div class="skeleton-item" style="width: 35%; height: 24px;"></div>
-                    <div class="skeleton-item" style="width: 55%; height: 16px;"></div>
-                    <div class="skeleton-item" style="width: 45%; height: 16px;"></div>
-                </div>
-                <div class="skeleton-row">
-                    <div class="skeleton-item" style="width: 25%; height: 24px;"></div>
-                    <div class="skeleton-item" style="width: 65%; height: 16px;"></div>
-                    <div class="skeleton-item" style="width: 35%; height: 16px;"></div>
-                </div>
-            `;
+            syncInFlight = true;
+
+            if (!silent) {
+                loadError = false;
+                loader.style.display = 'flex';
+                container.innerHTML = `
+                    <div class="skeleton-row">
+                        <div class="skeleton-item" style="width: 30%; height: 24px;"></div>
+                        <div class="skeleton-item" style="width: 60%; height: 16px;"></div>
+                        <div class="skeleton-item" style="width: 40%; height: 16px;"></div>
+                    </div>
+                    <div class="skeleton-row">
+                        <div class="skeleton-item" style="width: 35%; height: 24px;"></div>
+                        <div class="skeleton-item" style="width: 55%; height: 16px;"></div>
+                        <div class="skeleton-item" style="width: 45%; height: 16px;"></div>
+                    </div>
+                    <div class="skeleton-row">
+                        <div class="skeleton-item" style="width: 25%; height: 24px;"></div>
+                        <div class="skeleton-item" style="width: 65%; height: 16px;"></div>
+                        <div class="skeleton-item" style="width: 35%; height: 16px;"></div>
+                    </div>
+                `;
+            }
 
             google.script.run
                 .withSuccessHandler(data => {
+                    syncInFlight = false;
+                    lastSyncedAt = new Date();
+                    updateLastSyncedLabel();
                     allCases = data;
+                    loadError = false;
                     updateBadges();
                     renderCases();
                 })
                 .withFailureHandler(err => {
+                    syncInFlight = false;
                     console.error("Erro ao carregar casos:", err);
-                    showToast("Erro ao sincronizar com o servidor", "error");
-                    loadError = true;
-                    allCases = [];
-                    updateBadges();
-                    renderCases();
+                    // Uma falha de tick silencioso não deve interromper a tela com
+                    // um estado de erro - só a próxima tentativa (ou o clique manual).
+                    if (!silent) {
+                        showToast("Erro ao sincronizar com o servidor", "error");
+                        loadError = true;
+                        allCases = [];
+                        updateBadges();
+                        renderCases();
+                    }
                 })
                 .getPendingBAUCases();
         }
@@ -809,6 +858,7 @@
             // Reset state
             submitBtn.disabled = false;
             submitBtn.textContent = 'Confirmar';
+            document.getElementById('confirm-cancel-btn').disabled = false;
 
             if (isDiscardFlow) {
                 title.textContent = isPositive ? 'Manter Caso Ativo' : 'Confirmar Descarte';
@@ -833,6 +883,7 @@
             submitBtn.onclick = () => {
                 submitBtn.disabled = true;
                 submitBtn.textContent = 'Processando...';
+                document.getElementById('confirm-cancel-btn').disabled = true;
                 processAction(id, action);
             };
 
@@ -844,7 +895,7 @@
             const wasDiscardFlow = c && c.status === 'PENDING_TL_DISCARD';
 
             google.script.run
-                .withSuccessHandler(() => {
+                .withSuccessHandler((result) => {
                     closeModal('confirmModal');
                     let msg;
                     if (wasDiscardFlow) {
@@ -853,19 +904,44 @@
                         msg = newStatus === 'CREATED' ? 'Solicitação aprovada com sucesso' : 'Solicitação rejeitada';
                     }
                     showToast(msg);
-                    // OBRIGATORIAMENTE buscar a verdade do servidor após a ação
-                    loadCases();
+
+                    if (result && result.emailSent === false) {
+                        setTimeout(() => {
+                            showToast("Ação registrada, mas o email de confirmação ao agente falhou.", "warning");
+                        }, 3200);
+                    }
+
+                    removeCaseOptimistically(id);
                 })
                 .withFailureHandler(err => {
                     console.error("Erro na ação:", err);
                     showToast("Falha ao processar ação. Tente novamente.", "error");
 
-                    // Reabilita o botão se falhar
+                    // Reabilita os botões se falhar
                     const submitBtn = document.getElementById('confirm-submit-btn');
                     submitBtn.disabled = false;
                     submitBtn.textContent = 'Confirmar';
+                    document.getElementById('confirm-cancel-btn').disabled = false;
                 })
                 .updateBAUCaseStatus(id, newStatus);
+        }
+
+        // Tira a linha da tela na hora (animação já existia no CSS, nunca era usada -
+        // antes disso o TL só via o caso sumir depois de um loadCases() completo, com
+        // flash de skeleton, o que parecia "não mudar nada" na tela.
+        function removeCaseOptimistically(id) {
+            const row = document.getElementById('row-' + id);
+            const finish = () => {
+                allCases = allCases.filter(c => c.id !== id);
+                updateBadges();
+                renderCases();
+            };
+            if (row) {
+                row.classList.add('row-exit');
+                setTimeout(finish, 420);
+            } else {
+                finish();
+            }
         }
 
         function showToast(msg, type = "success") {
@@ -879,6 +955,11 @@
                 toast.style.background = "var(--danger)";
                 toast.style.color = "white";
                 icon.textContent = "error";
+            } else if (type === "warning") {
+                // TODO(PR B): trocar pelos tokens --yellow/--amber-text da nova paleta clara
+                toast.style.background = "#F9AB00";
+                toast.style.color = "#202124";
+                icon.textContent = "warning";
             } else {
                 toast.style.background = "";
                 toast.style.color = "";


### PR DESCRIPTION
## Resumo

Primeira de 3 PRs pra responder ao que voce achou testando o TL Dashboard ao vivo: um bug critico de sincronizacao, mais sincronizacao automatica e polish de UX. As outras duas (redesign visual + alerta de volume) vem depois, cada uma nascendo da anterior ja mergeada.

### O bug critico (causa raiz confirmada por leitura direta do codigo)

Aprovar/rejeitar um caso nao mudava nada na tela, nao mandava email pro agente, e so ao clicar "Sincronizar" manualmente o caso sumia da fila. Causa: `updateBAUCaseStatus()` passava `rowData[17]` (Disponibilidade) cru pro email - quando a celula tem uma data/hora preenchida, o Apps Script devolve um objeto `Date`, nao string (diferente da funcao irma `getPendingBAUCases()`, no mesmo arquivo, que ja normalizava isso certo). Esse `Date` cru chegava em `EmailEngine.js`, que chamava `.includes('|')` nele - `Date` nao tem esse metodo, estoura `TypeError`. Como a escrita do status na planilha ja tinha rodado ANTES do envio do email, e nao havia try/catch em volta dessa chamada (diferente das duas funcoes equivalentes em `BAU_API.js`, que ja tem esse padrao), a excecao subia como falha pro cliente mesmo com o status ja gravado: status muda em silencio, cliente acha que a acao falhou, email nunca sai. So acontecia quando o caso tinha disponibilidade preenchida - por isso parecia funcionar as vezes.

**Fix:** `BAU_Dashboard.js` normaliza `rowData[17]` igual `getPendingBAUCases()` ja faz; envolve o envio de email num try/catch (mesmo padrao de `BAU_API.js`) e retorna `emailSent: true/false`. `EmailEngine.js` ganha uma guarda extra contra `availability` nao-string, pro mesmo tipo de erro nao voltar por outro caminho no futuro. `TLDashboard.html` mostra um segundo toast se `emailSent === false`.

### Remocao otimista da linha

Mesmo com o bug corrigido, aprovar/rejeitar ainda dependia de um `loadCases()` completo (com flash de skeleton) pra linha sumir - por isso "nao vejo nada mudando" continuava valendo em parte. Existia uma classe CSS `.row-exit` no arquivo, criada mas nunca usada por nenhum JS. Agora ela e aplicada na hora que voce confirma uma acao, a linha anima pra fora, e some da lista local sem esperar um round-trip completo.

### Sincronizacao automatica

Polling silencioso a cada 60s (sem flash de skeleton) + refresh ao focar a aba de novo, pausado enquanto qualquer modal esta aberto pra nao te interromper numa revisao em andamento. Indicador "Sincronizado ha Xs" do lado do botao Sincronizar, pra voce ver que esta rodando sozinho.

### Polish pequeno

`aria-live` no toast, `role="dialog"` nos modais, botao Cancelar desabilita junto com o Confirmar durante o processamento (antes so o Confirmar desabilitava).

### Documentacao

`docs/TL_DASHBOARD_DIAGNOSTIC.md` estava desatualizado (marcava auto-refresh e o campo `description` como pendentes, mas o segundo ja tinha sido feito numa PR anterior) - atualizado pra refletir o que ja existe de fato, mantendo o resto do backlog (destaque de edicao, badge "Editado") documentado mas fora de escopo.

## Teste

gas-backend/ nao tem build - validacao foi revisao de codigo + o script embutido passou por um parse de sintaxe via Node. Pontos pra conferir depois do deploy:

- [ ] Aprovar/rejeitar um caso **com disponibilidade preenchida** (o cenario que quebrava antes): status muda, linha anima pra fora na hora, email chega, sem toast de erro
- [ ] Deixar o dashboard aberto, criar um caso em outro lugar: aparece sozinho em ate 60s, sem flash de skeleton
- [ ] Indicador "Sincronizado ha Xs" atualiza
- [ ] Abrir o modal de detalhes ou o de confirmacao pausa o auto-sync; fechar retoma
- [ ] Trocar de aba e voltar dispara um refresh

🤖 Gerado com [Claude Code](https://claude.com/claude-code)