### PR TITLE
fix(bau-alerts): pin volume-alert dashboard link to production deployment ID

### DIFF
--- a/gas-backend/BAU_Alerts.js
+++ b/gas-backend/BAU_Alerts.js
@@ -56,7 +56,11 @@ function checkBAUPendingVolume() {
 // dashboard/emails (gas-backend/TLDashboard.html, gas-backend/EmailTemplateDynamic.html),
 // pra nascer visualmente consistente.
 function sendBAUVolumeAlertEmail(pendingCount, creationCount, discardCount) {
-  const dashboardUrl = ScriptApp.getService().getUrl() + "?page=tl";
+  // Fixo (não ScriptApp.getService().getUrl()): esse email é enviado por gatilho de
+  // tempo, e nesse contexto getUrl() pode devolver a URL de OUTRA implantação do
+  // projeto (não a implantação fixa usada em produção, pinada via clasp deploy -i
+  // em .github/workflows/deploy.yml e referenciada em src/modules/shared/data-service.js).
+  const dashboardUrl = "https://script.google.com/a/macros/google.com/s/AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg/exec?page=tl";
 
   const html = `
     <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #F8F9FA;">


### PR DESCRIPTION
## Summary
- O e-mail de alerta de volume (>10 casos pendentes) montava o link do dashboard TL com `ScriptApp.getService().getUrl()`, que roda num contexto de gatilho de tempo e pode devolver a URL de uma implantação diferente da de produção.
- Isso mandava quem clicasse no e-mail pra uma implantação possivelmente desatualizada (sem os fixes recentes de carregamento do TL Dashboard), o que explicava o link redirecionar pra um ID de implantação diferente do usado no resto do projeto.
- Fix: link fixo apontando pro mesmo `DEPLOYMENT_ID` já pinado em `.github/workflows/deploy.yml` e usado em `src/modules/shared/data-service.js`.

## Test plan
- [ ] Merge nesta branch dispara o job `deploy-backend-gas`, que faz `clasp push` e promove a implantação `AKfycbxk...` (só roda em `refactor-structure`)
- [ ] Forçar `checkBAUPendingVolume()` (ou esperar o gatilho) e conferir que o e-mail de alerta chega com o link `https://script.google.com/a/macros/google.com/s/AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg/exec?page=tl`
- [ ] Clicar no link e confirmar que o TL Dashboard carrega sem travar

🤖 Generated with [Claude Code](https://claude.com/claude-code)