### PR TITLE
fix(tl-dashboard): avatar URL, initial load hanging forever

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -612,7 +612,10 @@
     <script>
         window.onload = () => {
             loadCases();
-            loadCurrentTLProfile();
+            // getCurrentTLProfile() só é disparado depois que o primeiro loadCases()
+            // termina (ver loadCases() abaixo) - dois google.script.run em paralelo
+            // logo no carregamento inicial travavam o "Acessando base de dados..."
+            // pra sempre (só um clique manual em Sincronizar, sozinho, funcionava).
             // Sincronização automática em segundo plano: silenciosa (sem skeleton),
             // pausa enquanto qualquer modal estiver aberto pra não puxar o tapete
             // de uma revisão em andamento. 60s é ponto de partida, fácil de ajustar.
@@ -632,7 +635,7 @@
                 .withSuccessHandler(profile => {
                     if (!profile || !profile.ldap) return;
                     const avatar = document.getElementById('tl-avatar');
-                    avatar.src = 'https://moma-teams-photos.corp.google.com/photos/' + encodeURIComponent(profile.ldap) + '?sz=600';
+                    avatar.src = 'https://moma-teams-photos.corp.google.com/photos/' + encodeURIComponent(profile.ldap) + '?sz=600&type=PLUS';
 
                     const g = getTLGreeting(profile.ldap);
                     document.getElementById('welcome-greeting').textContent = g.greeting;
@@ -748,6 +751,13 @@
         let loadError = false;
         let lastSyncedAt = null;
         let syncInFlight = false;
+        let tlProfileLoaded = false;
+
+        function loadCurrentTLProfileOnce() {
+            if (tlProfileLoaded) return;
+            tlProfileLoaded = true;
+            loadCurrentTLProfile();
+        }
 
         function isAnyModalOpen() {
             return document.getElementById('caseModal').classList.contains('active') ||
@@ -834,6 +844,7 @@
                     loadError = false;
                     updateBadges();
                     renderCases();
+                    loadCurrentTLProfileOnce();
                 })
                 .withFailureHandler(err => {
                     syncInFlight = false;
@@ -848,6 +859,7 @@
                         updateBadges();
                         renderCases();
                     }
+                    loadCurrentTLProfileOnce();
                 })
                 .getPendingBAUCases();
         }


### PR DESCRIPTION
## Resumo

### 1. Foto do TL usava o link errado
A foto usava o mesmo padrão de URL da foto do agente nos cards (`moma-teams-photos.corp.google.com/photos/{ldap}?sz=600`) - uma referência cruzada a outra pessoa. O padrão certo pra foto do próprio usuário logado já existe em `src/modules/configs/configs-assistant.js` (usado na seção de perfil do módulo de Configurações): mesmo domínio, com `&type=PLUS` no final. Ajustado pra usar o link que já tínhamos.

### 2. Carregamento inicial travava pra sempre
`window.onload` disparava `loadCases()` e `loadCurrentTLProfile()` em sequência síncrona - dois `google.script.run` simultâneos logo de cara, o que trava um dos dois indefinidamente (era por isso que um clique manual isolado em Sincronizar, sem concorrência, sempre funcionava). Agora `getCurrentTLProfile()` só é chamado depois que o primeiro `loadCases()` termina (sucesso ou falha), nunca em paralelo - guardado por uma flag pra disparar uma única vez.

## Teste

- [x] Script passou por parse de sintaxe via Node
- [ ] Visual (pós-deploy): abrir o dashboard pela primeira vez - os casos aparecem sozinhos, sem precisar clicar em Sincronizar
- [ ] Foto do TL aparece corretamente (ou o ícone genérico, se falhar)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)