### PR TITLE
fix(tl-dashboard): trigger initial load on DOMContentLoaded, not window.onload

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -610,10 +610,24 @@
     </main>
 
     <script>
-        window.onload = () => {
+        // DOMContentLoaded, não window.onload: confirmado ao vivo (DevTools) que o
+        // loader ficava preso mesmo depois de 18s+, sem o watchdog de loadCases()
+        // (abaixo) sequer chegar a rodar uma vez - ou seja, o próprio window.onload
+        // nunca disparava. window.onload só dispara depois que TODO recurso da janela
+        // termina (imagens, iframes, bootstrap interno do Apps Script incluído) - e
+        // esse bootstrap (visto como uma chamada "wardeninit" presa por 18s+ na aba
+        // Network) pode demorar bem mais que isso em rede/proxy corporativo lento,
+        // travando pra sempre um listener que dependa de "load". DOMContentLoaded
+        // dispara assim que o HTML termina de ser processado, sem esperar esses
+        // recursos - e como esse <script> já roda depois de todo o HTML que ele usa
+        // (#loader, #cases-container, etc.), não há necessidade real de esperar mais
+        // que isso. Clicar em "Sincronizar" sempre funcionava porque o onclick chama
+        // loadCases() direto, sem depender de load nenhum - só reproduzindo esse
+        // mesmo comportamento aqui.
+        document.addEventListener('DOMContentLoaded', () => {
             // Pequeno atraso antes da primeiríssima chamada: em alguns carregamentos
             // "frios", o bridge do google.script.run ainda não estava pronto bem no
-            // instante do window.onload dentro do iframe sandboxado do Apps Script,
+            // instante do DOMContentLoaded dentro do iframe sandboxado do Apps Script,
             // e a chamada travava sem nunca chamar success/failure. loadCases() também
             // tem seu próprio watchdog (abaixo) como rede de segurança pra esse mesmo
             // sintoma, então essa espera aqui é só a primeira linha de defesa.
@@ -630,7 +644,7 @@
             document.addEventListener('visibilitychange', () => {
                 if (document.visibilityState === 'visible') loadCases({ silent: true });
             });
-        };
+        });
 
         // Faixa de boas-vindas: foto (mesmo padrão de URL já usado na foto do
         // agente nos cards) + saudação inteligente por horário/dia, mesma ideia


### PR DESCRIPTION
## Summary
- O loader do TL Dashboard ("Acessando base de dados...") ficava travado indefinidamente até um clique manual em "Sincronizar" — reproduzido ao vivo via DevTools.
- Evidência: mesmo após 18s+ travado, o log do watchdog de `loadCases()` (`"...tentando de novo"`) nunca aparecia no console — ou seja, `window.onload` nunca chegava a disparar.
- Causa: `window.onload` só dispara quando a janela inteira termina de carregar, incluindo o bootstrap interno do iframe sandboxado do Apps Script (visto na aba Network como uma chamada `wardeninit` presa por 18s+ em rede lenta/corporativa). O botão "Sincronizar" sempre funcionava porque seu `onclick` chama `loadCases()` direto, sem depender de nenhum evento de load.
- Fix: troca o gatilho da primeira chamada de `window.onload` para `document.addEventListener('DOMContentLoaded', ...)`, que dispara assim que o HTML termina de ser processado, sem esperar por esses recursos mais lentos e alheios ao nosso código.

## Test plan
- [ ] Merge dispara `deploy-backend-gas` (clasp push + promoção da implantação `AKfycbxk...`)
- [ ] Abrir `.../exec?page=tl` com DevTools aberto e confirmar que os casos carregam sozinhos, sem precisar clicar em "Sincronizar"
- [ ] Testar também em rede lenta/com throttling, já que foi nesse cenário que o bug apareceu

🤖 Generated with [Claude Code](https://claude.com/claude-code)