### PR TITLE
fix(tl-dashboard): self-healing watchdog for initial load still hanging

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -611,7 +611,13 @@
 
     <script>
         window.onload = () => {
-            loadCases();
+            // Pequeno atraso antes da primeiríssima chamada: em alguns carregamentos
+            // "frios", o bridge do google.script.run ainda não estava pronto bem no
+            // instante do window.onload dentro do iframe sandboxado do Apps Script,
+            // e a chamada travava sem nunca chamar success/failure. loadCases() também
+            // tem seu próprio watchdog (abaixo) como rede de segurança pra esse mesmo
+            // sintoma, então essa espera aqui é só a primeira linha de defesa.
+            setTimeout(loadCases, 50);
             // getCurrentTLProfile() só é disparado depois que o primeiro loadCases()
             // termina (ver loadCases() abaixo) - dois google.script.run em paralelo
             // logo no carregamento inicial travavam o "Acessando base de dados..."
@@ -752,6 +758,7 @@
         let lastSyncedAt = null;
         let syncInFlight = false;
         let tlProfileLoaded = false;
+        let loadCasesWatchdog = null;
 
         function loadCurrentTLProfileOnce() {
             if (tlProfileLoaded) return;
@@ -835,8 +842,20 @@
                 `;
             }
 
+            // Watchdog: já vimos ao vivo a primeiríssima chamada de google.script.run
+            // da página travar de vez, sem nunca chamar success nem failure, ficando
+            // presa em "Acessando base de dados..." até um clique manual em Sincronizar.
+            // Se isso acontecer de novo, tenta sozinho em vez de depender do TL notar.
+            clearTimeout(loadCasesWatchdog);
+            loadCasesWatchdog = setTimeout(() => {
+                console.warn("loadCases() não respondeu a tempo, tentando de novo...");
+                syncInFlight = false;
+                loadCases(opts);
+            }, 10000);
+
             google.script.run
                 .withSuccessHandler(data => {
+                    clearTimeout(loadCasesWatchdog);
                     syncInFlight = false;
                     lastSyncedAt = new Date();
                     updateLastSyncedLabel();
@@ -847,6 +866,7 @@
                     loadCurrentTLProfileOnce();
                 })
                 .withFailureHandler(err => {
+                    clearTimeout(loadCasesWatchdog);
                     syncInFlight = false;
                     console.error("Erro ao carregar casos:", err);
                     // Uma falha de tick silencioso não deve interromper a tela com


### PR DESCRIPTION
## Resumo

A correção anterior (#236 - sequenciar `loadCases()`/`getCurrentTLProfile()` em vez de disparar em paralelo) não resolveu - você confirmou que o carregamento inicial continua preso em "Acessando base de dados..." pra sempre, só aparecendo os casos (e a foto, encadeada a eles) depois de um clique manual em Sincronizar. Ou seja, o problema não era só a concorrência entre as duas chamadas: a própria primeira chamada de `loadCases()`, sozinha, às vezes trava sem nunca chamar `success` nem `failure`.

Duas camadas de defesa, sem depender de entender 100% a causa exata (suspeita: o bridge do `google.script.run` às vezes não está pronto bem no instante do `window.onload` dentro do iframe sandboxado do Apps Script):

1. **Pequeno atraso (50ms)** antes da primeiríssima chamada, via `setTimeout` - dá uma folga pro ambiente terminar de se conectar.
2. **Watchdog em `loadCases()`**: se nem `success` nem `failure` responderem em 10s, assume que a chamada travou e tenta de novo sozinho, sem exigir que o TL perceba e clique em Sincronizar manualmente. Vale pra toda chamada (inicial, manual, silenciosa), não só a primeira.

## Teste

- [x] Script passou por parse de sintaxe via Node
- [ ] Visual (pós-deploy, o teste que importa): abrir o dashboard "frio" várias vezes (aba nova, F5) e confirmar que os casos aparecem sozinhos, sem precisar clicar em Sincronizar
- [ ] Se ainda travar: abrir o console do navegador e ver se aparece o aviso "loadCases() não respondeu a tempo, tentando de novo..." - isso confirma que o watchdog disparou e ajuda a diagnosticar se o problema é mais fundo (backend/quota)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)