### PR TITLE
fix(tl-dashboard): make reason/description fields copyable in details modal

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -820,6 +820,20 @@
                 </div>
             </div>`;
 
+            // Mesma ideia do createRow acima, mas pra texto longo (motivo/justificativa) -
+            // display:block pra parágrafo quebrar linha normalmente, botão de copiar fixo
+            // no canto em vez de disputar espaço com o texto num flex row.
+            const createBlockRow = (label, value) => `
+            <div class="detail-group">
+                <span class="detail-label">${escapeHtml(label)}</span>
+                <div class="detail-value" style="display: block; font-style: italic; position: relative; padding-right: 48px;">
+                    "${value ? escapeHtml(value) : '---'}"
+                    <button class="copy-btn" data-copy-value="${escapeHtml(value || '')}" onclick="copyText(this)" style="position: absolute; top: 10px; right: 10px;">
+                        <span class="material-symbols-rounded" style="font-size: 18px;">content_copy</span>
+                    </button>
+                </div>
+            </div>`;
+
             document.getElementById('modal-body-content').innerHTML = `
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
                 ${createRow('Anunciante', c.advName)}
@@ -844,14 +858,8 @@
             ${createRow('Site', c.site)}
             ${createRow('Agendamento', formatAvailability(c.availability))}
             ${createRow('Agente', c.agentEmail)}
-            <div class="detail-group">
-                <span class="detail-label">O que deve ser feito</span>
-                <div class="detail-value" style="display: block; font-style: italic;">"${escapeHtml(c.reason)}"</div>
-            </div>
-            <div class="detail-group">
-                <span class="detail-label">Justificativa / Detalhes</span>
-                <div class="detail-value" style="display: block; font-style: italic;">"${c.description ? escapeHtml(c.description) : '---'}"</div>
-            </div>
+            ${createBlockRow('O que deve ser feito', c.reason)}
+            ${createBlockRow('Justificativa / Detalhes', c.description)}
             `;
             document.getElementById('caseModal').classList.add('active');
         }


### PR DESCRIPTION
## Resumo

Pequeno ajuste: "O que deve ser feito" (motivo) e "Justificativa / Detalhes" no modal de detalhes do TL Dashboard eram os unicos dois campos sem botao de copiar - eram renderizados fora do createRow() (usavam display:block direto pra o paragrafo quebrar linha normalmente em vez do layout flex de uma linha so), e por isso nunca ganharam o botao que todo o resto dos campos ja tinha.

**Fix:** novo `createBlockRow()`, mesma logica do `createRow()` existente mas com o botao de copiar posicionado no canto (absolute) em vez de disputar espaco com o texto num flex row - preserva a quebra de linha de paragrafos longos e adiciona o botao que faltava. Agora todo campo do modal de detalhes e copiavel.

## Teste

- [x] Script do TLDashboard.html passa por um parse de sintaxe via Node (ja validado localmente)
- [x] Abrir os detalhes de qualquer caso: "O que deve ser feito" e "Justificativa / Detalhes" mostram o botao de copiar e o texto continua quebrando linha normalmente
- [x] Clicar em copiar em cada um dos dois copia o texto certo pra area de transferencia

🤖 Gerado com [Claude Code](https://claude.com/claude-code)