### PR TITLE
fix(bau): missing website alias, raw ISO date in TL dashboard

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -593,6 +593,23 @@
             else label.textContent = `Sincronizado há ${Math.floor(diffSec / 60)}min`;
         }
 
+        // Formata uma disponibilidade (ISO 8601, opcionalmente múltiplas datas
+        // separadas por " | ") pro fuso do projeto (America/Sao_Paulo, igual
+        // gas-backend/appsscript.json e o mesmo fuso que EmailEngine.js já usa
+        // pros emails) - sem isso, o texto cru mostrava milissegundos e "Z" no
+        // final (ex: "14:00:00.000Z") direto do ISO string, sem formatação.
+        function formatAvailability(raw) {
+            if (!raw) return "Não informado";
+            if (String(raw).includes(' | ')) {
+                return String(raw).split(' | ').map(formatAvailability).join(' | ');
+            }
+            const d = new Date(raw);
+            if (isNaN(d.getTime())) return "Não informado";
+            const datePart = new Intl.DateTimeFormat('pt-BR', { timeZone: 'America/Sao_Paulo', day: '2-digit', month: '2-digit', year: 'numeric' }).format(d);
+            const timePart = new Intl.DateTimeFormat('pt-BR', { timeZone: 'America/Sao_Paulo', hour: '2-digit', minute: '2-digit', hour12: false }).format(d);
+            return `${datePart} às ${timePart}`;
+        }
+
         function escapeHtml(str) {
             if (str === null || str === undefined) return '';
             return String(str)
@@ -720,11 +737,7 @@
                 row.id = `row-${c.id}`;
                 row.onclick = () => openDetails(c.id);
 
-                let dataFormatada = c.availability || "Não informado";
-                if (dataFormatada.includes("T")) {
-                    const p = dataFormatada.split("T");
-                    dataFormatada = `${p[0].split("-").reverse().join("/")} às ${p[1]}`;
-                }
+                const dataFormatada = formatAvailability(c.availability);
 
                 const dataEnvio = new Date(c.date).toLocaleDateString('pt-BR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
                 const agentLdap = c.agentEmail ? c.agentEmail.split('@')[0] : 'Unknown';
@@ -829,7 +842,7 @@
                 ${createRow('Programa de Vendas', c.salesProgram)}
             </div>
             ${createRow('Site', c.site)}
-            ${createRow('Agendamento', c.availability)}
+            ${createRow('Agendamento', formatAvailability(c.availability))}
             ${createRow('Agente', c.agentEmail)}
             <div class="detail-group">
                 <span class="detail-label">O que deve ser feito</span>

--- a/src/modules/shared/page-data.js
+++ b/src/modules/shared/page-data.js
@@ -478,6 +478,7 @@ export async function getPageData() {
         // Aliases for BAU Form compatibility
         advName: advertiserName,
         site: websiteUrl,
+        website: websiteUrl, // bau-form-config.js's campo 'website' lê pageData.website, não .site
         email: clientEmail,
         salesProgram: salesProgram,
         language: language,


### PR DESCRIPTION
## Resumo

Dois bugs achados testando ao vivo. Nao fazem parte do plano de 3 PRs do TL Dashboard (bug de sync ja mergeado, redesign visual e alerta de volume ainda vem) - achados a parte, corrigidos numa PR curta pra nao bloquear o resto.

### 1. Campo "Website" do formulario BAU sempre pedia de novo, mesmo ja capturado

`page-data.js` devolve os dados extraidos da pagina do CRM com uma lista de aliases explicitamente comentada como "pra compatibilidade com o formulario BAU" (`advName`, `site`, `email`, `salesProgram`, `language`, `seId`) - mas faltava exatamente o `website`, que e o nome de campo que `bau-form-config.js` usa (`id: 'website'`). `getPageData()` so tinha `site`/`websiteUrl`, nunca `website`.

Resultado: a logica que esconde o campo quando o dado ja foi capturado (`populateContextData()` em `bau-form-assistant.js`) lia `pageData['website']` = `undefined`, e sempre mostrava o campo vazio pedindo o site de novo - mesmo com o site capturado corretamente (visivel certinho no painel de "dados capturados", que ja fazia `pageData.website || pageData.site` como fallback ad-hoc nesse ponto especifico, mas nao em todo lugar). Se o agente via o campo vazio e digitava algo ali, esse valor manual sobrescrevia o que ja tinha sido capturado certo.

**Fix:** adiciona o alias que faltava na fonte (`website: websiteUrl`), em vez de espalhar mais `|| pageData.site` pontuais pelo formulario - resolve o problema onde ele realmente esta.

### 2. Disponibilidade aparecia como ISO cru no TL Dashboard

O card da fila e o modal de detalhes mostravam a Disponibilidade cortando o ISO string na primeira ocorrencia de "T", sem tratar milissegundos/Z (ex: "14:00:00.000Z" aparecia literalmente na tela) - e sem nenhuma conversao de fuso, entao os digitos mostrados eram os do UTC armazenado na planilha, nao necessariamente o horario que o agente escolheu.

**Fix:** nova `formatAvailability()`, usando `Intl.DateTimeFormat` com `timeZone: 'America/Sao_Paulo'` (mesmo fuso de `gas-backend/appsscript.json`, que `EmailEngine.js` ja assume implicitamente pros emails - agora os dois batem), com suporte a multiplas datas separadas por " | " (mesmo formato que o formulario ja usa quando o agente marca mais de um horario). Aplicada no card da fila e no modal de detalhes (que antes nem tentava formatar, so mostrava o ISO cru direto).

## Teste

- [x] `esbuild` roda sem erro (ja validado localmente)
- [x] Script do TLDashboard.html passa por um parse de sintaxe via Node (ja validado localmente)
- [x] Testado a formatacao com Node isoladamente: `"2026-08-20T17:00:00.000Z"` -> `"20/08/2026 as 14:00"`, string vazia -> `"Não informado"`, multiplas datas separadas por `" | "` formatam cada uma
- [x] Abrir o formulario BAU numa pagina do CRM onde o site e capturado com sucesso: o campo Website nao aparece pedindo preenchimento (fica escondido, ja preenchido por baixo)
- [x] TL Dashboard: card da fila e modal de detalhes mostram a Disponibilidade formatada, sem "Z"/milissegundos, no horario que bate com o que o agente escolheu

🤖 Gerado com [Claude Code](https://claude.com/claude-code)