### PR TITLE
refactor(tl-dashboard): light-dominant visual redesign for dashboard and emails

### DIFF
--- a/gas-backend/EmailEngine.js
+++ b/gas-backend/EmailEngine.js
@@ -70,11 +70,11 @@ function sendDynamicTechSolEmail(destinatario, data, escalacaoId, tipoEmail, aut
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
     if (diffDays <= 1) {
-      return `<div style="background-color: #450a0a; border: 1px solid #ef4444; color: #fca5a5; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">🚨 URGENTE: Agendado para Hoje/Amanhã!</div>`;
+      return `<div style="background-color: #FCE8E6; border: 1px solid rgba(217, 48, 37, 0.35); color: #D93025; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">🚨 URGENTE: Agendado para Hoje/Amanhã!</div>`;
     } else if (diffDays <= 3) {
-      return `<div style="background-color: #422006; border: 1px solid #f97316; color: #fdba74; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">⚠️ ATENÇÃO: Agendado para os próximos 3 dias</div>`;
+      return `<div style="background-color: #FEF7E0; border: 1px solid rgba(249, 171, 0, 0.35); color: #B06000; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">⚠️ ATENÇÃO: Agendado para os próximos 3 dias</div>`;
     } else {
-      return `<div style="background-color: #064e3b; border: 1px solid #10b981; color: #6ee7b7; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">📅 STATUS VERDE: Agendado para +5 dias</div>`;
+      return `<div style="background-color: #E6F4EA; border: 1px solid rgba(30, 142, 62, 0.35); color: #1E8E3E; padding: 12px; border-radius: 8px; margin-bottom: 24px; font-weight: 600; text-align: center; letter-spacing: 0.5px;">📅 STATUS VERDE: Agendado para +5 dias</div>`;
     }
   }
 

--- a/gas-backend/EmailTemplateDynamic.html
+++ b/gas-backend/EmailTemplateDynamic.html
@@ -10,20 +10,20 @@
         img { -ms-interpolation-mode: bicubic; }
         
         body {
-            margin: 0; 
-            padding: 0; 
-            background-color: #202124; 
-            font-family: 'Google Sans', Roboto, Helvetica, Arial, sans-serif; 
-            -webkit-font-smoothing: antialiased; 
-            color: #E8EAED;
+            margin: 0;
+            padding: 0;
+            background-color: #F8F9FA;
+            font-family: 'Google Sans', Roboto, Helvetica, Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            color: #202124;
         }
 
         /* Animação Grata de Entrada */
         .animate-up { animation: fadeUp 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) forwards; }
-        
+
         .ambient-glow-bg {
-            background-color: #202124;
-            background-image: radial-gradient(ellipse at top center, rgba(155, 114, 203, 0.12) 0%, rgba(32, 33, 36, 0) 70%);
+            background-color: #F8F9FA;
+            background-image: radial-gradient(ellipse at top center, rgba(66, 133, 244, 0.06) 0%, rgba(248, 249, 250, 0) 70%);
         }
 
         @keyframes fadeUp {
@@ -36,17 +36,17 @@
         .word-break { word-break: break-word; word-wrap: break-word; overflow-wrap: break-word; }
     </style>
 </head>
-<body style="margin: 0; padding: 0; background-color: #202124; font-family: 'Google Sans', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; color: #E8EAED;">
-    
-    <table width="100%" cellpadding="0" cellspacing="0" border="0" class="ambient-glow-bg" style="background-color: #202124;">
+<body style="margin: 0; padding: 0; background-color: #F8F9FA; font-family: 'Google Sans', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; color: #202124;">
+
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" class="ambient-glow-bg" style="background-color: #F8F9FA;">
         <tr>
             <td align="center" style="padding: 64px 20px;">
-                
-                <table class="animate-up" width="100%" max-width="640" cellpadding="0" cellspacing="0" border="0" style="max-width: 640px; width: 100%; background-color: #2D2F31; border-radius: 32px; overflow: hidden; box-shadow: 0 16px 40px rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.12); margin: 0 auto;">
-                    
+
+                <table class="animate-up" width="100%" max-width="640" cellpadding="0" cellspacing="0" border="0" style="max-width: 640px; width: 100%; background-color: #FFFFFF; border-radius: 32px; overflow: hidden; box-shadow: 0 8px 24px rgba(0,0,0,0.08); border: 1px solid #DADCE0; margin: 0 auto;">
+
                     <tr>
                         <td style="padding: 0;">
-                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: rgba(45,47,49,0.9); border-bottom: 1px solid rgba(255,255,255,0.12);">
+                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #131314; border-bottom: 1px solid rgba(255,255,255,0.12);">
                                 <tr>
                                     <td align="center" style="padding: 32px 32px 24px 32px; position: relative;">
                                         <div style="position: absolute; bottom: -1px; left: 0; width: 100%; height: 2px; background: linear-gradient(90deg, #4285f4, #9b72cb, #d96570); opacity: 0.8;"></div>
@@ -70,16 +70,16 @@
                             <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom: 24px;">
                                 <tr>
                                     <td>
-                                        <p style="margin: 0 0 8px 0; font-size: 18px; color: #FFFFFF; font-weight: 500; letter-spacing: -0.2px;">{{GREETING}}</p>
-                                        <div style="font-size: 13px; color: #9AA0A6; font-weight: 500;">
-                                            Solicitado por: 
-                                            <a href="https://moma.corp.google.com/chat?with={{SENDER_LDAP}}" target="_blank" style="color: #8AB4F8; text-decoration: none; font-weight: 600;">@{{SENDER_LDAP}}</a>
+                                        <p style="margin: 0 0 8px 0; font-size: 18px; color: #202124; font-weight: 500; letter-spacing: -0.2px;">{{GREETING}}</p>
+                                        <div style="font-size: 13px; color: #5F6368; font-weight: 500;">
+                                            Solicitado por:
+                                            <a href="https://moma.corp.google.com/chat?with={{SENDER_LDAP}}" target="_blank" style="color: #1A73E8; text-decoration: none; font-weight: 600;">@{{SENDER_LDAP}}</a>
                                         </div>
                                     </td>
                                 </tr>
                             </table>
-                            
-                            <p style="margin: 0 0 32px 0; font-size: 15px; line-height: 1.6; color: #F8F9FA;">
+
+                            <p style="margin: 0 0 32px 0; font-size: 15px; line-height: 1.6; color: #3C4043;">
                                 {{MAIN_MESSAGE}}
                             </p>
                             
@@ -87,17 +87,17 @@
                                 {{URGENCY_BADGE}}
                             </div>
                             
-                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #202124; border-radius: 24px; margin-bottom: 32px; border: 1px solid rgba(255,255,255,0.06);">
+                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #F8F9FA; border-radius: 24px; margin-bottom: 32px; border: 1px solid #DADCE0;">
                                 <tr>
                                     <td style="padding: 24px;">
                                         <table width="100%" cellpadding="0" cellspacing="0" border="0">
                                             <tr>
                                                 <td valign="top" width="28" style="padding-right: 16px;">
-                                                    <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/format_quote/default/48px.svg" width="28" height="28" alt="Quote" style="filter: invert(65%) sepia(35%) saturate(836%) hue-rotate(235deg) brightness(102%) contrast(96%); display: block;" />
+                                                    <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/format_quote/default/48px.svg" width="28" height="28" alt="Quote" style="display: block;" />
                                                 </td>
                                                 <td valign="top">
-                                                    <div style="font-size: 12px; color: #9AA0A6; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; font-weight: 600;">Contexto / Motivo</div>
-                                                    <div style="font-size: 15px; color: #FFFFFF; line-height: 1.6;">
+                                                    <div style="font-size: 12px; color: #5F6368; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; font-weight: 600;">Contexto / Motivo</div>
+                                                    <div style="font-size: 15px; color: #202124; line-height: 1.6;">
                                                         "{{REASON}}"
                                                     </div>
                                                 </td>
@@ -107,47 +107,47 @@
                                 </tr>
                             </table>
 
-                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #3C4043; border-radius: 24px; border: 1px solid rgba(255,255,255,0.08); margin-bottom: 32px;">
+                            <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #F8F9FA; border-radius: 24px; border: 1px solid #DADCE0; margin-bottom: 32px;">
                                 <tr>
                                     <td style="padding: 24px;">
-                                        
-                                        <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom: 24px; border-bottom: 1px solid rgba(255,255,255,0.08); padding-bottom: 24px;">
+
+                                        <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom: 24px; border-bottom: 1px solid #DADCE0; padding-bottom: 24px;">
                                             <tr>
                                                 <td valign="top" style="width: 30%; padding-right: 16px;">
-                                                    <div style="font-size: 12px; color: #9AA0A6; font-weight: 500; margin-bottom: 6px;">Case Connect</div>
-                                                    <a href="https://cases.connect.corp.google.com/#/case/{{CASE_ID}}" target="_blank" style="font-size: 15px; color: #8AB4F8; font-weight: 500; text-decoration: none; display: inline-block;">
+                                                    <div style="font-size: 12px; color: #5F6368; font-weight: 500; margin-bottom: 6px;">Case Connect</div>
+                                                    <a href="https://cases.connect.corp.google.com/#/case/{{CASE_ID}}" target="_blank" style="font-size: 15px; color: #1A73E8; font-weight: 500; text-decoration: none; display: inline-block;">
                                                         <span style="vertical-align: middle;">{{CASE_ID}}</span>
-                                                        <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/arrow_outward/default/48px.svg" width="14" height="14" alt="" style="filter: invert(80%) sepia(21%) saturate(760%) hue-rotate(186deg) brightness(102%) contrast(97%); vertical-align: middle; margin-left: 2px;" />
+                                                        <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/arrow_outward/default/48px.svg" width="14" height="14" alt="" style="vertical-align: middle; margin-left: 2px;" />
                                                     </a>
                                                 </td>
-                                                
+
                                                 <td valign="top" style="width: 35%; padding-right: 16px;">
-                                                    <div style="font-size: 12px; color: #9AA0A6; font-weight: 500; margin-bottom: 6px;">Domínio Final</div>
-                                                    <div class="word-break" style="font-size: 15px; color: #A8C7FA; font-weight: 600;">{{SITE}}</div>
+                                                    <div style="font-size: 12px; color: #5F6368; font-weight: 500; margin-bottom: 6px;">Domínio Final</div>
+                                                    <div class="word-break" style="font-size: 15px; color: #1A73E8; font-weight: 600;">{{SITE}}</div>
                                                 </td>
-                                                
+
                                                 <td valign="top" style="width: 35%;">
-                                                    <div style="font-size: 12px; color: #9AA0A6; font-weight: 500; margin-bottom: 6px;">Agendamento (SLA)</div>
-                                                    <div style="font-size: 13px; color: #E8EAED; background-color: rgba(255,255,255,0.05); padding: 6px 10px; border-radius: 6px; display: inline-block; border: 1px solid rgba(255,255,255,0.08);">
-                                                        <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/schedule/default/48px.svg" width="14" height="14" alt="" style="filter: invert(99%) sepia(2%) saturate(464%) hue-rotate(187deg) brightness(96%) contrast(90%); vertical-align: middle; margin-right: 6px;" />
+                                                    <div style="font-size: 12px; color: #5F6368; font-weight: 500; margin-bottom: 6px;">Agendamento (SLA)</div>
+                                                    <div style="font-size: 13px; color: #202124; background-color: #FFFFFF; padding: 6px 10px; border-radius: 6px; display: inline-block; border: 1px solid #DADCE0;">
+                                                        <img src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/schedule/default/48px.svg" width="14" height="14" alt="" style="vertical-align: middle; margin-right: 6px;" />
                                                         <span class="text-mono" style="vertical-align: middle;">{{AVAILABILITY}}</span>
                                                     </div>
                                                 </td>
                                             </tr>
                                         </table>
-                                        
+
                                         <table width="100%" cellpadding="0" cellspacing="0" border="0">
                                             <tr>
                                                 <td valign="top" style="width: 30%; padding-right: 16px;">
-                                                    <div style="font-size: 12px; color: #9AA0A6; font-weight: 500; margin-bottom: 6px;">Customer ID</div>
-                                                    <div class="text-mono" style="font-size: 14px; color: #8AB4F8; background-color: rgba(138, 180, 248, 0.1); padding: 6px 10px; border-radius: 6px; display: inline-block; border: 1px solid rgba(138, 180, 248, 0.2);">
+                                                    <div style="font-size: 12px; color: #5F6368; font-weight: 500; margin-bottom: 6px;">Customer ID</div>
+                                                    <div class="text-mono" style="font-size: 14px; color: #1A73E8; background-color: #E8F0FE; padding: 6px 10px; border-radius: 6px; display: inline-block; border: 1px solid rgba(26, 115, 232, 0.2);">
                                                         {{CID}}
                                                     </div>
                                                 </td>
-                                                
+
                                                 <td valign="top" style="width: 70%;">
-                                                    <div style="font-size: 12px; color: #9AA0A6; font-weight: 500; margin-bottom: 6px;">Procedimento / Task BAU</div>
-                                                    <div class="word-break" style="font-size: 15px; color: #FFFFFF; line-height: 1.5;">{{TASK}}</div>
+                                                    <div style="font-size: 12px; color: #5F6368; font-weight: 500; margin-bottom: 6px;">Procedimento / Task BAU</div>
+                                                    <div class="word-break" style="font-size: 15px; color: #202124; line-height: 1.5;">{{TASK}}</div>
                                                 </td>
                                             </tr>
                                         </table>
@@ -172,24 +172,24 @@
                     </tr>
                     
                     <tr>
-                        <td style="padding: 32px; text-align: center; border-top: 1px solid rgba(255,255,255,0.08);">
-                            
+                        <td style="padding: 32px; text-align: center; border-top: 1px solid #DADCE0;">
+
                             <div style="margin-bottom: 24px;">
-                                <span style="display: inline-block; background-color: rgba(255,255,255,0.05); color: #E8EAED; font-size: 12px; font-weight: 500; padding: 8px 20px; border-radius: 24px; border: 1px solid rgba(255,255,255,0.08);">
-                                    Automated by <a href="https://moma.corp.google.com/chat?with=lucaste" target="_blank" style="color: #8AB4F8; text-decoration: none; font-weight: 600;">@lucaste</a>
+                                <span style="display: inline-block; background-color: #F8F9FA; color: #5F6368; font-size: 12px; font-weight: 500; padding: 8px 20px; border-radius: 24px; border: 1px solid #DADCE0;">
+                                    Automated by <a href="https://moma.corp.google.com/chat?with=lucaste" target="_blank" style="color: #1A73E8; text-decoration: none; font-weight: 600;">@lucaste</a>
                                 </span>
                             </div>
 
-                            <p style="margin: 0 0 16px 0; font-size: 12px; color: #9AA0A6;">
-                                Rastreio: <span class="text-mono" style="color: #E8EAED; background: rgba(0,0,0,0.2); padding: 2px 6px; border-radius: 4px;">{{ID_ESCALACAO}}</span>
+                            <p style="margin: 0 0 16px 0; font-size: 12px; color: #5F6368;">
+                                Rastreio: <span class="text-mono" style="color: #202124; background: #F1F3F4; padding: 2px 6px; border-radius: 4px;">{{ID_ESCALACAO}}</span>
                             </p>
 
                             <div>
-                                <a href="https://forms.gle/AJX3NXz1TpJRm3mC7" target="_blank" style="color: #8AB4F8; text-decoration: none; font-size: 12px; font-weight: 500; display: inline-block; opacity: 0.8;">
+                                <a href="https://forms.gle/AJX3NXz1TpJRm3mC7" target="_blank" style="color: #1A73E8; text-decoration: none; font-size: 12px; font-weight: 500; display: inline-block; opacity: 0.8;">
                                     Report Bug / Feature Request
                                 </a>
                             </div>
-                            
+
                         </td>
                     </tr>
 

--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -10,36 +10,50 @@
         rel="stylesheet" />
     <style>
         :root {
-            /* Paleta Gemini AI */
-            --bg-base: #131314;
-            --surface-level-1: #1e1f20;
-            --surface-level-2: #282a2c;
-            --surface-level-3: #3c4043;
-            --border-subtle: rgba(255, 255, 255, 0.08);
+            /* Paleta clara predominante (Material) - os módulos irmãos da mesma
+               família (bau-form, email-assistant) já são claros; esse dashboard
+               100% escuro era a exceção, não a regra. */
+            --bg-base: #F1F3F4;
+            --surface-level-1: #FFFFFF;
+            --surface-level-2: #F8F9FA;
+            --surface-level-3: #E8EAED;
+            --border-subtle: #DADCE0;
 
-            --text-primary: #e3e3e3;
-            --text-secondary: #c4c7c5;
-            --text-tertiary: #8e918f;
+            --text-primary: #202124;
+            --text-secondary: #5F6368;
+            --text-tertiary: #5F6368;
 
             /* Vibrancy Tokens */
             --label: var(--text-primary);
             --secondaryLabel: var(--text-tertiary);
 
-            /* Gradientes e Auras */
-            --gemini-blue: #a8c7fa;
-            --gemini-purple: #c58af9;
-            --gemini-peach: #f2b8b5;
+            /* Cores de identidade - mesma paleta Material já usada em
+               src/modules/bau-form/bau-form-styles.js pro resto da família BAU */
+            --gemini-blue: #1A73E8;
+            --gemini-blue-light: #E8F0FE;
+            --gemini-purple: #9B72CB;
             --gemini-gradient: linear-gradient(90deg, #4285f4, #9b72cb, #d96570);
-            --gemini-gradient-subtle: linear-gradient(90deg, rgba(66, 133, 244, 0.15), rgba(155, 114, 203, 0.15));
+            --gemini-gradient-subtle: #E8F0FE;
 
-            --success: #81c995;
-            --danger: #f28b82;
-            --warning-aura: rgba(217, 48, 37, 0.12);
+            --success: #1E8E3E;
+            --danger: #D93025;
+            --danger-light: #FCE8E6;
+            --warning: #F9AB00;
+            --warning-light: #FEF7E0;
+            --warning-text: #B06000;
 
             --radius-sm: 8px;
             --radius-md: 16px;
             --radius-lg: 24px;
             --radius-pill: 100px;
+
+            /* Nav (topo) continua escura de propósito - âncora visual do
+               produto, "um pouco dark, um pouco light" em vez do corpo inteiro. */
+            --nav-bg: #131314;
+            --nav-surface: #1E1F20;
+            --nav-border: rgba(255, 255, 255, 0.08);
+            --nav-text-primary: #E3E3E3;
+            --nav-text-secondary: #9AA0A6;
 
             /* Motion */
             --spring-expressive: cubic-bezier(0.175, 0.885, 0.32, 1.275);
@@ -61,14 +75,14 @@
             left: 10vw;
             width: 80vw;
             height: 50vh;
-            background: radial-gradient(ellipse at center, rgba(155, 114, 203, 0.08) 0%, rgba(19, 19, 20, 0) 70%);
+            background: radial-gradient(ellipse at center, rgba(66, 133, 244, 0.06) 0%, rgba(241, 243, 244, 0) 70%);
             z-index: -1;
             pointer-events: none;
         }
 
-        /* Top Navigation */
+        /* Top Navigation - continua escura de propósito, âncora visual do produto */
         .topnav {
-            background: rgba(19, 19, 20, 0.7);
+            background: rgba(19, 19, 20, 0.92);
             backdrop-filter: blur(20px);
             -webkit-backdrop-filter: blur(20px);
             padding: 0 32px;
@@ -79,7 +93,7 @@
             position: sticky;
             top: 0;
             z-index: 100;
-            border-bottom: 1px solid var(--border-subtle);
+            border-bottom: 1px solid var(--nav-border);
             background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.05), transparent);
         }
 
@@ -91,7 +105,7 @@
             width: 100%;
             height: 1px;
             background: var(--gemini-gradient);
-            opacity: 0.5;
+            opacity: 0.7;
         }
 
         .brand-container {
@@ -107,11 +121,12 @@
             font-size: 20px;
             font-weight: 500;
             letter-spacing: -0.5px;
+            color: var(--nav-text-primary);
         }
 
         .brand-powered {
             font-size: 11px;
-            color: var(--text-tertiary);
+            color: var(--nav-text-secondary);
             text-transform: uppercase;
             letter-spacing: 1px;
             font-weight: 600;
@@ -165,14 +180,14 @@
         }
 
         .tab-btn.active {
-            background: var(--text-primary);
-            color: var(--bg-base);
-            border-color: var(--text-primary);
-            box-shadow: 0 4px 12px rgba(168, 199, 250, 0.3);
+            background: var(--gemini-blue);
+            color: #FFFFFF;
+            border-color: var(--gemini-blue);
+            box-shadow: 0 4px 12px rgba(26, 115, 232, 0.3);
         }
 
         .tab-btn .badge-count {
-            background: rgba(0,0,0,0.1);
+            background: rgba(0,0,0,0.06);
             padding: 2px 8px;
             border-radius: 10px;
             font-size: 11px;
@@ -180,7 +195,8 @@
         }
 
         .tab-btn.active .badge-count {
-            background: rgba(0,0,0,0.2);
+            background: rgba(255,255,255,0.25);
+            color: #FFFFFF;
         }
 
         /* Workspace & Grid */
@@ -196,7 +212,7 @@
             padding: 0 24px 16px 24px;
             font-size: 13px;
             font-weight: 500;
-            color: var(--text-tertiary);
+            color: var(--text-secondary);
             border-bottom: 1px solid var(--border-subtle);
             margin-bottom: 16px;
         }
@@ -210,23 +226,31 @@
             display: flex;
             flex-direction: column;
             gap: 20px;
-            transition: transform 0.4s var(--spring-expressive), opacity 0.3s ease, box-shadow 0.2s;
+            transition: transform 0.4s var(--spring-expressive), opacity 0.3s ease, box-shadow 0.2s, background 0.2s;
             position: relative;
             overflow: hidden;
             cursor: pointer;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
         }
 
         .case-row:hover {
             background: var(--surface-level-2);
-            border-color: rgba(255, 255, 255, 0.15);
+            border-color: #C4C7CC;
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
         }
+
+        /* Entrada suave das linhas ao renderizar */
+        @keyframes rowEnter {
+            from { opacity: 0; transform: translateY(8px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .case-row.row-enter { animation: rowEnter 0.35s var(--spring-functional) both; }
 
         /* Discard Queue Theme */
         .case-row.discard-theme {
             border-left: 4px solid var(--danger);
-            background: linear-gradient(to right, var(--warning-aura), transparent);
+            background: linear-gradient(to right, var(--danger-light), var(--surface-level-1) 45%);
         }
 
         .row-exit {
@@ -248,7 +272,7 @@
             font-family: 'Roboto Mono', monospace;
             font-size: 13px;
             color: var(--gemini-blue);
-            background: rgba(168, 199, 250, 0.08);
+            background: rgba(26, 115, 232, 0.08);
             padding: 2px 6px;
             border-radius: 4px;
         }
@@ -266,8 +290,8 @@
             width: fit-content;
         }
 
-        .badge-create { background: var(--gemini-gradient-subtle); color: var(--gemini-blue); border: 1px solid rgba(168, 199, 250, 0.2); }
-        .badge-discard { background: rgba(242, 139, 130, 0.1); color: var(--danger); border: 1px solid rgba(242, 139, 130, 0.2); }
+        .badge-create { background: var(--gemini-blue-light); color: var(--gemini-blue); border: 1px solid rgba(26, 115, 232, 0.2); }
+        .badge-discard { background: var(--danger-light); color: var(--danger); border: 1px solid rgba(217, 48, 37, 0.2); }
 
         .action-group { display: flex; gap: 12px; justify-content: flex-end; position: relative; z-index: 2; }
 
@@ -284,14 +308,20 @@
             transition: all 0.2s var(--spring-functional);
             border: 1px solid transparent;
         }
+        .btn:active { transform: scale(0.97); }
+        .btn:focus-visible, .tab-btn:focus-visible, .case-row:focus-visible {
+            outline: 2px solid var(--gemini-blue);
+            outline-offset: 2px;
+        }
 
-        .btn-primary { background: var(--text-primary); color: var(--bg-base); }
-        .btn-primary:hover { background: #ffffff; box-shadow: 0 0 20px rgba(168, 199, 250, 0.4); transform: scale(1.02); }
+        .btn-primary { background: var(--gemini-blue); color: #FFFFFF; }
+        .btn-primary:hover { background: #1557B0; box-shadow: 0 4px 14px rgba(26, 115, 232, 0.35); transform: scale(1.02); }
         .btn-danger-outline { background: transparent; color: var(--text-secondary); border-color: var(--border-subtle); }
-        .btn-danger-outline:hover { background: rgba(242, 139, 130, 0.1); color: var(--danger); border-color: rgba(242, 139, 130, 0.3); }
+        .btn-danger-outline:hover { background: var(--danger-light); color: var(--danger); border-color: rgba(217, 48, 37, 0.3); }
 
         .reason-box {
-            background: rgba(0, 0, 0, 0.2);
+            background: var(--surface-level-2);
+            border: 1px solid var(--border-subtle);
             border-radius: var(--radius-sm);
             padding: 16px 20px;
             font-size: 14px;
@@ -310,9 +340,9 @@
         .modal-overlay {
             position: fixed;
             top: 0; left: 0; width: 100%; height: 100%;
-            background: rgba(15, 15, 16, 0.9);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
+            background: rgba(32, 33, 36, 0.55);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
             display: flex;
             justify-content: center;
             align-items: center;
@@ -330,7 +360,7 @@
             border-radius: var(--radius-lg);
             width: 100%;
             max-width: 640px;
-            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.18);
             transform: scale(0.9);
             opacity: 0;
             transition: transform 0.6s var(--spring-expressive), opacity 0.4s ease;
@@ -357,9 +387,7 @@
         .confirm-icon {
             font-size: 48px !important;
             margin-bottom: 16px;
-            background: var(--gemini-gradient);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            /* cor definida dinamicamente via JS (confirmAction()): var(--success)/var(--danger) */
         }
         .confirm-footer {
             padding: 24px 32px;
@@ -371,9 +399,10 @@
 
         /* Detail Elements */
         .detail-group { display: flex; flex-direction: column; gap: 6px; }
-        .detail-label { font-size: 11px; color: var(--text-tertiary); text-transform: uppercase; font-weight: 600; letter-spacing: 0.5px; }
+        .detail-label { font-size: 11px; color: var(--text-secondary); text-transform: uppercase; font-weight: 600; letter-spacing: 0.5px; }
         .detail-value {
-            background: rgba(0, 0, 0, 0.2);
+            background: var(--surface-level-2);
+            border: 1px solid var(--border-subtle);
             padding: 12px 16px;
             border-radius: var(--radius-sm);
             font-size: 14px;
@@ -384,7 +413,7 @@
             word-break: break-word;
         }
 
-        .copy-btn { background: none; border: none; color: var(--text-tertiary); cursor: pointer; padding: 4px; display: flex; transition: color 0.2s; }
+        .copy-btn { background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 4px; display: flex; transition: color 0.2s; }
         .copy-btn:hover { color: var(--gemini-blue); }
 
         /* Agent Profile */
@@ -402,7 +431,7 @@
             border-radius: var(--radius-pill);
             font-size: 14px;
             font-weight: 500;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
             opacity: 0;
             transition: all 0.5s var(--spring-expressive);
             z-index: 2000;
@@ -418,8 +447,8 @@
 
         .empty-state { padding: 80px 20px; text-align: center; color: var(--text-secondary); display: flex; flex-direction: column; align-items: center; gap: 16px; }
 
-        .btn-icon-close { background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; padding: 8px; border-radius: 50%; transition: background 0.2s; }
-        .btn-icon-close:hover { background: rgba(255,255,255,0.1); color: var(--text-primary); }
+        .btn-icon-close { background: transparent; border: none; color: var(--text-secondary); cursor: pointer; padding: 8px; border-radius: 50%; transition: background 0.2s; }
+        .btn-icon-close:hover { background: rgba(0,0,0,0.06); color: var(--text-primary); }
 
         /* Skeleton Loading */
         .skeleton-row {
@@ -454,8 +483,7 @@
             background-image: linear-gradient(
                 90deg,
                 rgba(255, 255, 255, 0) 0,
-                rgba(255, 255, 255, 0.05) 20%,
-                rgba(255, 255, 255, 0.1) 60%,
+                rgba(255, 255, 255, 0.7) 50%,
                 rgba(255, 255, 255, 0)
             );
             animation: shimmer 2s infinite;
@@ -498,8 +526,8 @@
                 <div id="confirm-title" style="font-size: 20px; font-weight: 500; margin-bottom: 8px;">Confirmar Ação</div>
                 <div id="confirm-message" style="color: var(--text-secondary); font-size: 15px; line-height: 1.5;">Você tem certeza que deseja prosseguir com esta ação?</div>
 
-                <div id="confirm-context" style="margin-top: 16px; background: rgba(0,0,0,0.2); padding: 16px; border-radius: var(--radius-md); text-align: left;">
-                    <div style="font-size: 11px; color: var(--text-tertiary); text-transform: uppercase; margin-bottom: 8px;">Resumo do Caso</div>
+                <div id="confirm-context" style="margin-top: 16px; background: var(--surface-level-2); border: 1px solid var(--border-subtle); padding: 16px; border-radius: var(--radius-md); text-align: left;">
+                    <div style="font-size: 11px; color: var(--text-secondary); text-transform: uppercase; margin-bottom: 8px;">Resumo do Caso</div>
                     <div id="confirm-case-info" style="font-size: 14px; color: var(--text-primary); font-weight: 500;"></div>
                 </div>
             </div>
@@ -516,15 +544,15 @@
                 <span class="material-symbols-rounded brand-icon">auto_awesome</span>
                 Cases Wizard
             </div>
-            <div style="width: 1px; height: 24px; background: var(--border-subtle);"></div>
+            <div style="width: 1px; height: 24px; background: var(--nav-border);"></div>
             <div class="brand-powered">
-                <span style="color: var(--text-primary); font-size: 14px; letter-spacing: -0.2px;">BAU Central</span>
+                <span style="color: var(--nav-text-primary); font-size: 14px; letter-spacing: -0.2px;">BAU Central</span>
                 <span>TL Dashboard</span>
             </div>
         </div>
         <div style="display: flex; align-items: center; gap: 16px;">
-            <span id="last-synced-label" style="font-size: 12px; color: var(--text-tertiary);"></span>
-            <button class="btn" style="background: var(--surface-level-2); border: 1px solid var(--border-subtle); color: var(--text-secondary);" onclick="loadCases()">
+            <span id="last-synced-label" style="font-size: 12px; color: var(--nav-text-secondary);"></span>
+            <button class="btn" style="background: var(--nav-surface); border: 1px solid var(--nav-border); color: var(--nav-text-secondary);" onclick="loadCases()">
                 <span class="material-symbols-rounded" style="font-size: 20px;">sync</span>
                 Sincronizar
             </button>
@@ -723,17 +751,18 @@
             if (filtered.length === 0) {
                 container.innerHTML = `
                 <div class="empty-state">
-                    <span class="material-symbols-rounded" style="font-size: 48px; color: var(--border-subtle);">task_alt</span>
+                    <span class="material-symbols-rounded" style="font-size: 48px; color: var(--success);">task_alt</span>
                     <div style="font-size: 18px; font-weight: 500; color: var(--text-primary);">Fila limpa</div>
                     <div style="font-size: 14px;">Não há solicitações pendentes nesta categoria.</div>
                 </div>`;
                 return;
             }
 
-            filtered.forEach(c => {
+            filtered.forEach((c, idx) => {
                 const isDiscardFlow = c.status === "PENDING_TL_DISCARD";
                 const row = document.createElement('div');
-                row.className = `case-row ${isDiscardFlow ? 'discard-theme' : ''}`;
+                row.className = `case-row row-enter ${isDiscardFlow ? 'discard-theme' : ''}`;
+                row.style.animationDelay = `${idx * 30}ms`;
                 row.id = `row-${c.id}`;
                 row.onclick = () => openDetails(c.id);
 
@@ -977,9 +1006,8 @@
                 toast.style.color = "white";
                 icon.textContent = "error";
             } else if (type === "warning") {
-                // TODO(PR B): trocar pelos tokens --yellow/--amber-text da nova paleta clara
-                toast.style.background = "#F9AB00";
-                toast.style.color = "#202124";
+                toast.style.background = "var(--warning)";
+                toast.style.color = "var(--warning-text)";
                 icon.textContent = "warning";
             } else {
                 toast.style.background = "";

--- a/gas-backend/Teste.js
+++ b/gas-backend/Teste.js
@@ -19,11 +19,14 @@ function dispararTestesDeEmails() {
   
   // 3. Email de Sucesso (TL criou o caso)
   sendDynamicTechSolEmail(meuEmail, dataMock, id, 'AGENT_BAU_CREATED');
-  
-  // 4. Email de Descarte (Aprovado)
+
+  // 4. Email de Pedido de Descarte Enviado (Agente solicitou, aguardando TL)
+  sendDynamicTechSolEmail(meuEmail, dataMock, id, 'AGENT_DISCARD_SENT');
+
+  // 5. Email de Descarte (Aprovado)
   sendDynamicTechSolEmail(meuEmail, dataMock, id, 'AGENT_DISCARD_DONE');
-  
-  Logger.log("✅ 4 e-mails enviados para sua caixa de entrada. Veja as diferenças!");
+
+  Logger.log("✅ 5 e-mails enviados para sua caixa de entrada. Veja as diferenças!");
 }
 
 /**


### PR DESCRIPTION
## Resumo

Segunda das 3 partes do plano do TL Dashboard: revisão completa de estilo/UI/UX do dashboard e dos emails, que estavam 100% no tema escuro "Gemini AI" - a exceção dentro do próprio projeto, já que os módulos irmãos da mesma família (`bau-form`, o formulário que o agente preenche, e `email-assistant`) já são claros. Contraste ruim e falta de identidade profissional eram as queixas.

Nova paleta clara predominante (reaproveitando as cores Material já usadas em `bau-form-styles.js`: azul `#1A73E8`, vermelho `#D93025`, verde `#1E8E3E`, amarelo `#F9AB00`), com a nav do dashboard e a faixa do cabeçalho do email continuando escuras de propósito - identidade visual do produto, "um pouco dark, um pouco light" em vez do corpo inteiro.

### TLDashboard.html
- Todos os tokens de cor do `:root` redefinidos pra valores claros; a nav ganhou tokens próprios (`--nav-*`) pra continuar escura sem quebrar contraste - pego durante a revisão: o texto "BAU Central", o botão Sincronizar e o indicador de sincronização ficariam quase invisíveis se só herdassem os tokens globais agora claros.
- Badges/chips com pares fundo-claro + texto-saturado (mesmo padrão de contraste que `bau-form` já usa).
- Removido o hack de gradiente-como-texto do ícone de confirmação, deixando a cor dinâmica do JS (`var(--success)`/`var(--danger)`) controlar sozinha.
- Animação leve de entrada nas linhas da fila (fade+slide escalonado), estados de foco visíveis, feedback de clique nos botões.
- Ícone do estado "Fila limpa" trocado de um cinza quase invisível pra verde (`--success`) - fazia sentido decorativo e resolvia um contraste ruim de uma vez.

### EmailTemplateDynamic.html
Corpo/card claros, faixa do cabeçalho continua escura com o gradiente de marca (a cor por tipo de email, `{{THEME_COLOR}}`, já era pensada pra essa faixa escura - não precisou mudar). Caixas de contexto/dados neutras (cinza claro), sem tingir por tipo - email não mistura cor de forma limpa, então a cor semântica fica só no ícone/faixa do cabeçalho. Ícones dos SVGs tiveram o filtro de inversão removido (eram cor escura invertida pra aparecer no card escuro - no card claro novo, a cor padrão do SVG já aparece sozinha).

### EmailEngine.js
`getUrgencyHtml()` migrado pras variantes claras dos 3 níveis de urgência.

### Teste.js
`dispararTestesDeEmails()` ganhou a 5ª chamada que faltava (`AGENT_DISCARD_SENT`), pra cobrir todos os tipos de email na hora de conferir visualmente depois do deploy.

## Teste

- [x] `gas-backend/TLDashboard.html`'s script passou por parse de sintaxe via Node
- [x] `EmailEngine.js`/`Teste.js` passaram por `node -c`
- [ ] Visual (humano, pós-deploy): olhar o dashboard em todos os estados (vazio/carregando/populado/erro, as duas abas, os dois modais, os 3 tipos de toast)
- [ ] Disparar `dispararTestesDeEmails()` (Apps Script editor) e conferir os 5 tipos de email no Gmail/Outlook

🤖 Gerado com [Claude Code](https://claude.com/claude-code)