### PR TITLE
feat(motion): full-app UI/UX and motion-system audit remediation

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -509,6 +509,28 @@
             100% { transform: translateX(100%); }
         }
 
+        /* Mesma filosofia ja usada em src/modules/shared/command-center.js:
+           animacoes continuas (glow do logo, shimmer do skeleton) somem por
+           completo - sao so decoracao; transicoes de transform viram fade
+           simples, mantendo o feedback de estado sem o movimento. */
+        @media (prefers-reduced-motion: reduce) {
+            .brand-icon { animation: none !important; }
+            .skeleton-row::after { animation: none !important; }
+            .case-row, .case-row:hover, .case-row.row-enter, .row-exit {
+                animation: none !important;
+                transition: opacity 0.2s ease !important;
+                transform: none !important;
+            }
+            .modal-content, .modal-overlay.active .modal-content {
+                transition: opacity 0.2s ease !important;
+                transform: none !important;
+            }
+            .toast, .toast.show {
+                transition: opacity 0.2s ease !important;
+                transform: translateX(-50%) !important;
+            }
+        }
+
     </style>
 </head>
 

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import { DataService } from './modules/shared/data-service.js';
 
 // 2. Importação do Núcleo Compartilhado
 import { initCommandCenter } from './modules/shared/command-center.js';
+import { initCommandPalette } from './modules/shared/command-palette.js';
 import { initGlobalStylesAndFont, playStartupAnimation, showToast } from './modules/shared/utils.js';
 
 // --- Gerenciador de Som ---
@@ -40,9 +41,11 @@ function initApp() {
         initGlobalStylesAndFont();
 
         // --- Inicialização Sonora ---
+        // O som de boot ("TA-DUM") já é disparado dentro de playStartupAnimation(),
+        // sincronizado com o momento em que o "Bom dia" aparece na splash. Chamá-lo
+        // aqui também fazia o som tocar duas vezes se sobrepondo (cauda de 3.6s).
         try {
-            SoundManager.initGlobalListeners(); 
-            SoundManager.playStartup(); 
+            SoundManager.initGlobalListeners();
         } catch (audioErr) {
             console.warn("Áudio bloqueado:", audioErr);
         }
@@ -51,7 +54,10 @@ function initApp() {
         DataService.fetchTips();
 
         // C. Animação de Entrada (Aqui o 'Sherlock' começa a buscar o nome)
-        playStartupAnimation();
+        // playStartupAnimation() já é async e só resolve depois que a splash
+        // sai do DOM de vez - guardamos essa promise pra passar adiante em vez
+        // de deixar a pílula (abaixo) adivinhar seu próprio tempo de boot.
+        const splashDone = playStartupAnimation();
 
         // D. Inicializa os Módulos
         const toggleNotes = initCaseNotesAssistant();
@@ -63,10 +69,9 @@ function initApp() {
         const toggleConfigs = initConfigsAssistant();
         const toggleBAUForm = initBAUForm();
         
-        const broadcastControl = initBroadcastAssistant(); 
+        const broadcastControl = initBroadcastAssistant();
 
-        // E. Inicializa a Barra de Comando
-        initCommandCenter({
+        const moduleActions = {
             toggleNotes,
             toggleEmail,
             toggleScript,
@@ -76,7 +81,18 @@ function initApp() {
             toggleConfigs,
             toggleBAUForm,
             broadcastControl
-        });
+        };
+
+        // E. Inicializa a Barra de Comando
+        // A pílula só "dockeia" depois que a splash de fato terminou (ver
+        // splashDone acima) - antes ela tinha um tempo fixo próprio que quase
+        // nunca batia com a duração real da splash (variável, depende do
+        // tamanho do nome digitado no typewriter).
+        initCommandCenter(moduleActions, splashDone);
+
+        // E.1. Command Palette (Ctrl/Cmd+K) - mesma lista de módulos, só um
+        // jeito mais rápido de chegar neles sem tirar a mão do teclado.
+        initCommandPalette(moduleActions);
 
         // F. Logs e Modais (COM DELAY TÁTICO)
         // Esperamos 2.5s para garantir que a animação capturou o e-mail do agente
@@ -96,6 +112,7 @@ function initApp() {
 
     } catch (error) {
         console.error("Erro fatal na inicialização:", error);
+        SoundManager.playError();
         showToast("Erro crítico ao iniciar o Case Wizard.", { error: true });
     }
 }

--- a/src/modules/bau-form/bau-form-assistant.js
+++ b/src/modules/bau-form/bau-form-assistant.js
@@ -4,6 +4,7 @@ import { createStandardHeader } from '../shared/header-factory.js';
 import { toggleGenieAnimation } from '../shared/animations.js';
 import { showToast, formatToLocalUserDate, confirmDialog } from '../shared/utils.js';
 import { SoundManager } from '../shared/sound-manager.js';
+import { lockBodyScroll, unlockBodyScroll } from '../shared/dom-utils.js';
 import { sendBAUEscalation, readAgentBAU, updateBAUEscalation } from '../shared/data-service.js';
 import { getPageData } from '../shared/page-data.js';
 import { fetchAndInsertSpeakeasyId } from '../notes/automation/case-log-scraper.js';
@@ -130,6 +131,7 @@ function createField(fieldConfig) {
                     tzBtn.click();
                     SoundManager.playClick();
                 } else {
+                    SoundManager.playError();
                     showToast("Módulo Time Zone não encontrado.", { error: true });
                 }
             };
@@ -454,6 +456,7 @@ export function initBAUForm() {
                 </div>
             `;
             popup.querySelector('#bau-retry-btn')?.addEventListener('click', () => loadDashboardData());
+            SoundManager.playError();
             showToast("Erro ao carregar Dashboard. Verifique sua conexão.", { error: true });
         }
     }
@@ -839,6 +842,7 @@ export function initBAUForm() {
                     const regex = new RegExp(fieldConfig.validation.regex);
                     if (!regex.test(input.value.trim())) {
                         console.warn(`Validation failed for field "${fieldConfig.name}" in step ${step}: Regex mismatch.`);
+                        SoundManager.playError();
                         showToast(`Erro: ${fieldConfig.validation.error}`, { error: true });
                         input.classList.add('invalid-cid');
                         const errorHint = form.querySelector('#bau-cid-error');
@@ -876,6 +880,7 @@ export function initBAUForm() {
                     const checked = form.querySelector(`#bau-step-${step} input[name="${fieldConfig.name}"]:checked`);
                     if (!checked) {
                         failureReason = "No option selected in checkbox-grid";
+                        SoundManager.playError();
                         showToast(`Erro: Selecione pelo menos uma opção para "${fieldConfig.label}".`, { error: true });
                         isFieldValid = false;
                     }
@@ -885,6 +890,7 @@ export function initBAUForm() {
 
                     if (!firstInput.value.trim()) {
                         failureReason = "Datetime group first field is empty";
+                        SoundManager.playError();
                         showToast(`Erro: O campo "${fieldConfig.fields[0].label}" é obrigatório.`, { error: true });
                         isFieldValid = false;
                     }
@@ -895,6 +901,7 @@ export function initBAUForm() {
 
                     if (!input.value.trim()) {
                         failureReason = "Field is empty";
+                        SoundManager.playError();
                         showToast(`Erro: O campo '${fieldConfig.label}' é obrigatório.`, { error: true });
                         isFieldValid = false;
                     }
@@ -1362,9 +1369,11 @@ export function initBAUForm() {
             switchView('success');
 
             if (!isEditing && escalationResult && escalationResult.emailSent === false) {
+                SoundManager.playError();
                 showToast("Caso criado, mas não conseguimos confirmar por email.", { error: true });
             }
         } catch (error) {
+            SoundManager.playError();
             showToast("Erro: " + (error.message || "Erro desconhecido"), { error: true });
             console.error("Payload que tentou enviar:", payload); 
         } finally {
@@ -1404,8 +1413,11 @@ export function initBAUForm() {
         isVisible = !isVisible;
         popup.style.display = isVisible ? "flex" : "none";
         if (isVisible) {
+            lockBodyScroll();
             switchView('dashboard');
-            loadDashboardData(); 
+            loadDashboardData();
+        } else {
+            unlockBodyScroll();
         }
         toggleGenieAnimation(isVisible, popup, "cw-btn-bauform");
     }

--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -57,7 +57,6 @@ export const injectStyles = () => {
       
       transform-origin: center center;
       animation: cw-genie-effect-in 0.4s ${EASE};
-      transition: all 0.3s ease;
       color: #202124;
     }
 
@@ -125,7 +124,7 @@ export const injectStyles = () => {
         align-items: center;
         justify-content: center;
         gap: 8px;
-        transition: all 0.2s ease;
+        transition: background-color 0.2s ease, color 0.2s ease;
         margin-bottom: 24px;
     }
     .bau-accordion-toggle:hover { background-color: #F1F3F4; color: #202124; }
@@ -166,7 +165,7 @@ export const injectStyles = () => {
       gap: 8px;
       font-size: 13px;
       font-weight: 600;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
       height: 60px; /* Alinha com os cards de métricas */
     }
     .bau-metrics-refresh-btn:hover {
@@ -220,14 +219,16 @@ export const injectStyles = () => {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       cursor: default;
       position: relative;
       overflow: hidden;
     }
 
     .bau-case-card:hover {
-      transform: translateY(-2px);
+      /* Sem transform no próprio card: hit-box parado evita o flicker
+         hover-liga/desliga perto da borda superior quando ele "sobe". A
+         elevação vem só da sombra crescendo. */
       box-shadow: 0 8px 24px rgba(0,0,0,0.1);
       border-color: rgba(26, 115, 232, 0.4);
       background: #F1F3F4;
@@ -270,7 +271,7 @@ export const injectStyles = () => {
       display: flex;
       align-items: center;
       gap: 6px;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
       white-space: nowrap;
     }
 
@@ -382,7 +383,7 @@ export const injectStyles = () => {
         justify-content: center;
         margin-bottom: 24px;
         color: ${COLORS.green};
-        animation: bau-success-pop 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+        animation: bau-success-pop 0.7s var(--cw-ease-spring) forwards;
         box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.6), 0 12px 32px rgba(30, 142, 62, 0.2);
         border: 0.5px solid rgba(255, 255, 255, 0.25);
     }
@@ -451,12 +452,11 @@ export const injectStyles = () => {
       gap: 10px;
       cursor: pointer;
       box-shadow: 0 6px 16px rgba(26,115,232,0.4);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      transition: background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       z-index: 10;
     }
     .bau-dashboard-fab:hover {
       background: #1557b0;
-      transform: translateY(-4px);
       box-shadow: 0 8px 24px rgba(26,115,232,0.5);
     }
 
@@ -472,7 +472,7 @@ export const injectStyles = () => {
 
     .bau-progress-indicator { display: flex; justify-content: space-between; margin-bottom: 24px; position: relative; }
     .bau-progress-indicator::before { content: ''; position: absolute; top: 50%; left: 0; right: 0; height: 2px; background: #DADCE0; z-index: 1; transform: translateY(-50%); }
-    .bau-progress-step { width: 28px; height: 28px; border-radius: 50%; background: #FFFFFF; border: 2px solid #DADCE0; color: #5F6368; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; position: relative; z-index: 2; transition: all 0.3s ease; }
+    .bau-progress-step { width: 28px; height: 28px; border-radius: 50%; background: #FFFFFF; border: 2px solid #DADCE0; color: #5F6368; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; position: relative; z-index: 2; transition: border-color 0.3s ease, background-color 0.3s ease, color 0.3s ease; }
     .bau-progress-step.active { border-color: #1A73E8; background: #1A73E8; color: #FFFFFF; }
     .bau-progress-step.completed { border-color: #1E8E3E; background: #1E8E3E; color: #FFFFFF; }
 
@@ -500,7 +500,7 @@ export const injectStyles = () => {
       align-items: center;
       text-align: center;
       cursor: pointer;
-      transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      transition: transform 0.4s var(--cw-ease-spring), border-color 0.4s var(--cw-ease-spring), box-shadow 0.4s var(--cw-ease-spring), background-color 0.4s var(--cw-ease-spring);
       position: relative;
       overflow: hidden;
     }
@@ -515,7 +515,10 @@ export const injectStyles = () => {
     }
 
     .bau-branching-card:hover {
-      transform: translateY(-8px) scale(1.02);
+      /* Era o pior caso do arquivo: -8px + scale no próprio card, maior
+         chance de flicker de hit-box de todo o app. A elevação continua
+         nítida só com sombra+borda; o "movimento" fica com o ícone filho
+         (:hover .bau-branching-icon, abaixo). */
       border-color: #1A73E8;
       box-shadow: 0 12px 32px rgba(26, 115, 232, 0.15);
       background: rgba(255, 255, 255, 0.9);
@@ -535,7 +538,7 @@ export const injectStyles = () => {
       justify-content: center;
       margin-bottom: 20px;
       color: #1A73E8;
-      transition: all 0.3s ease;
+      transition: background-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
     }
 
     .bau-branching-card:hover .bau-branching-icon {
@@ -602,12 +605,11 @@ export const injectStyles = () => {
       z-index: 1;
       padding: 8px 12px;
       border-radius: 10px;
-      transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+      transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
       cursor: default;
     }
 
     .bau-highlight-item:hover {
-      transform: scale(1.05);
       background: rgba(255, 255, 255, 0.4);
       backdrop-filter: blur(8px);
       box-shadow: 0 4px 12px rgba(0,0,0,0.05);
@@ -626,7 +628,7 @@ export const injectStyles = () => {
       padding: 12px 16px;
       color: #202124;
       font-size: 14px;
-      transition: all 0.2s ease;
+      transition: border-color 0.2s ease, background-color 0.2s ease;
       box-sizing: border-box;
     }
 
@@ -652,7 +654,7 @@ export const injectStyles = () => {
       display: flex;
       align-items: center;
       gap: 10px;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
     }
     .bau-task-item:hover { background: #F1F3F4; border-color: #5F6368; }
     .bau-task-item.active { background: rgba(26, 115, 232, 0.1); border-color: #1A73E8; color: #1A73E8; }
@@ -692,7 +694,7 @@ export const injectStyles = () => {
       align-items: center;
       justify-content: center;
       gap: 6px;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
       align-self: flex-start;
     }
 
@@ -722,7 +724,7 @@ export const injectStyles = () => {
       display: flex;
       gap: 6px;
       font-size: 11px;
-      transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+      transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), border-color 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
       cursor: default;
     }
 
@@ -751,7 +753,7 @@ export const injectStyles = () => {
       background: #F8F9FA;
       border-radius: 10px;
       border: 1px solid #DADCE0;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease;
       position: relative;
     }
     .bau-confirm-row:hover {
@@ -781,7 +783,7 @@ export const injectStyles = () => {
       margin-left: -8px;
       width: calc(100% + 16px);
       outline: none;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease;
       cursor: text;
       box-sizing: border-box;
     }
@@ -829,7 +831,7 @@ export const injectStyles = () => {
       font-size: 14px;
       font-weight: 600;
       cursor: pointer;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
       display: flex;
       align-items: center;
       gap: 8px;
@@ -846,7 +848,7 @@ export const injectStyles = () => {
       font-size: 14px;
       font-weight: 600;
       cursor: pointer;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
     }
     .bau-btn-secondary:hover { background: #F1F3F4; color: #202124; border-color: #5F6368; }
 
@@ -922,7 +924,7 @@ export const injectStyles = () => {
         gap: 8px;
         font-size: 13px;
         font-weight: 500;
-        transition: all 0.2s ease;
+        transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
     }
     .bau-details-close-btn:hover { background: #E8EAED; color: #202124; transform: scale(1.02); }
     .bau-details-close-btn:active { transform: scale(0.95); transition: transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1); }
@@ -995,7 +997,7 @@ export const injectStyles = () => {
         cursor: pointer;
         padding: 4px;
         opacity: 0;
-        transition: all 0.2s ease;
+        transition: opacity 0.2s ease, background-color 0.2s ease;
         border-radius: 6px;
     }
     .bau-details-row:hover .bau-copy-btn { opacity: 1; background: #E8F0FE; }
@@ -1025,7 +1027,7 @@ export const injectStyles = () => {
       font-size: 14px;
       font-weight: 600;
       cursor: pointer;
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
       margin-left: -1px;
       display: flex;
       align-items: center;
@@ -1076,6 +1078,43 @@ export const injectStyles = () => {
       color: #202124;
       border-color: #5F6368;
       z-index: 1;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      /* Auras/pulsos puramente decorativos - infinitos, sem função de status.
+         Spinners (.bau-spinner, .bau-metrics-refresh-btn.spinning svg) e o
+         .bau-shimmer de skeleton ficam de fora: carregam estado de "carregando"
+         real, mesmo padrão adotado no cwLibSpin da Biblioteca Pessoal. */
+      .bau-success-view.active .bau-success-content::before,
+      .bau-highlight-panel::before,
+      .bau-pulse-attention {
+        animation: none !important;
+      }
+
+      /* Sequência de sucesso (ao submeter um caso) simplificada pra fade puro -
+         mesmo tratamento dado à splash screen em utils.js. */
+      .bau-success-view.active .bau-success-icon,
+      .bau-success-view.active .bau-success-title,
+      .bau-success-view.active .bau-success-subtitle,
+      .bau-success-view.active #bau-success-back-btn {
+        animation-name: bauFadeIn !important;
+        transform: none !important;
+      }
+      .bau-success-view.active #bau-success-back-btn::after {
+        animation: none !important;
+      }
+
+      .bau-case-card:hover,
+      .bau-dashboard-fab:hover,
+      .bau-branching-card:hover,
+      .bau-branching-card:hover .bau-branching-icon,
+      .bau-highlight-item:hover,
+      .bau-btn-primary:hover, .bau-btn-submit:hover,
+      .bau-details-close-btn:hover,
+      .bau-details-close-btn:active,
+      .bau-copy-btn:active {
+        transform: none !important;
+      }
     }
   `;
   document.head.appendChild(style);

--- a/src/modules/broadcast/broadcast-assistant.js
+++ b/src/modules/broadcast/broadcast-assistant.js
@@ -9,6 +9,7 @@ import {
   confirmDialog
 } from "../shared/utils.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { BROADCAST_MESSAGES, setBroadcastMessages } from "./broadcast-data.js";
@@ -75,7 +76,7 @@ function injectStyles() {
         .cw-bc-card {
             background: #FFFFFF; border-radius: 16px; border: 1px solid rgba(0,0,0,0.12);
             box-shadow: 0 4px 12px rgba(60,64,67,0.08);
-            overflow: hidden; transition: all 0.3s ease; position: relative; width: 100%; box-sizing: border-box; flex-shrink: 0;
+            overflow: hidden; transition: opacity 0.3s ease, filter 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease, transform 0.3s ease; position: relative; width: 100%; box-sizing: border-box; flex-shrink: 0;
         }
         .cw-bc-card.history {
             border: 1px solid rgba(0,0,0,0.05); box-shadow: none; opacity: 0.6; filter: grayscale(0.8);
@@ -99,12 +100,12 @@ function injectStyles() {
         .cw-bc-dismiss-btn {
             width: 28px; height: 28px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.1);
             background: #fff; color: #5f6368; cursor: pointer; display: flex; align-items: center; justify-content: center;
-            transition: all 0.2s ease; margin-left: 12px;
+            transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease; margin-left: 12px;
         }
         .cw-bc-dismiss-btn:hover { color: #1e8e3e; background: #e6f4ea; border-color: #1e8e3e; }
 
         .cw-card-actions { display: flex; justify-content: flex-end; gap: 12px; padding: 12px 20px; background: #F8F9FA; border-top: 1px solid #F1F3F4; }
-        .cw-action-btn { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer; border: 1px solid transparent; background: transparent; transition: all 0.2s; }
+        .cw-action-btn { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer; border: 1px solid transparent; background: transparent; transition: background-color 0.2s; }
         .cw-action-btn.edit { color: #1967D2; }
         .cw-action-btn.edit:hover { background: #E8F0FE; }
         .cw-action-btn.delete { color: #D93025; }
@@ -153,7 +154,7 @@ function injectStyles() {
         .cw-editor-overlay {
             position: absolute; inset: 0; background: rgba(255, 255, 255, 0.98);
             z-index: 200; display: flex; flex-direction: column;
-            transform: translateY(100%); transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+            transform: translateY(100%); transition: transform 0.35s var(--cw-ease-elastic);
             box-shadow: 0 -4px 20px rgba(0,0,0,0.1);
         }
         .cw-editor-overlay.active { transform: translateY(0); }
@@ -176,7 +177,7 @@ function injectStyles() {
         .cw-radio-option {
             flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px;
             padding: 12px; border-radius: 12px; border: 1px solid #E0E0E0;
-            font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; position: relative; color: #5F6368;
+            font-size: 13px; font-weight: 600; cursor: pointer; transition: background-color 0.2s, color 0.2s, border-color 0.2s; position: relative; color: #5F6368;
         }
         .cw-radio-option:hover { background: #F8F9FA; }
         .cw-radio-option input { position: absolute; opacity: 0; }
@@ -187,6 +188,14 @@ function injectStyles() {
         .cw-bc-btn-secondary { padding: 10px 20px; background: white; border: 1px solid #dadce0; color: #5f6368; border-radius: 24px; font-weight: 600; font-size: 13px; }
         .cw-bc-btn-primary { padding: 10px 24px; background: #1a73e8; color: white; border: none; border-radius: 24px; font-weight: 600; box-shadow: 0 4px 12px rgba(26,115,232,0.3); font-size: 13px; }
         .cw-bc-editor-close { background: none; border: none; color: #5f6368; padding: 8px; }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-bc-pulse-dot { animation: none !important; }
+            .cw-bc-card, .cw-bc-bau, .cw-bc-bau-chevron, .cw-editor-overlay {
+                transition: opacity 0.15s ease !important;
+                transform: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
@@ -270,6 +279,12 @@ export function initBroadcastAssistant() {
   let currentUser = null;
   let adminRetries = 0;
 
+  // IDs vistos no fetch anterior — usado só para saber se algo *novo* chegou
+  // entre polls (pra tocar playNotification só uma vez por aviso, não a cada
+  // sync). Começa null de propósito: no primeiro fetch (carga inicial) ainda
+  // não há "anterior" pra comparar, então não soa nada nesse momento.
+  let knownMessageIds = null;
+
   injectStyles();
 
   // --- UI SETUP ---
@@ -288,9 +303,12 @@ export function initBroadcastAssistant() {
     visible = !visible;
     toggleGenieAnimation(visible, popup, "cw-btn-broadcast");
     if (visible) {
+      lockBodyScroll();
       const btn = document.getElementById("cw-btn-broadcast");
       if (btn) btn.classList.remove("has-new");
       checkForUpdates();
+    } else {
+      unlockBodyScroll();
     }
   }
 
@@ -501,6 +519,7 @@ export function initBroadcastAssistant() {
       const type = typeInput ? typeInput.value : 'info';
 
       if (!inputTitle.value.trim() || !inputText.value.trim()) {
+          SoundManager.playError();
           showToast("Preencha todos os campos!", { error: true });
           return;
       }
@@ -531,6 +550,7 @@ export function initBroadcastAssistant() {
           closeEditor();
           setTimeout(() => checkForUpdates(), 1500);
       } else {
+          SoundManager.playError();
           showToast("Erro ao salvar. Verifique a conexão.", { error: true });
           btnSend.textContent = currentEditingId ? "Salvar Alterações" : "Publicar";
           btnSend.style.opacity = "1";
@@ -549,6 +569,7 @@ export function initBroadcastAssistant() {
               renderFeed();
               setTimeout(() => checkForUpdates(), 1500);
           } else {
+              SoundManager.playError();
               showToast("Erro ao excluir.", { error: true });
           }
       }
@@ -567,6 +588,17 @@ export function initBroadcastAssistant() {
       try {
           const data = await DataService.fetchData();
           if (data && data.broadcast) {
+              // Toca só quando um aviso novo e não lido chega num poll em
+              // segundo plano (pílula fechada/idle) - com o popup aberto o
+              // próprio feed atualizando já é o feedback, um som ali em cima
+              // seria redundante.
+              if (knownMessageIds && !visible) {
+                  const readMessages = JSON.parse(localStorage.getItem("cw_read_broadcasts") || "[]");
+                  const hasNewUnread = data.broadcast.some(m => !knownMessageIds.has(m.id) && !readMessages.includes(m.id));
+                  if (hasNewUnread) SoundManager.playNotification();
+              }
+              knownMessageIds = new Set(data.broadcast.map(m => m.id));
+
               setBroadcastMessages(data.broadcast);
               updateBadge();
               if (visible) {
@@ -815,13 +847,15 @@ export function initBroadcastAssistant() {
             SoundManager.playClick();
             card.style.transform = "translateX(20px)";
             card.style.opacity = "0";
+            // 300ms = duração real da transição de .cw-bc-card (opacity/transform);
+            // removia o card da lista no meio do slide-out antes.
             setTimeout(() => {
                 const currentRead = JSON.parse(localStorage.getItem("cw_read_broadcasts") || "[]");
                 currentRead.push(msg.id);
                 localStorage.setItem("cw_read_broadcasts", JSON.stringify(currentRead));
                 renderFeed();
                 updateBadge();
-            }, 200);
+            }, 300);
         };
         cardHead.appendChild(dismissBtn);
     } else {

--- a/src/modules/call-script/call-script-assistant.js
+++ b/src/modules/call-script/call-script-assistant.js
@@ -4,9 +4,11 @@ import {
   stylePopup,
   styleResizeHandle,
   makeResizable,
-  showToast
+  showToast,
+  confirmDialog
 } from "../shared/utils.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
@@ -201,6 +203,19 @@ function injectStyles() {
         }
         .csa-reset-btn:hover { background: ${COLORS.dangerBg}; }
         .csa-reset-btn:active { transform: scale(0.9); }
+
+        /* Duas animações infinite (dot "ao vivo" e shimmer da barra de
+           progresso) rodando o tempo inteiro que o script fica aberto,
+           sem nenhuma proteção de reduced-motion. */
+        @media (prefers-reduced-motion: reduce) {
+            .csa-live-dot { animation: none !important; }
+            .csa-progress-fill { animation: none !important; }
+            .csa-checkbox, .csa-checkbox.pulse, .cw-step-btn-hero,
+            .csa-data-pill, .csa-segmented-indicator {
+                transition: opacity 0.15s ease, background-color 0.15s ease, border-color 0.15s ease !important;
+                transform: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
@@ -282,9 +297,11 @@ export function initCallScriptAssistant() {
     toggleGenieAnimation(csaVisible, csaPopup, 'cw-btn-script');
 
     if (csaVisible) {
+        lockBodyScroll();
         updateContextData();
         if (!monitorInterval) monitorInterval = setInterval(updateContextData, 2000);
     } else {
+        unlockBodyScroll();
         if (monitorInterval) { clearInterval(monitorInterval); monitorInterval = null; }
     }
   }
@@ -426,7 +443,9 @@ export function initCallScriptAssistant() {
   const resetBtn = document.createElement("button");
   resetBtn.className = "csa-reset-btn";
   resetBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path><path d="M3 3v5h5"></path></svg> Resetar Script`;
-  resetBtn.onclick = () => {
+  resetBtn.onclick = async () => {
+    const confirmed = await confirmDialog("Resetar todo o progresso do script? Essa ação não pode ser desfeita.", { danger: true, confirmText: "Resetar" });
+    if (!confirmed) return;
     for (let key in csaCompletedTasks) delete csaCompletedTasks[key];
     csaBuildChecklist();
   };

--- a/src/modules/changelog/changelog-wizard.js
+++ b/src/modules/changelog/changelog-wizard.js
@@ -2,6 +2,7 @@
 
 import { stylePopup, showToast } from "../shared/utils.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 import { RELEASE_NOTES } from "./changelog-data.js";
 
 export function checkAndShowChangelog(currentAppVersion) {
@@ -66,6 +67,9 @@ function initChangelogModal(version) {
     // --- DOM ---
     const overlay = document.createElement("div");
     Object.assign(overlay.style, styles.overlay);
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.setAttribute("aria-labelledby", "cw-changelog-title");
 
     const card = document.createElement("div");
     Object.assign(card.style, styles.card);
@@ -79,6 +83,7 @@ function initChangelogModal(version) {
     Object.assign(iconEl.style, styles.icon);
 
     const titleEl = document.createElement("div");
+    titleEl.id = "cw-changelog-title";
     Object.assign(titleEl.style, styles.title);
 
     const textEl = document.createElement("div");
@@ -101,6 +106,7 @@ function initChangelogModal(version) {
     card.appendChild(btnNext);
     overlay.appendChild(card);
     document.body.appendChild(overlay);
+    lockBodyScroll();
 
     // --- LOGICA ---
     function renderSlide(index) {
@@ -130,12 +136,14 @@ function initChangelogModal(version) {
     function close() {
         // Atualiza a versão no cache para não mostrar mais
         localStorage.setItem("cw_last_version", version);
-        
+
         overlay.style.opacity = "0";
         card.style.transform = "translateY(30px)";
         setTimeout(() => overlay.remove(), 400);
         SoundManager.playSuccess();
         showToast(`TechSol atualizado para ${version}!`);
+        document.removeEventListener("keydown", handleKeydown);
+        unlockBodyScroll();
     }
 
     btnNext.onclick = () => {
@@ -148,10 +156,24 @@ function initChangelogModal(version) {
         }
     };
 
+    // Enter avança slide a slide (ou fecha no último); Esc dispensa direto -
+    // não há "pular" aqui, só o aviso do que mudou.
+    function handleKeydown(e) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            btnNext.click();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            close();
+        }
+    }
+    document.addEventListener("keydown", handleKeydown);
+
     // Start
     renderSlide(0);
     requestAnimationFrame(() => {
         overlay.style.opacity = "1";
         card.style.transform = "translateY(0)";
     });
+    setTimeout(() => btnNext.focus(), 450);
 }

--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -6,6 +6,7 @@ import { fetchUserProfile } from "../shared/data-service.js"; // Importação cr
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 
 export function initConfigsAssistant() {
     const CURRENT_VERSION = "v1.0";
@@ -92,6 +93,31 @@ export function initConfigsAssistant() {
             @keyframes shine {
                 to { background-position-x: -200%; }
             }
+
+            /* --- TOGGLE SWITCH --- */
+            /* O checkbox nativo continua no DOM (checked/foco/teclado de graça),
+               só o visual é trocado - único controle de OS "cru" que sobrava
+               no popup inteiro, destoando do resto do design system. */
+            .cw-toggle-switch { position: relative; display: inline-block; width: 40px; height: 22px; flex-shrink: 0; }
+            .cw-toggle-switch input {
+                position: absolute; inset: 0; width: 100%; height: 100%; margin: 0;
+                opacity: 0; cursor: pointer; z-index: 1;
+            }
+            .cw-toggle-track {
+                position: absolute; inset: 0; background: ${COLORS.border};
+                border-radius: 100px; transition: background-color 0.2s ease; pointer-events: none;
+            }
+            .cw-toggle-track::before {
+                content: ''; position: absolute; top: 2px; left: 2px; width: 18px; height: 18px;
+                background: #fff; border-radius: 50%; box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+                transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+            }
+            .cw-toggle-switch input:checked + .cw-toggle-track { background: ${COLORS.primary}; }
+            .cw-toggle-switch input:checked + .cw-toggle-track::before { transform: translateX(18px); }
+            .cw-toggle-switch input:focus-visible + .cw-toggle-track { outline: 2px solid ${COLORS.primary}; outline-offset: 2px; }
+            @media (prefers-reduced-motion: reduce) {
+                .cw-toggle-track, .cw-toggle-track::before { transition: none !important; }
+            }
         `;
         document.head.appendChild(style);
     }
@@ -137,7 +163,7 @@ export function initConfigsAssistant() {
                 <div class="cw-skeleton cw-skeleton-text" style="margin-top: 8px;"></div>
             </div>
         `;
-        setTimeout(async () => {
+        (async () => {
             try {
                 // Busca o LDAP real do usuário logado
                 const agentEmail = getAgentEmail();
@@ -185,11 +211,7 @@ export function initConfigsAssistant() {
                 console.warn("Erro ao renderizar perfil:", e);
                 profileSection.style.display = "none";
             }
-
-        }, 3000)
-
-
-
+        })();
     }
     renderUserProfile();
 
@@ -204,7 +226,10 @@ export function initConfigsAssistant() {
                     <div class="cw-configs-label">Efeitos Sonoros</div>
                     <div class="cw-configs-desc">Ativar ou desativar sons de interface.</div>
                 </div>
-                <input type="checkbox" id="cw-config-sound-toggle" ${SoundManager.isMuted() ? '' : 'checked'} style="cursor:pointer; width:20px; height:20px;">
+                <label class="cw-toggle-switch">
+                    <input type="checkbox" id="cw-config-sound-toggle" ${SoundManager.isMuted() ? '' : 'checked'}>
+                    <span class="cw-toggle-track"></span>
+                </label>
             </div>
         </div>
     `;
@@ -232,7 +257,10 @@ export function initConfigsAssistant() {
         visible = !visible;
         toggleGenieAnimation(visible, popup, 'cw-btn-configs');
         if (visible) {
+            lockBodyScroll();
             SoundManager.playClick();
+        } else {
+            unlockBodyScroll();
         }
     }
 

--- a/src/modules/email-assistant/email-assistant.js
+++ b/src/modules/email-assistant/email-assistant.js
@@ -9,6 +9,8 @@ import {
 } from "../shared/utils.js";
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from '../shared/animations.js';
+import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll, enableArrowKeyNav } from "../shared/dom-utils.js";
 import { getAgentName, getPageData } from "../shared/page-data.js";
 import { EmailDataService } from "./email-data-service.js";
 import { runQuickEmail, runEmailAutomation } from "./email-automation-service.js";
@@ -66,7 +68,7 @@ function injectStyles() {
             font-size: 15px; outline: none; color: ${COLORS.textPrimary};
             background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%238A8A8E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>');
             background-repeat: no-repeat; background-position: 12px center;
-            transition: all 0.2s ease-in-out;
+            transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
         }
         .cw-email-search-input:focus {
             background-color: #FFFFFF; border-color: ${COLORS.primary};
@@ -94,19 +96,23 @@ function injectStyles() {
             user-select: none; transition: background-color 0.2s ease;
         }
         .cw-email-cat-header:hover { background-color: rgba(230, 230, 232, 0.9); }
+        .cw-email-cat-header:focus-visible, .cw-email-list-item:focus-visible { outline: 2px solid ${COLORS.primary}; outline-offset: -2px; }
         .cw-email-cat-right { display: flex; align-items: center; }
         .cw-email-cat-badge { background-color: rgba(0, 0, 0, 0.05); padding: 2px 8px; border-radius: 10px; font-size: 10px; color: ${COLORS.textSecondary}; }
         .cw-email-cat-arrow { margin-left: 8px; transition: transform 0.3s ease; }
 
         .cw-email-list-item {
             padding: 12px 14px; font-size: 14px; cursor: pointer;
-            transition: all 0.3s cubic-bezier(0.25, 1, 0.5, 1); border-radius: 10px;
+            transition: background-color 0.3s cubic-bezier(0.25, 1, 0.5, 1), transform 0.3s cubic-bezier(0.25, 1, 0.5, 1), box-shadow 0.3s cubic-bezier(0.25, 1, 0.5, 1), border-color 0.3s cubic-bezier(0.25, 1, 0.5, 1), color 0.3s cubic-bezier(0.25, 1, 0.5, 1); border-radius: 10px;
             color: ${COLORS.textPrimary}; margin: 4px 6px; display: flex; align-items: center; gap: 12px;
             background-color: ${COLORS.bgSurface}; box-shadow: 0 1px 2px rgba(0,0,0,0.05);
             border: 1px solid ${COLORS.borderSubtle}; position: relative; overflow: hidden;
         }
         .cw-email-list-item:hover:not(.selected) {
-            background-color: #f8f8f9; transform: translateY(-1px) scale(1.01);
+            /* Sem transform aqui: itens empilhados verticalmente e bem juntos
+               são o caso clássico de flicker de hover quando o próprio item
+               se desloca. Sombra/borda já comunicam o hover sem mover nada. */
+            background-color: #f8f8f9;
             box-shadow: 0 4px 8px rgba(0,0,0,0.08); border-color: rgba(0, 122, 255, 0.2);
         }
         .cw-email-list-item:active:not(.selected) { transform: scale(0.98); }
@@ -121,14 +127,17 @@ function injectStyles() {
         .cw-email-list-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
 
         /* --- PAINEL DIREITO --- */
-        .cw-email-right-panel { flex: 1; display: flex; flex-direction: column; overflow: hidden; background-color: ${COLORS.bgApp}; transition: all 0.3s cubic-bezier(0.25, 1, 0.5, 1); }
+        /* 0.15s bate com o setTimeout de selectTemplate() (linha ~476) - o
+           swap de conteúdo acontece exatamente quando o fade-out termina,
+           não no meio dele. */
+        .cw-email-right-panel { flex: 1; display: flex; flex-direction: column; overflow: hidden; background-color: ${COLORS.bgApp}; transition: opacity 0.15s ease, transform 0.15s ease; }
         .cw-email-fields-section { padding: 20px; border-bottom: 1px solid ${COLORS.borderSubtle}; background-color: ${COLORS.bgSurface}; max-height: 250px; overflow-y: auto; display: none; }
         .cw-email-fields-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
         .cw-email-field-label { display: block; font-size: 11px; font-weight: 700; color: ${COLORS.textSecondary}; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
         .cw-email-field-input {
             width: 100%; box-sizing: border-box; padding: 10px 12px; border-radius: 8px;
             border: 1.5px solid ${COLORS.borderSubtle}; background-color: #FBFBFD; font-size: 14px;
-            transition: all 0.2s ease; outline: none;
+            transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease; outline: none;
         }
         .cw-email-field-input:focus { border-color: ${COLORS.primary}; background-color: #FFFFFF; box-shadow: 0 0 0 4px rgba(0, 122, 255, 0.1); }
 
@@ -152,7 +161,7 @@ function injectStyles() {
         .cw-email-btn {
             padding: 8px 14px; border-radius: 10px; border: 1.5px solid ${COLORS.primary};
             background: transparent; color: ${COLORS.primary}; font-size: 13px; font-weight: 600;
-            cursor: pointer; transition: all 0.2s cubic-bezier(0.25, 1, 0.5, 1);
+            cursor: pointer; transition: background-color 0.2s cubic-bezier(0.25, 1, 0.5, 1), transform 0.2s cubic-bezier(0.25, 1, 0.5, 1), box-shadow 0.2s cubic-bezier(0.25, 1, 0.5, 1);
         }
         .cw-email-btn:hover { background-color: rgba(0, 122, 255, 0.05); }
         .cw-email-btn:active { transform: scale(0.94); }
@@ -163,6 +172,14 @@ function injectStyles() {
         .cw-email-btn.primary:hover { background-color: #0062CC; transform: translateY(-1px); box-shadow: 0 6px 16px rgba(0, 122, 255, 0.4); }
         .cw-email-btn.warning { border-color: ${COLORS.warning}; color: ${COLORS.warning}; display: none; }
         .cw-email-btn.warning:hover { background-color: rgba(230, 126, 34, 0.08); }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-animate-float { animation: none !important; }
+            .cw-email-search-input, .cw-email-list-item, .cw-email-btn, .cw-email-right-panel {
+                transition: opacity 0.15s ease, background-color 0.15s ease !important;
+                transform: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
@@ -249,6 +266,7 @@ export function initEmailAssistant() {
 
     const templateList = document.createElement("div");
     templateList.id = "email-template-list";
+    enableArrowKeyNav(templateList, ".cw-email-cat-header, .cw-email-list-item");
 
     const clearSearch = document.createElement("div");
     clearSearch.className = "cw-email-clear-btn";
@@ -333,10 +351,12 @@ export function initEmailAssistant() {
     function toggleVisibility() {
         visible = !visible;
         if (visible) {
+            lockBodyScroll();
             popup.style.display = "flex";
             constrainToViewport(popup);
             if (templates.length === 0) loadTemplates();
         } else {
+            unlockBodyScroll();
             popup.style.display = "none";
         }
         toggleGenieAnimation(visible, popup, 'cw-btn-email');
@@ -351,6 +371,9 @@ export function initEmailAssistant() {
     function createCategoryHeader(cat, count, isExpanded) {
         const catHeader = document.createElement("div");
         catHeader.className = "cw-email-cat-header";
+        catHeader.tabIndex = 0;
+        catHeader.setAttribute("role", "button");
+        catHeader.setAttribute("aria-expanded", String(isExpanded));
 
         const headerText = document.createElement("span");
         headerText.textContent = cat;
@@ -378,6 +401,9 @@ export function initEmailAssistant() {
             }
             renderTemplateList();
         };
+        catHeader.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") { e.preventDefault(); catHeader.click(); }
+        });
 
         return catHeader;
     }
@@ -386,6 +412,9 @@ export function initEmailAssistant() {
         const isSelected = selectedTemplate && selectedTemplate.id === template.id;
         const item = document.createElement("div");
         item.className = "cw-email-list-item" + (isSelected ? " selected" : "");
+        item.tabIndex = 0;
+        item.setAttribute("role", "button");
+        item.setAttribute("aria-pressed", String(!!isSelected));
 
         if (isSelected) {
             const indicator = document.createElement("div");
@@ -404,6 +433,9 @@ export function initEmailAssistant() {
         item.appendChild(text);
 
         item.onclick = () => selectTemplate(template);
+        item.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") { e.preventDefault(); item.click(); }
+        });
 
         return item;
     }
@@ -564,7 +596,7 @@ export function initEmailAssistant() {
         const blob = new Blob([html], { type: 'text/html' });
         const text = previewContent.innerText;
         const data = [new ClipboardItem({ 'text/html': blob, 'text/plain': new Blob([text], { type: 'text/plain' }) })];
-        navigator.clipboard.write(data).then(() => showToast("E-mail copiado com sucesso!"), () => showToast("Erro ao copiar e-mail", { error: true }));
+        navigator.clipboard.write(data).then(() => showToast("E-mail copiado com sucesso!"), () => { SoundManager.playError(); showToast("Erro ao copiar e-mail", { error: true }); });
     };
 
     btnFill.onclick = async () => {
@@ -575,6 +607,7 @@ export function initEmailAssistant() {
             await runQuickEmail(filledTemplate);
             toggleVisibility();
         } catch (error) {
+            SoundManager.playError();
             showToast("Erro ao preencher e-mail", { error: true });
         } finally {
             finishLoading();
@@ -588,6 +621,7 @@ export function initEmailAssistant() {
             await runEmailAutomation(selectedTemplate.code);
             toggleVisibility();
         } catch (error) {
+            SoundManager.playError();
             showToast("Erro ao aplicar Smart CR", { error: true });
         } finally {
             finishLoading();

--- a/src/modules/email-assistant/email-automation-service.js
+++ b/src/modules/email-assistant/email-automation-service.js
@@ -3,6 +3,7 @@ import { showToast } from '../shared/utils.js';
 import { getPageData } from '../shared/page-data.js';
 import { getAgentName } from '../shared/page-data.js';
 import { esperar, simularCliqueReal } from '../shared/dom-utils.js';
+import { SoundManager } from '../shared/sound-manager.js';
 
 // --- UTILITÁRIOS ---
 function log(msg, type = 'info') {
@@ -152,6 +153,7 @@ async function openAndClearEmail() {
     }
 
     if (!emailAberto) {
+        SoundManager.playError();
         showToast("Erro: Botão de email não encontrado.", { error: true });
         return false;
     }
@@ -207,6 +209,7 @@ async function openAndClearEmail() {
     }
 
     if (!editorVisivel) {
+        SoundManager.playError();
         showToast("Erro: Editor não carregou.", { error: true });
         return false;
     }
@@ -383,10 +386,12 @@ export async function runEmailAutomation(cannedResponseText) {
                 showToast("Canned Response aplicada!");
             } else {
                 log(`❌ Timeout: Resultado '${cannedResponseText}' não apareceu após 15s.`, 'error');
+                SoundManager.playError();
                 showToast(`Timeout: Template '${cannedResponseText}' não carregou.`, { error: true });
             }
         }
     } else {
+        SoundManager.playError();
         showToast("Botão Canned Response não encontrado.", { error: true });
     }
 }
@@ -475,6 +480,7 @@ export async function runQuickEmail(template) {
         log("✅ Processo finalizado com sucesso.", 'success');
 
     } else {
+        SoundManager.playError();
         showToast("Erro ao focar no editor.", { error: true });
     }
 }

--- a/src/modules/links/links-assistant.js
+++ b/src/modules/links/links-assistant.js
@@ -4,6 +4,7 @@ import { stylePopup, showToast } from "../shared/utils.js";
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from '../shared/animations.js';
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll, createEmptyState } from "../shared/dom-utils.js";
 
 // --- DADOS (Links) ---
 const LINKS_DB = {
@@ -175,7 +176,7 @@ function injectStyles() {
             width: 56px; height: 56px; border-radius: 16px;
             display: flex; flex-direction: column; align-items: center; justify-content: center;
             cursor: pointer; color: ${COLORS.textSecondary};
-            transition: background 0.2s cubic-bezier(0.2, 0.0, 0.2, 1), color 0.2s ease;
+            transition: background 0.2s var(--cw-ease-standard), color 0.2s ease;
             position: relative; background: transparent;
         }
         .cw-links-nav-btn:hover:not(.active) { background: #F1F3F4; }
@@ -229,8 +230,9 @@ function injectStyles() {
             border-left: 4px solid transparent;
             border-radius: 16px;
             cursor: pointer;
+            text-decoration: none; color: inherit;
             box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-            transition: transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.2s cubic-bezier(0.2, 0.8, 0.2, 1), border-color 0.2s ease;
+            transition: transform 0.2s var(--cw-ease-elastic), box-shadow 0.2s var(--cw-ease-elastic), border-color 0.2s ease;
             position: relative; overflow: hidden; box-sizing: border-box;
         }
         .cw-links-card:hover {
@@ -240,6 +242,7 @@ function injectStyles() {
             border-left-color: var(--cat-color);
         }
         .cw-links-card:hover .cw-links-copy-btn { opacity: 1; background: #F1F3F4; }
+        .cw-links-card:focus-visible { outline: 2px solid var(--cat-color); outline-offset: 2px; }
 
         .cw-links-icon-box {
             width: 40px; height: 40px; border-radius: 12px;
@@ -264,7 +267,7 @@ function injectStyles() {
             position: absolute; bottom: 0; left: 0; width: 100%; height: 100%;
             background: rgba(255,255,255,0.98); z-index: 20;
             display: flex; flex-direction: column;
-            transform: translateY(100%); transition: transform 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+            transform: translateY(100%); transition: transform 0.3s var(--cw-ease-elastic);
             box-shadow: 0 -4px 20px rgba(0,0,0,0.1);
         }
         .cw-links-history-head { padding: 16px 24px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #F1F3F4; }
@@ -273,19 +276,27 @@ function injectStyles() {
         .cw-links-history-close:hover { background: #F1F3F4; }
         .cw-links-history-list { flex: 1; overflow-y: auto; padding: 20px; background: #F8F9FA; }
         .cw-links-history-empty { text-align: center; color: #999; margin-top: 60px; font-size: 13px; }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-links-card, .cw-links-nav-btn, .cw-links-nav-icon, .cw-links-history-overlay {
+                transition: opacity 0.15s ease, background 0.15s ease !important;
+                transform: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
 
 // --- LOGICA DE HISTÓRICO ---
 const HISTORY_KEY = 'cw_link_history_v4';
+const HISTORY_MAX = 10; // Era 3 - pouco pra quem alterna entre várias ferramentas no mesmo turno
 
 function addToHistory(linkObj, catKey) {
     try {
         let history = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
         history = history.filter(h => h.url !== linkObj.url);
         history.unshift({ ...linkObj, _originalCat: catKey });
-        history = history.slice(0, 3); // Mantém apenas 3
+        history = history.slice(0, HISTORY_MAX);
         localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
     } catch (e) { console.warn("Erro ao salvar histórico", e); }
 }
@@ -411,7 +422,11 @@ export function initLinksAssistant() {
       const history = getHistory();
 
       if (history.length === 0) {
-          list.innerHTML = `<div class="cw-links-history-empty">Nada por aqui ainda.</div>`;
+          list.appendChild(createEmptyState({
+              icon: CATEGORY_ICONS.history,
+              title: "Nada por aqui ainda",
+              subtitle: "Os links que você abrir aparecem aqui pra acesso rápido depois.",
+          }));
       } else {
           history.forEach(link => {
               const card = createLinkCard(link, CATEGORY_ICONS[link._originalCat], true, link._originalCat);
@@ -544,7 +559,11 @@ export function initLinksAssistant() {
           });
 
           if(results.length === 0) {
-              scrollContent.innerHTML = `<div class="cw-links-empty">Nada encontrado.</div>`;
+              scrollContent.appendChild(createEmptyState({
+                  icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,
+                  title: "Nada encontrado",
+                  subtitle: `Nenhum link bate com "${searchTerm.trim()}".`,
+              }));
               return;
           }
 
@@ -591,8 +610,14 @@ export function initLinksAssistant() {
   }
 
   function createLinkCard(link, iconSvg, isHistory, catKey) {
-      const card = document.createElement("div");
+      // <a> real em vez de <div onclick> + window.open(): preserva Ctrl/Cmd-click
+      // e clique do meio para abrir em nova aba, e fica focável/ativável por
+      // teclado (Enter) de graça, sem precisar de tabindex nem handler próprio.
+      const card = document.createElement("a");
       card.className = "cw-links-card";
+      card.href = link.url;
+      card.target = "_blank";
+      card.rel = "noopener noreferrer";
       const theme = CAT_THEMES[catKey] || CAT_THEMES.history; // Pega o tema da categoria
       card.style.setProperty('--cat-color', theme.color);
       card.style.setProperty('--cat-bg', theme.bg);
@@ -624,16 +649,20 @@ export function initLinksAssistant() {
 
       card.onclick = () => {
           if(!isHistory && catKey) addToHistory(link, catKey);
-          window.open(link.url, '_blank');
+          // A navegação em si já acontece nativamente via href/target do <a>.
       };
 
       copyBtn.onclick = (e) => {
+          // preventDefault, não só stopPropagation: sem isso o clique no botão
+          // de copiar, por estar dentro do <a>, ainda dispararia a navegação.
+          e.preventDefault();
           e.stopPropagation();
           navigator.clipboard.writeText(link.url).then(() => {
               SoundManager.playClick();
               if(!isHistory && catKey) addToHistory(link, catKey);
               showToast("Link copiado!");
           }).catch(() => {
+              SoundManager.playError();
               showToast("Não foi possível copiar o link.", { error: true });
           });
       };
@@ -654,6 +683,7 @@ export function initLinksAssistant() {
   // --- INIT ---
   function toggleVisibility() {
       visible = !visible;
+      if (visible) lockBodyScroll(); else unlockBodyScroll();
       toggleGenieAnimation(visible, popup, 'cw-btn-links');
   }
 

--- a/src/modules/notes/automation/case-log-scraper.js
+++ b/src/modules/notes/automation/case-log-scraper.js
@@ -225,6 +225,7 @@ export async function fetchAndInsertSpeakeasyId(targetInputId) {
 
     } catch (error) {
         console.error("Erro na automação:", error);
+        SoundManager.playError();
         showToast("Erro ao processar.", { error: true });
     } finally {
         if (inputWidget) {

--- a/src/modules/notes/components/split-transfer.js
+++ b/src/modules/notes/components/split-transfer.js
@@ -3,6 +3,8 @@
 import { getPageData } from "../../shared/page-data.js";
 import { showToast } from "../../shared/utils.js";
 import { copyHtmlToClipboard, ensureNoteCardIsOpen, triggerInputEvents } from "../notes-bridge.js";
+import { SoundManager } from "../../shared/sound-manager.js";
+import { enableFilledCheck } from "../../shared/dom-utils.js";
 
 export function createSplitTransferComponent(onBack) {
     // --- 1. LAYOUT & STRUCTURE ---
@@ -50,14 +52,15 @@ export function createSplitTransferComponent(onBack) {
     // Generic Input Builder
     const fields = {}; // Store references for easy access later
 
-    function createField({ id, label, type = "text", placeholder = "", required = false, parent = scrollArea }) {
+    function createField({ id, label, type = "text", placeholder = "", required = false, autocomplete = "", parent = scrollArea }) {
         const wrapper = document.createElement("div");
         wrapper.style.cssText = styles.inputWrapper;
-        
+
         const lbl = document.createElement("label");
+        lbl.setAttribute("for", id);
         lbl.style.cssText = styles.label;
         lbl.innerHTML = `${label} ${required ? '<span style="color:#D93025">*</span>' : ''}`;
-        
+
         let input;
         if (type === "textarea") {
             input = document.createElement("textarea");
@@ -67,9 +70,10 @@ export function createSplitTransferComponent(onBack) {
             input.type = type;
             input.style.cssText = styles.input;
         }
-        
+
         input.id = id;
         input.placeholder = placeholder;
+        if (autocomplete) input.setAttribute("autocomplete", autocomplete);
         
         // Focus Effects
         input.addEventListener('focus', () => {
@@ -89,6 +93,10 @@ export function createSplitTransferComponent(onBack) {
 
         wrapper.appendChild(lbl);
         wrapper.appendChild(input);
+        // "Check verde" só faz sentido num campo de uma linha - numa textarea
+        // grande (descrição, checks) o ícone fixo no canto não acompanha bem
+        // o conteúdo que cresce em altura.
+        if (type !== "textarea") enableFilledCheck(input);
         parent.appendChild(wrapper);
         return wrapper;
     }
@@ -208,10 +216,10 @@ export function createSplitTransferComponent(onBack) {
     contactSection.innerHTML = `<div style="${styles.sectionTitle}">📞 Contato & Problema</div>`;
     scrollArea.appendChild(contactSection);
 
-    createField({ id: "name", label: "Advertiser Name", required: true, parent: contactSection });
-    createField({ id: "url", label: "Website URL", parent: contactSection });
-    createField({ id: "phone", label: "Phone Number", parent: contactSection });
-    createField({ id: "email", label: "Contact Email", parent: contactSection });
+    createField({ id: "name", label: "Advertiser Name", required: true, autocomplete: "name", parent: contactSection });
+    createField({ id: "url", label: "Website URL", type: "url", autocomplete: "url", parent: contactSection });
+    createField({ id: "phone", label: "Phone Number", type: "tel", autocomplete: "tel", parent: contactSection });
+    createField({ id: "email", label: "Contact Email", type: "email", autocomplete: "email", parent: contactSection });
     createField({ id: "callback", label: "Preferred Callback Time (Timezone)", parent: contactSection });
     
     createField({ id: "desc", label: "Detailed Issue Description", type: "textarea", placeholder: "Descreva o erro, passos para reproduzir...", required: true, parent: contactSection });
@@ -299,34 +307,40 @@ export function createSplitTransferComponent(onBack) {
     };
 
     // Validation Logic
+    const prefersReducedMotion = () => window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     const validate = () => {
         let isValid = true;
         let firstError = null;
+        const reduceMotion = prefersReducedMotion();
 
         Object.values(fields).forEach(field => {
             if (field.required && !field.input.value.trim()) {
                 isValid = false;
                 field.input.style.cssText += styles.inputError;
                 // Shake animation
-                field.wrapper.animate([
-                    { transform: 'translateX(0)' },
-                    { transform: 'translateX(-5px)' },
-                    { transform: 'translateX(5px)' },
-                    { transform: 'translateX(0)' }
-                ], { duration: 300 });
-                
+                if (!reduceMotion) {
+                    field.wrapper.animate([
+                        { transform: 'translateX(0)' },
+                        { transform: 'translateX(-5px)' },
+                        { transform: 'translateX(5px)' },
+                        { transform: 'translateX(0)' }
+                    ], { duration: 300 });
+                }
+
                 if (!firstError) firstError = field.input;
             }
         });
 
-        if (firstError) firstError.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (firstError) firstError.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "center" });
         return isValid;
     };
 
     // Generation Logic
     btnGenerate.onclick = async () => {
         if (!validate()) {
-            showToast("Preencha os campos obrigatórios.", { isError: true });
+            SoundManager.playError();
+            showToast("Preencha os campos obrigatórios.", { error: true });
             return;
         }
 
@@ -373,6 +387,7 @@ ${getVal('checks')}
             if (editor.innerText.trim() === "") editor.innerHTML = "";
             document.execCommand("insertHTML", false, htmlToInsert);
             triggerInputEvents(editor);
+            SoundManager.playSuccess();
             showToast("Nota gerada e inserida!");
         } else {
             showToast("Copiado! Abra uma nota para colar.");

--- a/src/modules/notes/components/step-scenarios.js
+++ b/src/modules/notes/components/step-scenarios.js
@@ -4,6 +4,9 @@ import { scenarioSnippets } from "../data/notes-data.js";
 import { SoundManager } from "../../shared/sound-manager.js";
 
 export function createScenariosComponent(onSelectCallback) {
+  // Hover/preview aqui é todo via estilo inline em JS, sem classe CSS pra
+  // pendurar um @media - checa direto, igual foi feito na animação do genie.
+  const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   const container = document.createElement("div");
   container.className = "cw-step-scenarios";
@@ -38,7 +41,9 @@ export function createScenariosComponent(onSelectCallback) {
   });
 
   const previewText = document.createElement("span");
-  previewText.style.transition = "opacity 0.2s ease, transform 0.2s ease";
+  // 0.05s bate com o setTimeout de 50ms do hover (abaixo) - o texto troca
+  // exatamente quando o fade-out termina, não no meio dele.
+  previewText.style.transition = "opacity 0.05s ease, transform 0.05s ease";
   previewText.textContent = DEFAULT_PREVIEW_TEXT;
   previewBox.appendChild(previewText);
 
@@ -72,6 +77,7 @@ export function createScenariosComponent(onSelectCallback) {
           const label = id.replace('quickfill-', '').replace(/-/g, ' ');
           chip.textContent = label;
           chip.dataset.id = id;
+          chip.dataset.sound = "hover";
 
           Object.assign(chip.style, {
             padding: "6px 12px",
@@ -95,12 +101,12 @@ export function createScenariosComponent(onSelectCallback) {
               }
 
               previewText.style.opacity = "0";
-              previewText.style.transform = "translateY(5px)";
+              if (!reduceMotion) previewText.style.transform = "translateY(5px)";
 
               hoverTimeout = setTimeout(() => {
                   previewText.textContent = textPreviewContent.substring(0, 120) + (textPreviewContent.length > 120 ? '...' : '');
                   previewText.style.opacity = "1";
-                  previewText.style.transform = "translateY(0)";
+                  if (!reduceMotion) previewText.style.transform = "translateY(0)";
               }, 50);
           };
 

--- a/src/modules/notes/components/step-tasks.js
+++ b/src/modules/notes/components/step-tasks.js
@@ -1,5 +1,6 @@
 import { TASKS_DB } from "../data/notes-data.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
+import { createEmptyState, enableArrowKeyNav } from "../../shared/dom-utils.js";
 
 // Tarefas que, com Tag Support já usado, dispensam screenshot de evidência
 // (a menos que o agente force manualmente via "Incluir mesmo assim").
@@ -154,7 +155,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
                 position: relative; 
                 height: 90px;
                 display: flex; flex-direction: column; align-items: center; justify-content: center;
-                transition: all 0.4s cubic-bezier(0.25, 1, 0.3, 1);
+                transition: all 0.4s var(--cw-ease-decelerate);
                 box-shadow: 0 2px 6px rgba(0,0,0,0.02);
                 overflow: hidden;
             }
@@ -165,6 +166,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
             /* Interação */
             .cw-hero-card:hover { border-color: var(--hero-color); box-shadow: 0 8px 20px rgba(0,0,0,0.06); transform: translateY(-3px); }
             .cw-hero-card:active { transform: scale(0.96) translateY(0); }
+            .cw-hero-card:focus-visible { outline: 2px solid var(--hero-color); outline-offset: 2px; }
 
             /* HERO ACTIVE STATE (Borda Colorida Apenas) */
             .cw-hero-card.active {
@@ -225,7 +227,15 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
                 color: ${DS.textMain}; display: flex; align-items: center; justify-content: center;
                 font-size: 14px; font-weight: bold; cursor: pointer; transition: background 0.1s;
             }
-            .cw-step-btn-hero:hover { background: #E5E7EB; color: var(--hero-color); }            /* LIST SECTION */
+            .cw-step-btn-hero:hover { background: #E5E7EB; color: var(--hero-color); }            /* Some SR (Screen Reader) só - o placeholder do campo de busca já
+               é a dica visual; isso dá o mesmo texto pra quem usa leitor de
+               tela, sem duplicar nada na tela pra quem enxerga. */
+            .cw-sr-only {
+                position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+                overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+            }
+
+            /* LIST SECTION */
             .cw-list-section { padding: 24px 24px; }
             .cw-search-input {
                 width: 100%; box-sizing: border-box; padding: 10px 12px 10px 36px;
@@ -258,6 +268,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
             }
             .cw-task-item:last-child { border-bottom: none; }
             .cw-task-item:hover { background: #F3F4F6; }
+            .cw-task-item:focus-visible, .cw-acc-header:focus-visible { outline: 2px solid ${DS.blue}; outline-offset: -2px; }
             .cw-task-item.selected { background: ${DS.blueLight}; }
             .cw-task-item.ts-success { background: #F0FDF4 !important; border-left: 4px solid #22C55E; }
             .cw-task-item.ts-success .cw-task-label { color: #166534 !important; }
@@ -331,7 +342,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
                 
                 padding: 24px;
                 position: relative;
-                transition: all 0.4s cubic-bezier(0.25, 1, 0.3, 1);
+                transition: all 0.4s var(--cw-ease-decelerate);
                 box-shadow: 0 4px 12px rgba(0,0,0,0.03);
                 margin-bottom: 16px;
             }
@@ -467,7 +478,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
                 border: 1.5px solid #f1f3f4;
                 background: #f8f9fa;
                 font-size: 14px; color: #374151;
-                transition: all 0.25s cubic-bezier(0.25, 1, 0.3, 1); outline: none;
+                transition: all 0.25s var(--cw-ease-decelerate); outline: none;
             }
 
             /* Foco no Input: Usa a cor da marca */
@@ -487,13 +498,26 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
 
             /* Check Icon Animado */
             .cw-input-check {
-                position: absolute; right: 10px; bottom: 10px; 
+                position: absolute; right: 10px; bottom: 10px;
                 color: #16A34A; width: 16px; height: 16px;
-                opacity: 0; transform: scale(0.5); 
-                transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+                opacity: 0; transform: scale(0.5);
+                transition: all 0.3s var(--cw-ease-spring);
                 pointer-events: none;
             }
             .cw-input-field.filled + .cw-input-check { opacity: 1; transform: scale(1); }
+
+            /* Esta é a etapa mais repetida do app inteiro (escolher a task do
+               caso) e não tinha nenhuma proteção de reduced-motion, apesar
+               dos hero cards, do accordion e do "check verde" animarem
+               transform em praticamente toda interação. */
+            @media (prefers-reduced-motion: reduce) {
+                .cw-hero-card, .cw-hero-card:hover, .cw-hero-main, .cw-hero-stepper,
+                .cw-task-item, .cw-acc-icon, .cw-status-bar, .cw-input-check {
+                    transition: opacity 0.15s ease !important;
+                    transform: none !important;
+                }
+                .cw-acc-group.open .cw-acc-body { animation: none !important; }
+            }
         `;
     document.head.appendChild(style);
   }
@@ -521,7 +545,8 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
 
             <div class="cw-list-section">
                 <div class="cw-search-wrapper">
-                    <input class="cw-search-input" placeholder="${t('buscar_catalogo')}">
+                    <label class="cw-sr-only" for="cw-task-search-input">${t('buscar_catalogo')}</label>
+                    <input id="cw-task-search-input" class="cw-search-input" placeholder="${t('buscar_catalogo')}">
                 </div>
                 <div class="cw-acc-container"></div>
                 <div class="cw-results-container" style="display:none"></div>
@@ -538,6 +563,10 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
   const accContainer = container.querySelector(".cw-acc-container");
   const resultsContainer = container.querySelector(".cw-results-container");
   const searchInput = container.querySelector(".cw-search-input");
+  // ↓/↑ anda entre cabeçalhos de categoria e itens visíveis (do acordeão ou
+  // dos resultados de busca, ambos dentro de `container`) sem precisar
+  // reconstruir nada quando a lista muda.
+  enableArrowKeyNav(container, ".cw-acc-header, .cw-task-item");
   const statusBar = container.querySelector(".cw-status-bar");
   const statusText = container.querySelector(".cw-status-text");
   const footerIcons = container.querySelector(".cw-footer-icons");
@@ -579,6 +608,18 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
     card.querySelector(".minus").onclick = () => updateTask(key, -1, task);
     card.querySelector(".plus").onclick = () => updateTask(key, 1, task);
 
+    // Cards eram só clicáveis por mouse - a etapa de escolher a task é a
+    // interação central do módulo de Notes, então precisa funcionar por teclado.
+    card.tabIndex = 0;
+    card.setAttribute("role", "button");
+    card.setAttribute("aria-pressed", "false");
+    card.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        card.click();
+      }
+    });
+
     card.dataset.color = brand.color;
 
     heroGrid.appendChild(card);
@@ -611,6 +652,17 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
     row.querySelector(".minus").onclick = () => updateTask(key, -1, task);
     row.querySelector(".plus").onclick = () => updateTask(key, 1, task);
 
+    row.tabIndex = 0;
+    row.setAttribute("role", "button");
+    row.setAttribute("aria-pressed", "false");
+    row.setAttribute("aria-label", task.name);
+    row.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        row.click();
+      }
+    });
+
     return row;
   }
 
@@ -628,12 +680,25 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
             </div>
             <div class="cw-acc-icon">▼</div>
         `;
+    header.tabIndex = 0;
+    header.setAttribute("role", "button");
+    header.setAttribute("aria-expanded", "false");
     header.onclick = () => {
       accContainer.querySelectorAll(".cw-acc-group.open").forEach((g) => {
-        if (g !== group) g.classList.remove("open");
+        if (g !== group) {
+          g.classList.remove("open");
+          g.querySelector(".cw-acc-header")?.setAttribute("aria-expanded", "false");
+        }
       });
-      group.classList.toggle("open");
+      const isOpen = group.classList.toggle("open");
+      header.setAttribute("aria-expanded", String(isOpen));
     };
+    header.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        header.click();
+      }
+    });
 
     const body = document.createElement("div");
     body.className = "cw-acc-body";
@@ -672,12 +737,14 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
 
       if (sel) {
         card.classList.add("active");
+        card.setAttribute("aria-pressed", "true");
         card.querySelector(".cw-step-val").textContent = sel.count;
         card.querySelector(".cw-step-val").style.color = card.dataset.color;
 
         card.classList.toggle("ts-success", shouldSuppressScreenshots(key, notesState));
       } else {
         card.classList.remove("active");
+        card.setAttribute("aria-pressed", "false");
         card.classList.remove("ts-success");
       }
     });
@@ -689,11 +756,13 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
       const sel = selection[key];
       if (sel) {
         row.classList.add("selected");
+        row.setAttribute("aria-pressed", "true");
         row.querySelector(".cw-step-val").textContent = sel.count;
 
         row.classList.toggle("ts-success", shouldSuppressScreenshots(key, notesState));
       } else {
         row.classList.remove("selected");
+        row.setAttribute("aria-pressed", "false");
         row.classList.remove("ts-success");
       }
     });
@@ -754,6 +823,7 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
           const item = createListItem(key, task);
           if (selection[key]) {
             item.classList.add("selected");
+            item.setAttribute("aria-pressed", "true");
             item.querySelector(".cw-step-val").textContent =
               selection[key].count;
           }
@@ -784,7 +854,10 @@ export function createStepTasksComponent(onUpdateCallback, t, notesState) {
     let hasAny = false;
 
     if (keys.length === 0) {
-      screenList.innerHTML = `<div class="cw-empty-state">${t('selecione_tarefas')}</div>`;
+      screenList.appendChild(createEmptyState({
+        icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><circle cx="8.5" cy="8.5" r="1.5"></circle><path d="M21 15l-5-5L5 21"></path></svg>`,
+        title: t('selecione_tarefas'),
+      }));
       screenshotsContainer.style.display = "none";
       return;
     }

--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -3,7 +3,7 @@ import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, trans
 import { fetchAndInsertSpeakeasyId } from "../automation/case-log-scraper.js";
 import { enableAutoBullet } from "../components/bullet-editor.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
-import { confirmDialog } from "../../shared/utils.js";
+import { SoundManager } from "../../shared/sound-manager.js";
 
 export function buildDynamicForm(subStatusKey, container, state) {
     container.innerHTML = "";
@@ -38,7 +38,7 @@ export function buildDynamicForm(subStatusKey, container, state) {
             btnSearch.style.cssText = `font-size: 11px; font-weight: 700; color: ${COLORS.primary}; background-color: ${COLORS.primaryBg}; border: none; border-radius: ${RADIUS.pill}; padding: 6px 14px; margin-left: 10px; cursor: pointer; transition: all 0.2s ${EASE};`;
             btnSearch.onmouseenter = () => btnSearch.style.backgroundColor = "#d2e3fc";
             btnSearch.onmouseleave = () => btnSearch.style.backgroundColor = COLORS.primaryBg;
-            btnSearch.onclick = (e) => { e.preventDefault(); fetchAndInsertSpeakeasyId(fieldId); };
+            btnSearch.onclick = (e) => { e.preventDefault(); SoundManager.playClick(); fetchAndInsertSpeakeasyId(fieldId); };
             label.appendChild(btnSearch);
         }
 
@@ -48,13 +48,15 @@ export function buildDynamicForm(subStatusKey, container, state) {
             btnDelete.style.cssText = `font-size: 14px; background: ${COLORS.bgInput}; border: none; color: ${COLORS.textSub}; cursor: pointer; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-left: auto; transition: all 0.2s ${EASE};`;
             btnDelete.onmouseenter = () => { btnDelete.style.background = COLORS.error; btnDelete.style.color = COLORS.surface; };
             btnDelete.onmouseleave = () => { btnDelete.style.background = COLORS.bgInput; btnDelete.style.color = COLORS.textSub; };
-            btnDelete.onclick = async (e) => {
+            // Sem confirmDialog aqui: remover um campo opcional é reversível
+            // num clique só (o chip "+ campo" reaparece logo abaixo), então
+            // bloquear com um modal só atrapalhava a velocidade sem
+            // proteger nada de fato irreversível.
+            btnDelete.onclick = (e) => {
                 e.preventDefault();
-                const confirmed = await confirmDialog(`Tem certeza que deseja remover o campo "${labelText.textContent.replace(':', '')}"?`);
-                if (confirmed) {
-                    state.removeField(fieldName);
-                    buildDynamicForm(subStatusKey, container, state);
-                }
+                SoundManager.playClick();
+                state.removeField(fieldName);
+                buildDynamicForm(subStatusKey, container, state);
             };
             label.appendChild(btnDelete);
         }
@@ -119,6 +121,7 @@ export function buildDynamicForm(subStatusKey, container, state) {
             chip.onmouseleave = () => chip.style.backgroundColor = COLORS.primaryBg;
             chip.onclick = (e) => {
                 e.preventDefault();
+                SoundManager.playClick();
                 state.addFieldAt(fieldName, state.activeFields.length);
                 buildDynamicForm(subStatusKey, container, state);
             };

--- a/src/modules/notes/drafts/draft-ui.js
+++ b/src/modules/notes/drafts/draft-ui.js
@@ -35,31 +35,33 @@ export function createDraftsManager(callbacks) {
         align-items: center; 
         justify-content: center;
         gap: 8px;
-        transition: all 0.2s ${EASE};
+        transition: background-color 0.2s ${EASE}, border-color 0.2s ${EASE}, color 0.2s ${EASE}, box-shadow 0.2s ${EASE}, transform 0.1s ${EASE};
         box-shadow: ${SHADOW.subtle};
         text-transform: uppercase;
         letter-spacing: 0.5px;
     `;
 
     // Micro-interações (Hover/Active)
+    // Sem transform no enter/leave: era o único botão do app cujo próprio
+    // hover-lift era disparado via onmouseenter/onmouseleave (não :hover CSS)
+    // - mesmo risco de flicker na borda, só que sem o hover "sticky" que o
+    // navegador dá pra pseudo-classe. A sombra crescendo já comunica o hover.
     parkButton.onmouseenter = () => {
         parkButton.style.backgroundColor = "#F8F9FA";
         parkButton.style.borderColor = "#202124";
         parkButton.style.color = "#202124";
         parkButton.style.boxShadow = "0 2px 4px rgba(0,0,0,0.1)";
-        parkButton.style.transform = "translateY(-1px)";
     };
-    
+
     parkButton.onmouseleave = () => {
         parkButton.style.backgroundColor = "#FFFFFF";
         parkButton.style.borderColor = "#DADCE0";
         parkButton.style.color = "#5F6368";
         parkButton.style.boxShadow = "0 1px 2px rgba(0,0,0,0.05)";
-        parkButton.style.transform = "translateY(0)";
     };
 
     parkButton.onmousedown = () => parkButton.style.transform = "scale(0.96)";
-    parkButton.onmouseup = () => parkButton.style.transform = "scale(1) translateY(-1px)";
+    parkButton.onmouseup = () => parkButton.style.transform = "scale(1)";
 
     // LÓGICA DE SALVAR
     parkButton.onclick = async () => {
@@ -74,10 +76,12 @@ export function createDraftsManager(callbacks) {
                     SoundManager.playSuccess();
                     showToast("Rascunho salvo com sucesso!");
                 } else {
+                    SoundManager.playError();
                     showToast("Erro: Não foi possível ler os dados.", { error: true });
                 }
             } catch (e) {
                 console.error("Erro ao salvar rascunho:", e);
+                SoundManager.playError();
                 showToast("Erro ao salvar.", { error: true });
             }
         }
@@ -121,11 +125,14 @@ export function createDraftsManager(callbacks) {
             badge.style.display = "block";
             badge.textContent = count;
             // Animação de "Pop"
-            badge.animate([
-                { transform: 'scale(1)' },
-                { transform: 'scale(1.5)' },
-                { transform: 'scale(1)' }
-            ], { duration: 200 });
+            const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            if (!reduceMotion) {
+                badge.animate([
+                    { transform: 'scale(1)' },
+                    { transform: 'scale(1.5)' },
+                    { transform: 'scale(1)' }
+                ], { duration: 200 });
+            }
         } else {
             badge.style.display = "none";
         }
@@ -192,7 +199,7 @@ export function createDraftsManager(callbacks) {
             card.style.cssText = `
                 background: ${COLORS.surface}; padding: 20px; border-radius: ${RADIUS.large};
                 border: 1.5px solid ${COLORS.bgInput}; box-shadow: ${SHADOW.subtle};
-                position: relative; transition: all 0.3s ${EASE};
+                position: relative;
             `;
             
             // Data formatada
@@ -217,10 +224,10 @@ export function createDraftsManager(callbacks) {
                     ${tagsHtml}
                 </div>
                 <div style="display:flex; gap:8px;">
-                    <button class="cw-resume-btn" style="flex:1; padding:8px; background:#1A73E8; color:#FFF; border:none; border-radius:6px; font-size:12px; font-weight:600; cursor:pointer; box-shadow:0 1px 2px rgba(26,115,232,0.3); transition:all 0.2s;">
+                    <button class="cw-resume-btn" style="flex:1; padding:8px; background:#1A73E8; color:#FFF; border:none; border-radius:6px; font-size:12px; font-weight:600; cursor:pointer; box-shadow:0 1px 2px rgba(26,115,232,0.3);">
                         Retomar Caso
                     </button>
-                    <button class="cw-del-btn" style="width:36px; padding:8px; background:#FFF; border:1px solid #DADCE0; color:#5F6368; border-radius:6px; cursor:pointer; display:flex; align-items:center; justify-content:center; transition:all 0.2s;" title="Descartar">
+                    <button class="cw-del-btn" style="width:36px; padding:8px; background:#FFF; border:1px solid #DADCE0; color:#5F6368; border-radius:6px; cursor:pointer; display:flex; align-items:center; justify-content:center;" title="Descartar">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
                     </button>
                 </div>

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -13,6 +13,7 @@ import { createDraftsManager } from "./drafts/draft-ui.js";
 import { createSplitTransferComponent } from "./components/split-transfer.js";
 import { DraftService } from "./drafts/draft-service.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { enableFilledCheck, lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 import { getPageData } from "../shared/page-data.js";
 import {
     SUBSTATUS_TEMPLATES,
@@ -30,7 +31,7 @@ import {
     triggerInputEvents
 } from "./notes-bridge.js";
 import { runEmailAutomation } from "../email-assistant/email-automation-service.js";
-import { triggerProcessingAnimation, updateNotesBadge } from "../shared/command-center.js";
+import { triggerProcessingAnimation, updateNotesBadge, registerCaseCompleted } from "../shared/command-center.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 
 export function initCaseNotesAssistant() {
@@ -87,6 +88,7 @@ export function initCaseNotesAssistant() {
         input.style.marginBottom = "0";
         wrapper.appendChild(label);
         wrapper.appendChild(input);
+        enableFilledCheck(input, { minLength: 8 }); // link de evidência - poucos caracteres ainda não é um link válido
         evidenceInputs[id] = input;
         return wrapper;
     };
@@ -201,6 +203,7 @@ export function initCaseNotesAssistant() {
 
     function toggleVisibility() {
         notesState.visible = !notesState.visible;
+        if (notesState.visible) lockBodyScroll(); else unlockBodyScroll();
         toggleGenieAnimation(notesState.visible, popup, "cw-btn-notes");
     }
 
@@ -314,7 +317,7 @@ export function initCaseNotesAssistant() {
                 div.querySelectorAll('#lang-selector button').forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
                 updateIndicator('lang-selector', idx);
-                SoundManager.playHover();
+                SoundManager.playClick();
                 if (notesState.currentSubStatus) {
                     onSubStatusChange(notesState.currentSubStatus);
                 }
@@ -327,7 +330,7 @@ export function initCaseNotesAssistant() {
                 div.querySelectorAll('#type-selector button').forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
                 updateIndicator('type-selector', idx);
-                SoundManager.playHover();
+                SoundManager.playClick();
                 if (notesState.currentSubStatus) {
                     onSubStatusChange(notesState.currentSubStatus);
                 }
@@ -340,7 +343,7 @@ export function initCaseNotesAssistant() {
                 div.querySelectorAll('#portugal-selector button').forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
                 updateIndicator('portugal-selector', idx);
-                SoundManager.playHover();
+                SoundManager.playClick();
                 if (notesState.currentSubStatus) {
                     onSubStatusChange(notesState.currentSubStatus);
                 }
@@ -355,7 +358,7 @@ export function initCaseNotesAssistant() {
         div.className = "cw-status-section";
         div.style.cssText = "display: flex; flex-direction: column; gap: 8px;";
         div.innerHTML = `
-            <div class="cw-section-title js-label-status" style="margin-top: 8px;">${t('status_principal')}</div>
+            <label class="cw-section-title js-label-status" for="main-status-select" style="margin-top: 8px;">${t('status_principal')}</label>
             <select id="main-status-select" class="cw-select">
                 <option value="" disabled selected>${t('select_status')}</option>
                 <option value="NI">NI - Need Info</option>
@@ -364,7 +367,7 @@ export function initCaseNotesAssistant() {
                 <option value="AS">AS - Assigned</option>
                 <option value="DC">DC - Discard</option>
             </select>
-            <div class="cw-section-title js-label-substatus" style="margin-top: 8px;">${t('substatus')}</div>
+            <label class="cw-section-title js-label-substatus" for="sub-status-select" style="margin-top: 8px;">${t('substatus')}</label>
             <select id="sub-status-select" class="cw-select" disabled>
                 <option value="">${t('select_substatus')}</option>
             </select>
@@ -403,13 +406,36 @@ export function initCaseNotesAssistant() {
             subSelect.disabled = true;
             return;
         }
+
+        // IN é a única lista longa o bastante (8 itens) pra ter um subgrupo
+        // real dentro dela: "Fora de Escopo" já é uma categoria com nome
+        // próprio nos dados (Out_of_Scope_*), então o <optgroup> aqui separa
+        // informação de verdade, não só decora. Os demais status têm poucos
+        // itens (2 a 4) e nenhum subgrupo natural — envolvê-los num optgroup
+        // não ajudaria em nada a escanear a lista.
+        const outOfScopeGroup = status === 'IN'
+            ? (() => {
+                const g = document.createElement("optgroup");
+                g.label = "Fora de Escopo";
+                return g;
+            })()
+            : null;
+
         for (const key in SUBSTATUS_TEMPLATES) {
             if (SUBSTATUS_TEMPLATES[key].status === status) {
                 const opt = document.createElement("option");
                 opt.value = key;
                 opt.textContent = SUBSTATUS_TEMPLATES[key].name;
-                subSelect.appendChild(opt);
+
+                if (outOfScopeGroup && key.startsWith('IN_Out_of_Scope')) {
+                    outOfScopeGroup.appendChild(opt);
+                } else {
+                    subSelect.appendChild(opt);
+                }
             }
+        }
+        if (outOfScopeGroup && outOfScopeGroup.children.length > 0) {
+            subSelect.appendChild(outOfScopeGroup);
         }
         subSelect.disabled = false;
     }
@@ -666,6 +692,7 @@ export function initCaseNotesAssistant() {
 
     async function handleCopy() {
         if (!notesState.currentSubStatus) {
+            SoundManager.playError();
             showToast(t('select_substatus'), { error: true });
             return;
         }
@@ -675,12 +702,14 @@ export function initCaseNotesAssistant() {
             showToast(t('copiado_sucesso'));
             SoundManager.playClick();
         } else {
+            SoundManager.playError();
             showToast(t('select_substatus'), { error: true });
         }
     }
 
     async function handleGenerate() {
         if (!notesState.currentSubStatus) {
+            SoundManager.playError();
             showToast(t('select_substatus'), { error: true });
             return;
         }
@@ -693,11 +722,13 @@ export function initCaseNotesAssistant() {
             return !value || !value.trim();
         });
         if (missingRequired.length > 0) {
+            SoundManager.playError();
             showToast(`Preencha o campo obrigatório antes de gerar: ${t(missingRequired[0].toLowerCase())}`, { error: true });
             return;
         }
 
         if (templateData?.requiresTasks && stepTasks.getCheckedElements().length === 0) {
+            SoundManager.playError();
             showToast("Selecione ao menos uma tarefa antes de gerar a nota.", { error: true });
             return;
         }
@@ -723,6 +754,7 @@ export function initCaseNotesAssistant() {
 
             showToast(t('inserido_copiado'));
             SoundManager.playSuccess();
+            registerCaseCompleted(); // nota inserida com sucesso = 1 caso concluído no ritmo do turno
             resetModule();
         } else {
             // ensureNoteCardIsOpen() não achou/abriu o editor de nota no CRM
@@ -730,6 +762,7 @@ export function initCaseNotesAssistant() {
             // (linha acima), então o conteúdo não se perde — mas o popup
             // tinha sido fechado como se tivesse dado certo, deixando o
             // agente sem nenhum aviso de que a nota não foi inserida.
+            SoundManager.playError();
             showToast("Não foi possível abrir a nota no CRM. O conteúdo já está copiado — cole manualmente.", { error: true });
             toggleVisibility();
         }

--- a/src/modules/notes/notes-bridge.js
+++ b/src/modules/notes/notes-bridge.js
@@ -1,6 +1,7 @@
 // src/modules/notes/notes-bridge.js
 import { showToast } from '../shared/utils.js';
 import { esperar, simularCliqueReal } from '../shared/dom-utils.js';
+import { SoundManager } from '../shared/sound-manager.js';
 
 export function copyHtmlToClipboard(html) {
     const container = document.createElement('div');
@@ -16,6 +17,7 @@ export function copyHtmlToClipboard(html) {
     try {
         document.execCommand('copy');
     } catch (err) {
+        SoundManager.playError();
         showToast("Falha ao copiar", { error: true });
     }
     selection.removeAllRanges();

--- a/src/modules/notes/tag-support.js
+++ b/src/modules/notes/tag-support.js
@@ -4,6 +4,7 @@
 import { styleLabel } from '../shared/utils.js';
 import {styleCheckboxInput} from '../notes/notes-styles.js'
 import { notesState } from './core/notes-state.js';
+import { SoundManager } from '../shared/sound-manager.js';
 
 // Estilos locais específicos deste módulo
 const styleContainer = { 
@@ -62,7 +63,7 @@ export function createTagSupportModule(t) {
 
     const warningText = document.createElement("div");
     warningText.className = "js-ts-warning";
-    warningText.innerHTML = `⚠️ <strong>${t('lembre_preencher_form')}</strong> <a href="https://docs.google.com/forms/d/e/1FAIpQLSeP_JM8D-6qHa5ZC93aTzj38WiO5zx8nyrWNPvbZhjJj6CpkA/viewform" target="_blank" style="color:#e37400; text-decoration:underline;">Link aqui</a>`;
+    warningText.innerHTML = `⚠️ <strong>${t('lembre_preencher_form')}</strong> <a href="https://docs.google.com/forms/d/e/1FAIpQLSeP_JM8D-6qHa5ZC93aTzj38WiO5zx8nyrWNPvbZhjJj6CpkA/viewform" target="_blank" rel="noopener noreferrer" style="color:#e37400; text-decoration:underline;">Link aqui</a>`;
     Object.assign(warningText.style, styleWarning);
 
     reasonDiv.appendChild(reasonLabel);
@@ -75,10 +76,12 @@ export function createTagSupportModule(t) {
 
     // --- 2. EVENTOS INTERNOS ---
     rSim.onchange = () => {
+        SoundManager.playClick();
         reasonDiv.style.display = 'none';
         notesState.setTagSupportUsed(true);
     };
     rNao.onchange = () => {
+        SoundManager.playClick();
         reasonDiv.style.display = 'block';
         notesState.setTagSupportUsed(false);
     };
@@ -122,7 +125,7 @@ export function createTagSupportModule(t) {
         t = newT;
         mainLabel.textContent = t('utilizou_tag_support');
         reasonLabel.textContent = t('motivo_ts');
-        warningText.innerHTML = `⚠️ <strong>${t('lembre_preencher_form')}</strong> <a href="https://docs.google.com/forms/d/e/1FAIpQLSeP_JM8D-6qHa5ZC93aTzj38WiO5zx8nyrWNPvbZhjJj6CpkA/viewform" target="_blank" style="color:#b06000; text-decoration:underline;">Link aqui</a>`;
+        warningText.innerHTML = `⚠️ <strong>${t('lembre_preencher_form')}</strong> <a href="https://docs.google.com/forms/d/e/1FAIpQLSeP_JM8D-6qHa5ZC93aTzj38WiO5zx8nyrWNPvbZhjJj6CpkA/viewform" target="_blank" rel="noopener noreferrer" style="color:#b06000; text-decoration:underline;">Link aqui</a>`;
     }
 
     // Reseta o estado (chamado ao mudar de passo)

--- a/src/modules/notes/ui/notes-popup.js
+++ b/src/modules/notes/ui/notes-popup.js
@@ -77,7 +77,7 @@ function injectStyles() {
             border: 1.5px solid ${COLORS.border} !important;
             font-size: 14px !important;
             font-family: 'Google Sans', Roboto, sans-serif !important;
-            transition: all 0.2s ${EASE} !important;
+            transition: border-color 0.2s ${EASE}, background-color 0.2s ${EASE}, box-shadow 0.2s ${EASE} !important;
             box-sizing: border-box !important;
             background: ${COLORS.bgInput} !important;
             color: ${COLORS.text} !important;
@@ -142,7 +142,7 @@ function injectStyles() {
             padding: 12px 24px;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s ${EASE};
+            transition: background-color 0.2s ${EASE}, transform 0.2s ${EASE}, box-shadow 0.2s ${EASE};
             box-shadow: 0 4px 12px rgba(26, 115, 232, 0.3);
             display: flex;
             align-items: center;
@@ -164,12 +164,19 @@ function injectStyles() {
             padding: 12px 24px;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s ${EASE};
+            transition: background-color 0.2s ${EASE}, border-color 0.2s ${EASE}, color 0.2s ${EASE};
         }
         .cw-btn-secondary:hover {
             background: ${COLORS.bgInput};
             border-color: #bdc1c6;
             color: ${COLORS.text};
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-btn-primary, .cw-btn-secondary, .cw-input, .cw-textarea, .cw-select {
+                transition: opacity 0.15s ease, background-color 0.15s ease, border-color 0.15s ease !important;
+                transform: none !important;
+            }
         }
     `;
     document.head.appendChild(style);

--- a/src/modules/onboarding/onboarding-wizard.js
+++ b/src/modules/onboarding/onboarding-wizard.js
@@ -2,6 +2,7 @@
 
 import { stylePopup, showToast, confirmDialog } from "../shared/utils.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 
 export function initOnboarding() {
     // 1. Verificação de Segurança (Já viu?)
@@ -75,6 +76,9 @@ export function initOnboarding() {
     // --- CONSTRUÇÃO DA UI ---
     const overlay = document.createElement("div");
     Object.assign(overlay.style, styles.overlay);
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.setAttribute("aria-labelledby", "cw-onboarding-title");
 
     const card = document.createElement("div");
     Object.assign(card.style, styles.card);
@@ -84,6 +88,7 @@ export function initOnboarding() {
     Object.assign(iconEl.style, styles.icon);
 
     const titleEl = document.createElement("div");
+    titleEl.id = "cw-onboarding-title";
     Object.assign(titleEl.style, styles.title);
 
     const textEl = document.createElement("div");
@@ -119,6 +124,7 @@ export function initOnboarding() {
     card.appendChild(actionsEl);
     overlay.appendChild(card);
     document.body.appendChild(overlay);
+    lockBodyScroll();
 
     // --- LÓGICA DE RENDERIZAÇÃO ---
     function renderSlide(index) {
@@ -157,6 +163,8 @@ export function initOnboarding() {
         setTimeout(() => overlay.remove(), 400);
         SoundManager.playSuccess();
         showToast("Tudo pronto! Use o menu flutuante.");
+        document.removeEventListener("keydown", handleKeydown);
+        unlockBodyScroll();
     }
 
     // --- LISTENERS ---
@@ -175,10 +183,27 @@ export function initOnboarding() {
         if(confirmed) closeWizard();
     };
 
+    // Enter avança para o próximo slide, Esc equivale a "Pular" - o wizard é
+    // linear e essa é a primeira tela que um usuário novo vê, então navegar
+    // sem tirar a mão do teclado importa mais aqui do que em qualquer outro popup.
+    function handleKeydown(e) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            btnNext.click();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            btnSkip.click();
+        }
+    }
+    document.addEventListener("keydown", handleKeydown);
+
     // Iniciar Animação de Entrada
     renderSlide(0);
     requestAnimationFrame(() => {
         overlay.style.opacity = "1";
         card.style.transform = "translateY(0)";
     });
+    // Foco inicial no botão de ação principal - primeiro dialog modal que um
+    // usuário novo vê, então precisa entrar já com foco em algo operável.
+    setTimeout(() => btnNext.focus(), 450);
 }

--- a/src/modules/personal-library/personal-library-assistant.js
+++ b/src/modules/personal-library/personal-library-assistant.js
@@ -4,6 +4,7 @@ import { stylePopup, styleResizeHandle, makeResizable, showToast, confirmDialog,
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 import { SnippetService } from "./snippet-service.js";
 
 // --- ÍCONES (Material Symbols, estilo outline) ---
@@ -34,6 +35,31 @@ const TABS = [
     { id: 'note', label: 'Notas', icon: ICONS.tabs.note },
     { id: 'email', label: 'Emails', icon: ICONS.tabs.email }
 ];
+
+// --- USADOS RECENTEMENTE ---
+// Só guarda IDs (não o conteúdo) - a lista de itens de verdade continua
+// vindo do SnippetService, isso aqui é só "última ordem de uso" por aba.
+const RECENT_KEY = 'cw_lib_recent_v1';
+const RECENT_MAX = 4;
+
+function trackRecentUse(itemId) {
+    try {
+        let recent = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+        recent = recent.filter(id => id !== itemId);
+        recent.unshift(itemId);
+        recent = recent.slice(0, RECENT_MAX * 3); // folga pra sobreviver a filtros por aba
+        localStorage.setItem(RECENT_KEY, JSON.stringify(recent));
+    } catch (e) { console.warn("Erro ao salvar uso recente", e); }
+}
+
+function getRecentItems(tab) {
+    try {
+        const recentIds = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+        if (recentIds.length === 0) return [];
+        const itemsById = new Map(SnippetService.getSnippets(tab).map(item => [item.id, item]));
+        return recentIds.map(id => itemsById.get(id)).filter(Boolean).slice(0, RECENT_MAX);
+    } catch (e) { return []; }
+}
 
 // --- FOLHA DE ESTILOS DEDICADA (Material 3 + Glass) ---
 // Substitui o antigo padrão de montar style="..." via objectToCss() elemento a
@@ -95,7 +121,7 @@ function injectStyles() {
             flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
             padding: 8px 10px; border-radius: 100px; cursor: pointer; user-select: none;
             font-size: 12.5px; font-weight: 500; color: #5f6368;
-            transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+            transition: background-color 0.25s var(--cw-ease-standard), color 0.25s var(--cw-ease-standard), box-shadow 0.25s var(--cw-ease-standard);
         }
         .cw-lib-tab svg { flex-shrink: 0; }
         .cw-lib-tab:hover { color: #202124; }
@@ -114,7 +140,7 @@ function injectStyles() {
             border-radius: 18px; padding: 16px 16px 12px 16px;
             position: relative; isolation: isolate;
             box-shadow: 0 1px 3px rgba(60,64,67,0.08);
-            transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), border-color 0.35s ease;
+            transition: box-shadow 0.35s var(--cw-ease-elastic), border-color 0.35s ease;
             display: flex; flex-direction: column;
         }
         /* isolation:isolate dá a cada card seu próprio contexto de empilhamento,
@@ -127,7 +153,9 @@ function injectStyles() {
             background: linear-gradient(135deg, rgba(138,180,248,0.16), rgba(197,138,249,0.16), rgba(242,139,130,0.16));
             background-size: 300% 300%; opacity: 0; transition: opacity 0.4s ease;
         }
-        .cw-lib-card:hover { transform: translateY(-3px); box-shadow: 0 10px 24px rgba(60,64,67,0.14); border-color: rgba(255,255,255,0.9); }
+        /* Sem transform no próprio card - hit-box parado evita flicker de
+           hover perto da borda. Elevação só por sombra/borda. */
+        .cw-lib-card:hover { box-shadow: 0 10px 24px rgba(60,64,67,0.14); border-color: rgba(255,255,255,0.9); }
         .cw-lib-card:hover::before { opacity: 1; animation: cwLibAura 8s ease infinite; }
         .cw-lib-card.is-code { border-left: 3px solid #1a73e8; }
         @keyframes cwLibAura { 0% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } 100% { background-position: 0% 50%; } }
@@ -190,6 +218,23 @@ function injectStyles() {
         .cw-lib-empty-title { font-weight: 600; font-size: 15px; color: #3c4043; }
         .cw-lib-empty-sub { font-size: 13px; max-width: 260px; line-height: 1.5; }
 
+        /* --- USADOS RECENTEMENTE --- */
+        .cw-lib-recent-section { grid-column: 1 / -1; margin-bottom: 4px; }
+        .cw-lib-recent-title {
+            font-size: 11px; font-weight: 700; color: #80868b; text-transform: uppercase;
+            letter-spacing: 0.6px; margin-bottom: 8px; display: flex; align-items: center; gap: 6px;
+        }
+        .cw-lib-recent-row { display: flex; flex-wrap: wrap; gap: 8px; }
+        .cw-lib-recent-chip {
+            display: flex; align-items: center; gap: 6px; padding: 7px 14px;
+            background: rgba(26,115,232,0.08); border: 1px solid rgba(26,115,232,0.18);
+            border-radius: 100px; font-size: 12.5px; font-weight: 600; color: #1a73e8;
+            cursor: pointer; max-width: 220px; transition: background-color 0.15s ease, transform 0.15s ease;
+        }
+        .cw-lib-recent-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .cw-lib-recent-chip:hover { background: rgba(26,115,232,0.14); }
+        .cw-lib-recent-chip:focus-visible { outline: 2px solid #1a73e8; outline-offset: 2px; }
+
         /* --- FAB --- */
         .cw-lib-fab {
             position: absolute; bottom: 24px; right: 24px; z-index: 15;
@@ -206,7 +251,7 @@ function injectStyles() {
         .cw-lib-sheet {
             position: absolute; inset: 0; z-index: 25;
             background: rgba(250,251,252,0.6); backdrop-filter: blur(36px) saturate(180%); -webkit-backdrop-filter: blur(36px) saturate(180%);
-            transform: translateY(100%); transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+            transform: translateY(100%); transition: transform 0.5s var(--cw-ease-decelerate);
             display: flex; flex-direction: column;
         }
         .cw-lib-sheet.open { transform: translateY(0); }
@@ -238,7 +283,7 @@ function injectStyles() {
         .cw-lib-tb-btn {
             width: 32px; height: 32px; border-radius: 8px; border: none; background: transparent;
             display: flex; align-items: center; justify-content: center; cursor: pointer; color: #474747;
-            transition: all 0.15s ease;
+            transition: background-color 0.15s ease, color 0.15s ease;
         }
         .cw-lib-tb-btn:hover { background: rgba(0,0,0,0.05); color: #1a73e8; }
         .cw-lib-tb-btn.active { background: rgba(26,115,232,0.12); color: #1a73e8; }
@@ -268,6 +313,19 @@ function injectStyles() {
 
         .cw-tactile { transition: transform 0.15s ease; }
         .cw-tactile:active { transform: scale(0.94); }
+
+        /* O spinner de carregamento fica de fora de propósito - é
+           informativo (comunica "ainda trabalhando"), não decorativo.
+           O resto (aura infinita no hover, cards, FAB, painel deslizando)
+           é puro movimento e não tinha nenhuma proteção. */
+        @media (prefers-reduced-motion: reduce) {
+            .cw-lib-card::before { animation: none !important; }
+            .cw-lib-card, .cw-lib-recent-chip, .cw-lib-fab, .cw-lib-save-btn,
+            .cw-lib-menu, .cw-lib-sheet {
+                transition: opacity 0.15s ease, background-color 0.15s ease !important;
+                transform: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
@@ -427,11 +485,42 @@ export function initPersonalLibrary() {
         return haystack.includes(term);
     }
 
+    function createRecentSection(recentItems) {
+        const section = document.createElement("div");
+        section.className = "cw-lib-recent-section";
+        section.innerHTML = `<div class="cw-lib-recent-title">🕒 Usados recentemente</div>`;
+
+        const row = document.createElement("div");
+        row.className = "cw-lib-recent-row";
+        recentItems.forEach(item => {
+            const chip = document.createElement("div");
+            chip.className = "cw-lib-recent-chip";
+            chip.tabIndex = 0;
+            chip.setAttribute("role", "button");
+            chip.title = item.title;
+            chip.innerHTML = `<span>${escapeHtml(item.title)}</span>`;
+            chip.onclick = () => { SoundManager.playClick(); copyItem(item); };
+            chip.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") { e.preventDefault(); chip.click(); }
+            });
+            row.appendChild(chip);
+        });
+        section.appendChild(row);
+        return section;
+    }
+
     function renderList() {
         closeCardMenu();
         grid.innerHTML = "";
         const term = searchTerm.trim().toLowerCase();
         const items = SnippetService.getSnippets(currentTab).filter(item => matchesSearch(item, term));
+
+        // Atalho de acesso rápido: um clique copia direto, sem abrir o card
+        // inteiro - só aparece fora de busca, pra não competir com resultados.
+        if (!term) {
+            const recentItems = getRecentItems(currentTab);
+            if (recentItems.length > 0) grid.appendChild(createRecentSection(recentItems));
+        }
 
         if (items.length === 0) {
             const empty = document.createElement("div");
@@ -537,6 +626,7 @@ export function initPersonalLibrary() {
         } else {
             navigator.clipboard.writeText(item.content);
         }
+        trackRecentUse(item.id);
         showToast("Copiado!");
     }
 
@@ -563,16 +653,19 @@ export function initPersonalLibrary() {
         saveBtn.textContent = item ? "Salvar Alterações" : "Salvar";
         sheet.classList.add('open');
 
+        // 500ms = duração real da transição de .cw-lib-sheet (transform 0.5s
+        // var(--cw-ease-decelerate)) - focar antes disso rouba o scroll no
+        // meio do slide-in.
         setTimeout(() => {
             const firstInput = sheetBody.querySelector("input");
             if (firstInput) firstInput.focus();
-        }, 350);
+        }, 500);
     }
 
     function closeEditor() {
         SoundManager.playSwoosh();
         sheet.classList.remove('open');
-        setTimeout(() => { currentEditingId = null; }, 300);
+        setTimeout(() => { currentEditingId = null; }, 500);
     }
 
     async function handleSave() {
@@ -588,6 +681,7 @@ export function initPersonalLibrary() {
             const isCode = contentInput.getAttribute('data-is-code') === 'true';
 
             if (!title || !content || content === '<br>') {
+                SoundManager.playError();
                 showToast("Preencha título e conteúdo.", { error: true });
                 return;
             }
@@ -602,6 +696,7 @@ export function initPersonalLibrary() {
             if (currentTab === 'email') {
                 const subject = sheetBody.querySelector("#cw-lib-inp-subject").value.trim();
                 if (!subject) {
+                    SoundManager.playError();
                     showToast("Assunto é obrigatório para emails.", { error: true });
                     return;
                 }
@@ -617,6 +712,7 @@ export function initPersonalLibrary() {
             // sucesso falso e fechando o editor com o item perdido — era isso que
             // fazia parecer que "nenhuma função rodava".
             if (saved === false) {
+                SoundManager.playError();
                 showToast("Não foi possível salvar: usuário não identificado. Recarregue a página e tente de novo.", { error: true });
                 return;
             }
@@ -625,6 +721,7 @@ export function initPersonalLibrary() {
             closeEditor();
 
             if (saved.synced === false) {
+                SoundManager.playError();
                 showToast("Salvo localmente — sem conexão com a nuvem no momento.", { error: true });
             } else {
                 showToast("Salvo e sincronizado!");
@@ -632,6 +729,7 @@ export function initPersonalLibrary() {
             }
         } catch (error) {
             console.error("Erro ao salvar item da biblioteca:", error);
+            SoundManager.playError();
             showToast("Erro ao salvar item.", { error: true });
         } finally {
             loadingOverlay.classList.remove('active');
@@ -748,10 +846,10 @@ export function initPersonalLibrary() {
         visible = !visible;
         toggleGenieAnimation(visible, popup, "cw-btn-library");
         if (visible) {
-            document.body.style.overflow = "hidden";
+            lockBodyScroll();
             renderList();
         } else {
-            document.body.style.overflow = "";
+            unlockBodyScroll();
             closeCardMenu();
         }
     }

--- a/src/modules/personal-library/snippet-service.js
+++ b/src/modules/personal-library/snippet-service.js
@@ -3,6 +3,7 @@
 import { DataService } from "../shared/data-service.js";
 import { getAgentEmail } from "../shared/page-data.js";
 import { showToast } from "../shared/utils.js";
+import { SoundManager } from "../shared/sound-manager.js";
 
 const STORAGE_KEY = "cw_personal_library_v1";
 
@@ -34,6 +35,7 @@ export const SnippetService = {
     save: async (snippet) => {
         const userEmail = getAgentEmail();
         if (!userEmail) {
+            SoundManager.playError();
             showToast("Erro: Usuário não identificado.", { error: true });
             return false;
         }

--- a/src/modules/shared/animations.js
+++ b/src/modules/shared/animations.js
@@ -11,7 +11,7 @@ if (!document.getElementById('cw-module-styles')) {
             /* Animação Apple Spring (Ida e Volta) */
             transition: 
                 opacity 0.3s ease,
-                transform 0.45s cubic-bezier(0.25, 1, 0.5, 1), 
+                transform 0.45s var(--cw-ease-decelerate),
                 filter 0.3s ease,
                 box-shadow 0.3s ease;
             
@@ -59,12 +59,40 @@ if (!document.getElementById('cw-module-styles')) {
     document.head.appendChild(style);
 }
 
+// --- ESC GLOBAL: fecha qualquer popup de módulo aberto ---
+// Todo módulo (Notes, Email, Call Script, Links, Biblioteca, Timezone,
+// Configs, BAU Form, Broadcast) compartilha a mesma marcação via
+// createStandardHeader() (.cw-module-window + botão .cw-header-close), então
+// um único listener genérico cobre o app inteiro sem cada módulo precisar
+// implementar o próprio Esc. Cede a vez se um dialog customizado
+// (alertDialog/confirmDialog/promptDialog) estiver por cima, para não fechar
+// os dois de uma vez só.
+if (!window._cwEscapeListenerActive) {
+    window._cwEscapeListenerActive = true;
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') return;
+        if (document.querySelector('.cw-dialog-overlay')) return;
+
+        const openWindow = document.querySelector('.cw-module-window.open');
+        if (!openWindow) return;
+
+        const closeBtn = openWindow.querySelector('.cw-header-close');
+        if (closeBtn) closeBtn.click();
+    });
+}
+
 /**
  * Gerencia a animação Genie e o Foco
  */
 export function toggleGenieAnimation(show, popup, buttonId) {
     const btn = document.getElementById(buttonId);
     if (!popup) return;
+
+    // A animação mais disparada do app inteiro (9 módulos, várias aberturas
+    // por turno) não tinha nenhuma proteção de reduced-motion - a física de
+    // voo (translate+scale) some, mas a posição final é aplicada do mesmo
+    // jeito, só sem o trajeto animado.
+    const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     // Verifica se é a primeira vez (Centro) ou se já foi movido (Customizado)
     const isCustomPosition = popup.getAttribute("data-moved") === "true";
@@ -113,6 +141,12 @@ export function toggleGenieAnimation(show, popup, buttonId) {
         popup.style.transition = 'none';
         popup.style.opacity = '0';
         popup.style.pointerEvents = 'auto';
+        // will-change só durante a animação em si (~500ms) - este popup é 1
+        // de ~9 janelas de módulo que existem no DOM o tempo todo, então
+        // deixar isso ligado sempre desperdiçaria memória de GPU nas 8 que
+        // estão fechadas e paradas.
+        popup.style.willChange = 'transform, opacity';
+        setTimeout(() => { popup.style.willChange = 'auto'; }, 550);
 
         // B. POSIÇÃO DE PARTIDA (NO BOTÃO)
         if (!isCustomPosition) {
@@ -132,7 +166,9 @@ export function toggleGenieAnimation(show, popup, buttonId) {
             if (btn) btn.classList.add('active');
 
             // Física Apple
-            popup.style.transition = "opacity 0.4s ease-out, transform 0.5s cubic-bezier(0.19, 1, 0.22, 1)";
+            popup.style.transition = reduceMotion
+                ? "opacity 0.15s ease"
+                : "opacity 0.4s ease-out, transform 0.5s var(--cw-ease-decelerate)";
             popup.style.opacity = '1';
 
             // POSIÇÃO FINAL (DESTINO)
@@ -152,8 +188,11 @@ export function toggleGenieAnimation(show, popup, buttonId) {
         // --- FECHAR ---
 SoundManager.playSwoosh();
         // A. CONFIGURA SAÍDA
-        popup.style.transition = "opacity 0.25s ease, transform 0.3s cubic-bezier(0.5, 0, 1, 1)";
+        popup.style.transition = reduceMotion
+            ? "opacity 0.15s ease"
+            : "opacity 0.25s ease, transform 0.3s var(--cw-ease-accelerate)";
         popup.style.pointerEvents = 'none';
+        popup.style.willChange = 'transform, opacity';
 
         // B. ANIMAÇÃO DE SAÍDA (VOLTA PRO BOTÃO)
         requestAnimationFrame(() => {
@@ -173,7 +212,8 @@ SoundManager.playSwoosh();
             
             // Limpa estilos
             popup.style.transition = '';
-            popup.style.transform = ''; 
+            popup.style.transform = '';
+            popup.style.willChange = 'auto';
             // IMPORTANTE: Não limpamos top/left aqui, para a memória persistir
         }, 300);
 

--- a/src/modules/shared/command-center.js
+++ b/src/modules/shared/command-center.js
@@ -1,11 +1,12 @@
 // src/modules/shared/command-center.js
 
-import { DataService } from './data-service.js'; 
-import { showToast } from './utils.js';
+import { DataService } from './data-service.js';
+import { showToast, triggerGoogleAnimation } from './utils.js';
 import { SoundManager } from './sound-manager.js';
 import { ADMINS } from './config.js';
 import { getAgentEmail } from './page-data.js';
 import { esperar, clamp } from './dom-utils.js';
+import { getCaseStreakToday, incrementCaseStreak } from './streak-tracker.js';
 
 // --- 1. CONFIGURAÇÃO VISUAL ---
 const COLORS = {
@@ -46,14 +47,45 @@ export function updateNotesBadge(hasDrafts) {
   }
 }
 
-export function initCommandCenter(actions) {
+// Sincroniza o badge visual com o valor já salvo (chamado no boot, pra
+// mostrar o número certo mesmo se o agente já tiver casos hoje antes de
+// concluir mais nenhum nesta sessão).
+export function syncStreakBadge() {
+  const badge = document.getElementById('cw-streak-badge');
+  const countEl = document.getElementById('cw-streak-count');
+  if (!badge || !countEl) return;
+  const count = getCaseStreakToday();
+  countEl.textContent = count;
+  badge.classList.toggle('visible', count > 0);
+}
+
+// Chamado quando um caso é efetivamente concluído (nota gerada e inserida).
+// Incrementa o contador do dia e, em marcos redondos, toca uma
+// microcelebração discreta - mesmo precedente do easter egg "Sextou" em
+// utils.js: o produto já aceita um toque de personalidade sem virar
+// gamificação forçada.
+export function registerCaseCompleted() {
+  const { count, isMilestone } = incrementCaseStreak();
+  syncStreakBadge();
+
+  if (isMilestone) {
+    const pill = document.querySelector('.cw-pill');
+    SoundManager.playSuccess();
+    if (pill) triggerGoogleAnimation(pill);
+    showToast(`🔥 ${count} casos hoje!`);
+  }
+}
+
+export function initCommandCenter(actions, splashDone) {
   // 1. ESTILOS
   const styleId = "cw-command-center-style";
   if (!document.getElementById(styleId)) {
     const style = document.createElement("style");
     style.id = styleId;
     style.innerHTML = `
-            @import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@500&display=swap');
+            /* Google Sans (400/500/700) já vem via <link> em initGlobalStylesAndFont()
+               (utils.js), que roda antes de qualquer módulo inicializar - esse @import
+               era uma segunda requisição redundante e bloqueava o parse do CSSOM. */
 
             .cw-focus-backdrop {
                 position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
@@ -74,10 +106,14 @@ export function initCommandCenter(actions) {
                 border: 1px solid ${COLORS.glassBorder}; border-radius: 50px;
                 box-shadow: 0 12px 32px rgba(0,0,0,0.25); z-index: 2147483647;
                 
-                opacity: 0; 
+                opacity: 0;
                 width: 56px;
-                
-                
+                /* Único elemento persistente do app que anima quase o tempo
+                   todo (hover em 9 botões, abrir/fechar, drag) - único caso
+                   onde will-change estático (em vez de ligar/desligar por
+                   interação) compensa, já que é sempre 1 elemento só. */
+                will-change: transform, opacity, width;
+
                 overflow: visible;
 
                 /* ABRIR: A pílula expande PRIMEIRO */
@@ -164,7 +200,7 @@ export function initCommandCenter(actions) {
                 .cw-pill > *:not(.cw-main-logo) { transition: opacity 0.2s ease 0.1s !important; transform: none !important; }
             }
 
-            .cw-pill.collapsed > *:not(.cw-main-logo) {
+            .cw-pill.collapsed > *:not(.cw-main-logo):not(#cw-streak-badge) {
                 opacity: 0; pointer-events: none; visibility: hidden;
                 transform: scale(0.5); filter: blur(8px);
                 /* Desaparece imediatamente */
@@ -194,7 +230,7 @@ export function initCommandCenter(actions) {
                 display: flex; align-items: center; justify-content: center; 
                 cursor: pointer; position: relative; color: ${COLORS.iconIdle};
                 flex-shrink: 0;
-                transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+                transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1), color 0.2s cubic-bezier(0.4, 0, 0.2, 1), transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
             }
             @media (prefers-reduced-motion: reduce) {
                 .cw-btn { transition: background 0.2s ease, color 0.2s ease !important; }
@@ -202,7 +238,11 @@ export function initCommandCenter(actions) {
             .cw-btn:hover {
                 background: ${COLORS.glassHighlight};
                 color: ${COLORS.iconActive};
-                transform: scale(1.18) translateY(-2px) !important;
+                /* Só scale (cresce do centro), sem translateY: botões redondos
+                   colados lado a lado numa fileira única - um lift vertical
+                   é o caso clássico de flicker quando o mouse passa raspando
+                   a borda entre dois ícones adjacentes. */
+                transform: scale(1.18) !important;
             }
             @media (prefers-reduced-motion: reduce) {
                 .cw-btn:hover { transform: none !important; }
@@ -374,7 +414,29 @@ export function initCommandCenter(actions) {
             .cw-pill:not(.collapsed) .cw-admin-badge.visible {
                 transform: translateX(-50%) scale(1);
             }
-            
+
+            /* --- RITMO DO TURNO (contador de casos hoje) --- */
+            /* Só aparece com a pílula fechada/idle - é um indicador ambiente,
+               não uma notificação; some assim que o menu abre pra não competir
+               com nada. Fica de fora da regra geral de "esconder no collapsed"
+               (seletor lá em cima) de propósito. */
+            .cw-streak-badge {
+                position: absolute; top: -6px; right: -6px;
+                background: #202124; color: #FDD663;
+                font-size: 10px; font-weight: 800;
+                padding: 3px 7px; border-radius: 100px;
+                display: flex; align-items: center; gap: 3px;
+                border: 1px solid rgba(255,255,255,0.15);
+                box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+                pointer-events: none; z-index: 25;
+                opacity: 0; transform: scale(0.5);
+                transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+            }
+            .cw-pill.collapsed .cw-streak-badge.visible { opacity: 1; transform: scale(1); }
+            @media (prefers-reduced-motion: reduce) {
+                .cw-streak-badge { transition: opacity 0.15s ease !important; transform: none !important; }
+            }
+
             .cw-center-success { display: none; color: ${COLORS.green}; margin-bottom: 10px; }
             .cw-center-success svg { width: 48px; height: 48px; }
             .cw-center-success.show { display: block; animation: popIn 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
@@ -439,8 +501,9 @@ export function initCommandCenter(actions) {
 
   pill.innerHTML = `
         <div id="cw-command-center" style="display:none;"></div>
-        <div class="cw-main-logo">${ICONS.main}</div>
+        <div class="cw-main-logo" title="Busca rápida: Ctrl/Cmd+K">${ICONS.main}</div>
         <div id="cw-admin-tag" class="cw-admin-badge">Admin</div>
+        <div id="cw-streak-badge" class="cw-streak-badge" title="Casos concluídos hoje">🔥 <span id="cw-streak-count">0</span></div>
 
         <div class="cw-grip" title="Arrastar">
             <div class="cw-grip-bar"></div>
@@ -465,6 +528,7 @@ export function initCommandCenter(actions) {
   overlay.className = 'cw-focus-backdrop';
   document.body.appendChild(overlay);
   document.body.appendChild(pill);
+  syncStreakBadge();
 
   // 3. LISTENERS
   const toggleModule = (btnClass, actionFn) => {
@@ -536,7 +600,20 @@ export function initCommandCenter(actions) {
     };
     checkAdmin();
 
-    await esperar(2800); pill.classList.add("docked");
+    // A pílula só assume a cena depois que a splash de fato terminou e saiu
+    // do DOM - antes disso era um esperar(2800) fixo, adivinhado sem relação
+    // com a duração real da splash (que varia com o tamanho do nome no
+    // typewriter). Os dois podiam ficar até ~1.5s fora de sincronia: a
+    // pílula já 100% visível, botões "popados", por cima de uma splash ainda
+    // intacta. Fallback pro tempo antigo só se por algum motivo a promise não
+    // for passada (nunca deve travar o boot por causa disso).
+    if (splashDone && typeof splashDone.then === 'function') {
+      try { await splashDone; } catch (e) { /* a splash já trata os próprios erros; só não travamos o dock por causa disso */ }
+      await esperar(150);
+    } else {
+      await esperar(2800);
+    }
+    pill.classList.add("docked");
     await esperar(300);
     const items = pill.querySelectorAll(".cw-btn");
     pill.querySelectorAll(".cw-sep").forEach((s) => s.classList.add("visible"));

--- a/src/modules/shared/command-palette.js
+++ b/src/modules/shared/command-palette.js
@@ -1,0 +1,237 @@
+// src/modules/shared/command-palette.js
+//
+// Command palette (Ctrl/Cmd+K) - abre um buscador rápido por cima de
+// qualquer coisa e liga direto nas mesmas funções de toggle que a pílula
+// flutuante já usa. Não duplica lógica de abrir/fechar módulo nenhuma: só
+// chama a função de toggle de cada um, exatamente como um clique no ícone
+// faria.
+
+import { SoundManager } from './sound-manager.js';
+import { lockBodyScroll, unlockBodyScroll } from './dom-utils.js';
+
+const ICONS = {
+    notes: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`,
+    email: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>`,
+    script: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>`,
+    links: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>`,
+    library: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12z"/></svg>`,
+    timezone: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/></svg>`,
+    configs: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>`,
+    bauform: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14zm-1-6h-3v3h-2v-3H8v-2h3V8h2v3h3v2z"/></svg>`,
+    broadcast: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>`,
+    search: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,
+    enter: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 10 4 15 9 20"></polyline><path d="M20 4v7a4 4 0 0 1-4 4H4"></path></svg>`,
+    arrowDown: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>`,
+    arrowUp: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>`,
+};
+
+function injectStyles() {
+    if (document.getElementById('cw-palette-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'cw-palette-styles';
+    style.textContent = `
+        .cw-palette-overlay {
+            position: fixed; inset: 0;
+            background: rgba(32,33,36,0.4);
+            backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+            z-index: 2147483647;
+            display: flex; align-items: flex-start; justify-content: center;
+            padding-top: 14vh;
+            opacity: 0; pointer-events: none;
+            transition: opacity 0.2s ease;
+        }
+        .cw-palette-overlay.active { opacity: 1; pointer-events: auto; }
+
+        .cw-palette {
+            width: 560px; max-width: 90vw;
+            background: rgba(255,255,255,0.98);
+            backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+            border-radius: 20px;
+            box-shadow: 0 24px 64px rgba(0,0,0,0.35), 0 0 0 1px rgba(255,255,255,0.5);
+            overflow: hidden;
+            transform: scale(0.96) translateY(-8px);
+            transition: transform 0.25s var(--cw-ease-decelerate);
+            font-family: 'Google Sans', Roboto, sans-serif;
+        }
+        .cw-palette-overlay.active .cw-palette { transform: scale(1) translateY(0); }
+        @media (prefers-reduced-motion: reduce) {
+            .cw-palette-overlay, .cw-palette { transition: opacity 0.15s ease !important; transform: none !important; }
+        }
+
+        .cw-palette-search { display: flex; align-items: center; gap: 12px; padding: 18px 20px; border-bottom: 1px solid #F1F3F4; }
+        .cw-palette-search-icon { color: #9AA0A6; display: flex; flex-shrink: 0; }
+        .cw-palette-search-icon svg { width: 20px; height: 20px; }
+        .cw-palette-input { flex: 1; border: none; outline: none; background: transparent; font-size: 16px; color: #202124; font-family: inherit; }
+        .cw-palette-input::placeholder { color: #9AA0A6; }
+
+        .cw-palette-list { max-height: 340px; overflow-y: auto; padding: 8px; }
+        .cw-palette-item { display: flex; align-items: center; gap: 14px; padding: 10px 12px; border-radius: 12px; cursor: pointer; transition: background 0.1s ease; }
+        .cw-palette-item.selected { background: #E8F0FE; }
+        .cw-palette-item-icon { width: 32px; height: 32px; border-radius: 9px; background: #F1F3F4; display: flex; align-items: center; justify-content: center; flex-shrink: 0; color: #5F6368; transition: background-color 0.1s ease, color 0.1s ease; }
+        .cw-palette-item-icon svg { width: 18px; height: 18px; }
+        .cw-palette-item.selected .cw-palette-item-icon { background: #FFFFFF; color: #1A73E8; }
+        .cw-palette-item-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+        .cw-palette-item-label { font-size: 14px; font-weight: 600; color: #202124; }
+        .cw-palette-item-hint { font-size: 12px; color: #5F6368; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .cw-palette-empty { padding: 32px; text-align: center; color: #9AA0A6; font-size: 13px; }
+
+        .cw-palette-footer { display: flex; gap: 16px; padding: 10px 20px; border-top: 1px solid #F1F3F4; background: #FAFAFA; font-size: 11px; color: #9AA0A6; font-weight: 600; }
+        .cw-palette-footer span { display: flex; align-items: center; gap: 4px; }
+        .cw-palette-footer svg { width: 12px; height: 12px; }
+    `;
+    document.head.appendChild(style);
+}
+
+export function initCommandPalette(actions) {
+    injectStyles();
+
+    // Remove acentos pra busca tolerar "notas"/"nota", com ou sem acento -
+    // o resto do app inteiro é em PT-BR, mas os módulos em si têm nome em
+    // inglês (Case Notes, Call Script...); sem os `keywords` em português,
+    // digitar a palavra óbvia ("notas", "script", "fuso") não achava nada.
+    function normalize(str) {
+        return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    }
+
+    const ALL_ACTIONS = [
+        { id: 'notes', label: 'Case Notes', hint: 'Montar a nota técnica do caso', keywords: 'notas nota caso anotacoes', icon: ICONS.notes, run: actions.toggleNotes },
+        { id: 'bauform', label: 'BAU Form', hint: 'Solicitação de criação/descarte BAU', keywords: 'bau formulario solicitacao criacao descarte', icon: ICONS.bauform, run: actions.toggleBAUForm },
+        { id: 'email', label: 'Email Assistant', hint: 'Templates inteligentes de e-mail', keywords: 'email e-mail correio template', icon: ICONS.email, run: actions.toggleEmail },
+        { id: 'script', label: 'Call Script', hint: 'Guia interativo de chamada', keywords: 'script roteiro chamada ligacao', icon: ICONS.script, run: actions.toggleScript },
+        { id: 'links', label: 'Central de Links', hint: 'Ferramentas, SOPs e atalhos', keywords: 'links atalhos ferramentas sop sops', icon: ICONS.links, run: actions.toggleLinks },
+        { id: 'library', label: 'Minha Biblioteca', hint: 'Snippets e respostas salvas', keywords: 'biblioteca snippets respostas salvas', icon: ICONS.library, run: actions.toggleLibrary },
+        { id: 'timezone', label: 'Fusos Horários', hint: 'Monitoramento e planejador de chamada', keywords: 'fuso horario timezone', icon: ICONS.timezone, run: actions.toggleTimezone },
+        { id: 'broadcast', label: 'Avisos', hint: 'Comunicados e disponibilidade BAU', keywords: 'avisos broadcast comunicados disponibilidade', icon: ICONS.broadcast, run: () => actions.broadcastControl && actions.broadcastControl.toggle() },
+        { id: 'configs', label: 'Configurações', hint: 'Perfil, som e preferências', keywords: 'configuracoes config preferencias perfil som', icon: ICONS.configs, run: actions.toggleConfigs },
+    ]
+        .filter(a => typeof a.run === 'function')
+        .map(a => ({ ...a, _haystack: normalize(`${a.label} ${a.hint} ${a.keywords}`) }));
+
+    let isOpen = false;
+    let selectedIndex = 0;
+    let filtered = ALL_ACTIONS;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'cw-palette-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', 'Busca rápida');
+
+    const palette = document.createElement('div');
+    palette.className = 'cw-palette';
+    palette.innerHTML = `
+        <div class="cw-palette-search">
+            <span class="cw-palette-search-icon">${ICONS.search}</span>
+            <input type="text" class="cw-palette-input" placeholder="Buscar um módulo..." autocomplete="off" spellcheck="false">
+        </div>
+        <div class="cw-palette-list"></div>
+        <div class="cw-palette-footer">
+            <span>${ICONS.arrowDown}${ICONS.arrowUp} navegar</span>
+            <span>${ICONS.enter} selecionar</span>
+            <span>esc fechar</span>
+        </div>
+    `;
+    overlay.appendChild(palette);
+    overlay.onmousedown = (e) => { if (e.target === overlay) close(); };
+
+    const input = palette.querySelector('.cw-palette-input');
+    const list = palette.querySelector('.cw-palette-list');
+
+    function render() {
+        list.innerHTML = '';
+        if (filtered.length === 0) {
+            list.innerHTML = `<div class="cw-palette-empty">Nada encontrado.</div>`;
+            return;
+        }
+        filtered.forEach((action, idx) => {
+            const item = document.createElement('div');
+            item.className = 'cw-palette-item' + (idx === selectedIndex ? ' selected' : '');
+            item.innerHTML = `
+                <span class="cw-palette-item-icon">${action.icon}</span>
+                <span class="cw-palette-item-text">
+                    <span class="cw-palette-item-label">${action.label}</span>
+                    <span class="cw-palette-item-hint">${action.hint}</span>
+                </span>
+            `;
+            item.onmouseenter = () => { selectedIndex = idx; render(); };
+            item.onclick = () => activate(idx);
+            list.appendChild(item);
+        });
+        const selectedEl = list.children[selectedIndex];
+        if (selectedEl) selectedEl.scrollIntoView({ block: 'nearest' });
+    }
+
+    function activate(idx) {
+        const action = filtered[idx];
+        if (!action) return;
+        SoundManager.playClick();
+        close();
+        action.run();
+    }
+
+    function open() {
+        if (isOpen) return;
+        isOpen = true;
+        filtered = ALL_ACTIONS;
+        selectedIndex = 0;
+        input.value = '';
+        render();
+        lockBodyScroll();
+        document.body.appendChild(overlay);
+        SoundManager.playGenieOpen();
+        requestAnimationFrame(() => {
+            overlay.classList.add('active');
+            input.focus();
+        });
+    }
+
+    function close() {
+        if (!isOpen) return;
+        isOpen = false;
+        unlockBodyScroll();
+        overlay.classList.remove('active');
+        setTimeout(() => overlay.remove(), 200);
+    }
+
+    function toggle() {
+        if (isOpen) close(); else open();
+    }
+
+    input.addEventListener('input', () => {
+        const term = normalize(input.value.trim());
+        filtered = term
+            ? ALL_ACTIONS.filter(a => a._haystack.includes(term))
+            : ALL_ACTIONS;
+        selectedIndex = 0;
+        render();
+    });
+
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
+            render();
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            selectedIndex = Math.max(selectedIndex - 1, 0);
+            render();
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            activate(selectedIndex);
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            close();
+        }
+    });
+
+    // Ctrl/Cmd+K abre de qualquer lugar - mesmo padrão que Slack/Linear/Notion
+    // já consagraram, sobrepondo o atalho nativo do navegador de propósito.
+    document.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+            e.preventDefault();
+            toggle();
+        }
+    });
+
+    return { open, close, toggle };
+}

--- a/src/modules/shared/dom-utils.js
+++ b/src/modules/shared/dom-utils.js
@@ -34,3 +34,130 @@ export function objectToCss(obj) {
 export function clamp(value, min, max) {
     return Math.max(min, Math.min(value, max));
 }
+
+// Scroll-lock do <body> com contagem de referências: mais de um módulo pode
+// estar aberto ao mesmo tempo (a pílula não fecha os outros ao abrir um
+// novo), então destravar direto no fechamento de UM popup reabriria o scroll
+// da página de fundo mesmo com outro popup ainda aberto por cima. Cada
+// módulo chama lockBodyScroll() ao abrir e unlockBodyScroll() ao fechar; só
+// o último a fechar de fato libera o scroll.
+let scrollLockCount = 0;
+export function lockBodyScroll() {
+    scrollLockCount++;
+    document.body.style.overflow = "hidden";
+}
+export function unlockBodyScroll() {
+    scrollLockCount = Math.max(0, scrollLockCount - 1);
+    if (scrollLockCount === 0) document.body.style.overflow = "";
+}
+
+// "Check verde" (dopamina) ao preencher um campo - padrão promovido de
+// components/step-tasks.js pro resto do app: ao digitar algo válido, o
+// campo ganha um fundo/borda verdes e um check anima "encaixando", reforço
+// visual instantâneo de "isso está certo" sem esperar validação no fim do
+// formulário. O input precisa já estar no DOM (dentro do wrapper) quando
+// isso é chamado - o ícone é inserido logo depois dele como irmão.
+let filledCheckStylesInjected = false;
+function injectFilledCheckStyles() {
+    if (filledCheckStylesInjected || document.getElementById('cw-filled-check-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'cw-filled-check-styles';
+    style.textContent = `
+        .cw-dopamine-field.filled {
+            background-color: #F0FDF4 !important;
+            border-color: #86EFAC !important;
+            color: #166534;
+            padding-right: 36px !important;
+        }
+        .cw-dopamine-check {
+            position: absolute; right: 10px; top: 50%; transform: translateY(-50%) scale(0.5);
+            color: #16A34A; width: 16px; height: 16px;
+            opacity: 0; pointer-events: none;
+            transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+        .cw-dopamine-check.show { opacity: 1; transform: translateY(-50%) scale(1); }
+        @media (prefers-reduced-motion: reduce) {
+            .cw-dopamine-check { transition: opacity 0.15s ease !important; }
+        }
+    `;
+    document.head.appendChild(style);
+    filledCheckStylesInjected = true;
+}
+
+// Estado vazio ilustrado (ícone num badge circular + título + subtítulo),
+// no mesmo espírito do que notes-assistant.js já fazia sozinho - só que
+// genérico o bastante pra qualquer módulo usar em vez de cair de volta pra
+// uma linha de texto solta sem nada. Aceita qualquer SVG/emoji como ícone.
+let emptyStateStylesInjected = false;
+function injectEmptyStateStyles() {
+    if (emptyStateStylesInjected || document.getElementById('cw-empty-state-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'cw-empty-state-styles';
+    style.textContent = `
+        .cw-empty-illustrated { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 12px; padding: 32px 20px; }
+        .cw-empty-illustrated-badge { border-radius: 50%; background: #F8F9FA; display: flex; align-items: center; justify-content: center; color: #9AA0A6; flex-shrink: 0; }
+        .cw-empty-illustrated-badge svg { width: 44%; height: 44%; }
+        .cw-empty-illustrated-title { font-family: 'Google Sans', Roboto, sans-serif; font-size: 15px; font-weight: 600; color: #202124; }
+        .cw-empty-illustrated-subtitle { font-size: 12px; color: #5F6368; line-height: 1.5; max-width: 240px; }
+    `;
+    document.head.appendChild(style);
+    emptyStateStylesInjected = true;
+}
+
+export function createEmptyState({ icon, title, subtitle = "", size = 88 }) {
+    injectEmptyStateStyles();
+    const el = document.createElement("div");
+    el.className = "cw-empty-illustrated";
+    el.innerHTML = `
+        <div class="cw-empty-illustrated-badge" style="width:${size}px;height:${size}px;">${icon}</div>
+        <div class="cw-empty-illustrated-title">${title}</div>
+        ${subtitle ? `<div class="cw-empty-illustrated-subtitle">${subtitle}</div>` : ""}
+    `;
+    return el;
+}
+
+// Navegação por seta numa lista de itens focáveis (catálogo de tasks,
+// templates de e-mail, etc.): ↓/↑ move o foco pro próximo/anterior item
+// visível de `itemSelector` dentro de `container`, sem precisar reconstruir
+// nada quando a lista é re-renderizada (a busca é feita a cada tecla, ao
+// vivo, contra o DOM atual). Enter/Espaço continuam ativando o item porque
+// cada item já tem seu próprio keydown handler - isso só cobre o "andar"
+// entre eles.
+export function enableArrowKeyNav(container, itemSelector) {
+    container.addEventListener('keydown', (e) => {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+        const active = document.activeElement;
+        if (!active || !active.matches(itemSelector)) return;
+
+        const items = Array.from(container.querySelectorAll(itemSelector)).filter(el => el.offsetParent !== null);
+        const idx = items.indexOf(active);
+        if (idx === -1) return;
+
+        e.preventDefault();
+        const nextIdx = e.key === 'ArrowDown' ? Math.min(idx + 1, items.length - 1) : Math.max(idx - 1, 0);
+        items[nextIdx].focus();
+    });
+}
+
+export function enableFilledCheck(input, { minLength = 2 } = {}) {
+    injectFilledCheckStyles();
+
+    const parent = input.parentElement;
+    if (parent && getComputedStyle(parent).position === 'static') {
+        parent.style.position = 'relative';
+    }
+    input.classList.add('cw-dopamine-field');
+
+    const check = document.createElement('span');
+    check.className = 'cw-dopamine-check';
+    check.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+    input.insertAdjacentElement('afterend', check);
+
+    const sync = () => {
+        const isFilled = input.value.trim().length >= minLength;
+        input.classList.toggle('filled', isFilled);
+        check.classList.toggle('show', isFilled);
+    };
+    input.addEventListener('input', sync);
+    sync();
+}

--- a/src/modules/shared/header-factory.js
+++ b/src/modules/shared/header-factory.js
@@ -63,7 +63,12 @@ export function createStandardHeader(popupElement, titleText, versionText, helpD
         `;
         document.head.appendChild(style);
     }
-    gradientLine.style.animation = 'cw-header-flow 6s linear infinite';
+    // Linha decorativa (não carrega estado nenhum) - roda infinito em TODO
+    // header de módulo aberto, então é a primeira a cair sob reduced-motion.
+    const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (!reduceMotion) {
+        gradientLine.style.animation = 'cw-header-flow 6s linear infinite';
+    }
 
     header.appendChild(gradientLine);
     
@@ -75,9 +80,12 @@ export function createStandardHeader(popupElement, titleText, versionText, helpD
     const leftDiv = document.createElement("div");
     Object.assign(leftDiv.style, { display: 'flex', alignItems: 'center', gap: '12px' });
 
-    const logo = document.createElement("img");
-    logo.src = "https://upload.wikimedia.org/wikipedia/commons/c/c1/Google_%22G%22_logo.svg";
-    Object.assign(logo.style, { width: "20px", height: "20px", pointerEvents: "none" });
+    // SVG local em vez de hotlink pro Wikipedia Commons: esse logo aparece em
+    // TODO popup aberto - dependia de uma requisição externa não controlada
+    // pra um elemento que renderiza dezenas de vezes por sessão.
+    const logo = document.createElement("div");
+    logo.innerHTML = `<svg viewBox="0 0 48 48" width="20" height="20"><path fill="#4285F4" d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"/><path fill="#34A853" d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"/><path fill="#FBBC05" d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"/><path fill="#EA4335" d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"/></svg>`;
+    Object.assign(logo.style, { width: "20px", height: "20px", pointerEvents: "none", flexShrink: "0", display: "flex" });
 
     const title = document.createElement("span");
     title.textContent = titleText;

--- a/src/modules/shared/streak-tracker.js
+++ b/src/modules/shared/streak-tracker.js
@@ -1,0 +1,30 @@
+// src/modules/shared/streak-tracker.js
+//
+// Contador de "casos hoje" - puramente local (localStorage), zera sozinho
+// virando o dia. Só guarda um número, não guarda nenhum dado de caso. A UI
+// (badge da pílula) fica em command-center.js; isso aqui é só a contagem.
+
+const KEY = 'cw_case_streak_v1';
+const MILESTONES = [5, 10, 15, 20, 25, 30, 40, 50];
+
+function todayKey() {
+    const d = new Date();
+    return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+}
+
+export function getCaseStreakToday() {
+    try {
+        const data = JSON.parse(localStorage.getItem(KEY) || '{}');
+        return data.date === todayKey() ? (data.count || 0) : 0;
+    } catch (e) {
+        return 0;
+    }
+}
+
+export function incrementCaseStreak() {
+    const count = getCaseStreakToday() + 1;
+    try {
+        localStorage.setItem(KEY, JSON.stringify({ date: todayKey(), count }));
+    } catch (e) { /* localStorage indisponível - segue sem persistir */ }
+    return { count, isMilestone: MILESTONES.includes(count) };
+}

--- a/src/modules/shared/utils.js
+++ b/src/modules/shared/utils.js
@@ -33,6 +33,19 @@ export function initGlobalStylesAndFont() {
             --cw-text: #202124;
             --cw-text-sub: #5f6368;
             --cw-ease-elastic: cubic-bezier(0.25, 0.8, 0.25, 1);
+
+            /* --- TOKENS DE MOVIMENTO --- */
+            /* 4 curvas canônicas, escolhidas a partir das que já dominavam o
+               projeto (por contagem de uso) - não curvas novas. O resto do
+               código tinha ~15 variantes cubic-bezier distintas, várias delas
+               diferindo por 1 dígito sem nenhuma escolha deliberada por trás
+               (ex: 0.2,0.8,0.2,1 vs 0.25,0.8,0.25,1, usadas quase o mesmo
+               número de vezes em arquivos que nunca se falaram). Todo código
+               novo deveria escolher entre essas 4 em vez de inventar mais uma. */
+            --cw-ease-standard: cubic-bezier(0.4, 0, 0.2, 1);      /* Material padrão - já a curva mais usada do projeto */
+            --cw-ease-decelerate: cubic-bezier(0.19, 1, 0.22, 1);  /* Entrada - a curva do genie abrindo */
+            --cw-ease-accelerate: cubic-bezier(0.5, 0, 1, 1);      /* Saída - a curva do genie fechando */
+            --cw-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);   /* Bounce/overshoot - já é o EASE de notes-styles.js */
         }
 
         /* RESET DE BOX MODEL (Escopado só ao app, nunca ao CRM host) */
@@ -236,6 +249,17 @@ export function initGlobalStylesAndFont() {
     background-color: #E8F0FE;
     font-weight: 500;
 }
+
+/* Sistema de diálogo (alertDialog/confirmDialog/promptDialog): é o ponto de
+   maior consequência do app - toda ação destrutiva passa por aqui, várias
+   vezes por turno - e não tinha nenhuma proteção de reduced-motion, ao
+   contrário da pílula (a mais bem coberta do projeto). O overlay usa a
+   classe .cw-dialog-overlay (createBaseOverlay em utils.js); a caixa do
+   diálogo é sempre o filho direto dela. */
+@media (prefers-reduced-motion: reduce) {
+    .cw-dialog-overlay { transition: opacity 0.15s ease !important; }
+    .cw-dialog-overlay > div { transition: opacity 0.15s ease !important; transform: none !important; }
+}
     `;
     document.head.appendChild(style);
 }
@@ -265,7 +289,7 @@ export function showToast(message, opts = {}) {
     lineHeight: "20px",
     zIndex: "9999999",
     opacity: "0",
-    transition: "all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)", // Efeito Mola
+    transition: "all 0.4s var(--cw-ease-spring)", // Efeito Mola
     pointerEvents: "none",
   });
 
@@ -378,7 +402,7 @@ function closeDragElement() {
 
     setTimeout(() => {
         // ... (seu código existente de restaurar transition) ...
-        element.style.transition = "all 0.5s cubic-bezier(0.19, 1, 0.22, 1), opacity 0.3s ease";
+        element.style.transition = "all 0.5s var(--cw-ease-decelerate), opacity 0.3s ease";
         element.setAttribute("data-dragging", "false");
 
         // --- ADICIONE ESTA LINHA ---
@@ -408,7 +432,7 @@ export const styleFloatingButton = {
   boxShadow: "0 4px 16px rgba(26, 115, 232, 0.4)", // Glow azul
   zIndex: "9999",
   border: "none",
-  transition: "transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease",
+  transition: "transform 0.2s var(--cw-ease-spring), box-shadow 0.2s ease",
   transform: "scale(1)",
   fontFamily: "'Google Sans', 'Roboto'",
 };
@@ -666,7 +690,7 @@ export function injectGoogleAnimationStyles() {
             50% { box-shadow: 0 0 0 20px rgba(251, 188, 5, 0); }
             100% { box-shadow: 0 0 0 30px rgba(52, 168, 83, 0); }
         }
-        .google-animate-click { animation: google-pulse-ring 0.6s cubic-bezier(0.215, 0.61, 0.355, 1); }
+        .google-animate-click { animation: google-pulse-ring 0.6s var(--cw-ease-spring); }
         .google-active-state { position: relative !important; overflow: visible !important; }
         .google-active-state::before {
             content: ''; position: absolute; top: -1px; left: -1px; right: -1px; bottom: -1px; border-radius: 50%;
@@ -726,7 +750,9 @@ export async function playStartupAnimation() {
     const style = document.createElement("style");
     style.id = "google-splash-style";
     style.innerHTML = `
-            @import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap');
+            /* Google Sans já vem via <link> logo acima em initGlobalStylesAndFont(),
+               chamada antes da splash - esse @import era uma 3a requisição redundante
+               pra fonte (a 1a é o <link>, a 2a era o do command-center.js). */
             .splash-container { font-family: 'Google Sans', sans-serif; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background-color: #202124; z-index: 2147483647; display: flex; flex-direction: column; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.5s cubic-bezier(0.4, 0.0, 0.2, 1); }
             .splash-exit { animation: focus-out 0.9s cubic-bezier(0.4, 0.0, 0.2, 1) forwards; }
             @keyframes focus-out { 0% { opacity: 1; transform: scale(1); filter: blur(0); } 100% { opacity: 0; transform: scale(1.15); filter: blur(15px); } }
@@ -736,11 +762,11 @@ export async function playStartupAnimation() {
             .text-name { font-size: 32px; font-weight: 700; background: linear-gradient(90deg, #8AB4F8, #C58AF9, #F28B82); -webkit-background-clip: text; -webkit-text-fill-color: transparent; opacity: 0; }
             .text-footer { font-size: 20px; color: #9AA0A6; font-weight: 400; width: 100%; text-align: center; margin-top: 12px; opacity: 0; transform: translateY(10px); transition: all 1s cubic-bezier(0.0, 0.0, 0.2, 1); }
 
-            .sextou-badge { display: inline-flex; align-items: center; gap: 6px; margin-top: 16px; padding: 6px 16px; border-radius: 20px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #F28B82; font-size: 14px; font-weight: 500; opacity: 0; transform: scale(0.8); transition: all 1s cubic-bezier(0.34, 1.56, 0.64, 1); }
+            .sextou-badge { display: inline-flex; align-items: center; gap: 6px; margin-top: 16px; padding: 6px 16px; border-radius: 20px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #F28B82; font-size: 14px; font-weight: 500; opacity: 0; transform: scale(0.8); transition: all 1s var(--cw-ease-spring); }
             .cursor { color: #8AB4F8; -webkit-text-fill-color: #8AB4F8; font-weight: 100; margin-left: 1px; animation: blink 1s infinite; }
 
             .brand-logo { position: absolute; top: 40px; font-size: 20px; font-weight: 500; color: #5f6368; letter-spacing: 1px; text-transform: uppercase; opacity: 0; animation: fade-in-down 0.8s ease forwards; }
-            .weather-icon { width: 42px; height: 42px; margin-bottom: 24px; opacity: 0; transform: scale(0.8); transition: all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1); }
+            .weather-icon { width: 42px; height: 42px; margin-bottom: 24px; opacity: 0; transform: scale(0.8); transition: all 0.6s var(--cw-ease-spring); }
             .credit-pro { position: absolute; bottom: 30px; font-size: 11px; color: #5f6368; letter-spacing: 0.5px; opacity: 0; animation: fade-in-simple 1.5s ease 1s forwards; }
             .credit-pro span { color: #8AB4F8; font-weight: 500; opacity: 0.9; }
 
@@ -750,12 +776,26 @@ export async function playStartupAnimation() {
             @keyframes fade-in-down { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
             @keyframes load-line { 0% { transform: scaleX(0); } 100% { transform: scaleX(1); } }
             @keyframes fade-in-simple { to { opacity: 1; } }
+
+            /* A primeira tela que qualquer agente vê, todo santo dia - e não
+               tinha nenhuma proteção de reduced-motion, apesar de combinar
+               blur(15px) + scale(1.15) na saída (o efeito de "zoom" mais
+               forte do app inteiro) e um cursor piscando em loop infinito. */
+            @media (prefers-reduced-motion: reduce) {
+                .splash-container { transition: opacity 0.2s ease !important; }
+                .splash-exit { animation: fade-out-simple 0.2s ease forwards !important; }
+                @keyframes fade-out-simple { to { opacity: 0; } }
+                .text-footer { transition: opacity 0.3s ease !important; transform: none !important; }
+                .sextou-badge, .weather-icon { transition: opacity 0.2s ease !important; transform: none !important; }
+                .cursor { animation: none !important; opacity: 1 !important; }
+            }
         `;
     document.head.appendChild(style);
   }
 
   // 2. Monta HTML
   const splash = document.createElement("div");
+  splash.id = "techsol-splash-screen"; // guard do topo desta função checa esse id - nunca era setado, então nunca protegia nada
   splash.className = "splash-container";
   splash.innerHTML = `
         <div class="brand-logo">Case Wizard</div>
@@ -866,7 +906,7 @@ export function constrainToViewport(element) {
     if (newLeft !== currentLeft || newTop !== currentTop) {
         // Adiciona uma transição rápida para o "pulo" ser suave se for um resize
         const originalTransition = element.style.transition;
-        element.style.transition = "left 0.3s cubic-bezier(0.2, 0.8, 0.2, 1), top 0.3s cubic-bezier(0.2, 0.8, 0.2, 1)";
+        element.style.transition = "left 0.3s var(--cw-ease-elastic), top 0.3s var(--cw-ease-elastic)";
 
         element.style.left = `${newLeft}px`;
         element.style.top = `${newTop}px`;
@@ -1064,6 +1104,7 @@ export function parseEmojiCodes(text) {
 
 function createBaseOverlay() {
     const overlay = document.createElement('div');
+    overlay.className = 'cw-dialog-overlay';
     Object.assign(overlay.style, {
         position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
         background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(8px)',
@@ -1078,7 +1119,7 @@ function createBaseDialog() {
     Object.assign(dialog.style, {
         background: 'rgba(255, 255, 255, 0.95)', padding: '24px', borderRadius: '20px',
         boxShadow: '0 24px 60px rgba(0,0,0,0.3)', width: '340px',
-        textAlign: 'center', transform: 'scale(0.85)', transition: 'transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        textAlign: 'center', transform: 'scale(0.85)', transition: 'transform 0.4s var(--cw-ease-spring)',
         fontFamily: "'Google Sans', Roboto, sans-serif", border: '1px solid rgba(255,255,255,0.4)'
     });
     return dialog;

--- a/src/modules/timezone/timezone-assistant.js
+++ b/src/modules/timezone/timezone-assistant.js
@@ -4,6 +4,7 @@ import { stylePopup, styleSelect, showToast } from "../shared/utils.js";
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 
 const PINNED_STORAGE_KEY = "cw_timezone_pinned";
 
@@ -43,7 +44,45 @@ const FILTERS = [
     { id: 'eu', label: 'Europa' }
 ];
 
+// --- FOLHA DE ESTILOS DEDICADA (estados interativos) ---
+// Este módulo ainda montava hover via onmouseenter/onmouseleave em JS
+// (único no app a não ter migrado pro padrão usado em call-script/broadcast/
+// personal-library) - isso significa nenhum :focus-visible de graça e nenhum
+// respeito a prefers-reduced-motion nesses hovers. O layout/cores estático
+// continua no objeto `styles` local (não há necessidade de reescrever tudo),
+// só os estados de interação (hover/focus) viram classes CSS reais aqui.
+function injectInteractiveStyles() {
+    if (document.getElementById('cw-timezone-interactive-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'cw-timezone-interactive-styles';
+    style.textContent = `
+        .tz-tab-btn:focus-visible,
+        .tz-chip:focus-visible,
+        .tz-hub-card:focus-visible,
+        .tz-pin-btn:focus-visible {
+            outline: 2px solid #1A73E8;
+            outline-offset: 2px;
+        }
+        .tz-chip:hover { border-color: #1A73E8; }
+        .tz-hub-card {
+            transition: transform 0.2s cubic-bezier(0.25, 0.8, 0.25, 1), box-shadow 0.2s ease;
+        }
+        .tz-hub-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 12px rgba(60,64,67,0.1);
+        }
+        .tz-pin-btn { transition: background-color 0.2s ease; }
+        .tz-pin-btn:hover { background-color: #F1F3F4; }
+        @media (prefers-reduced-motion: reduce) {
+            .tz-hub-card { transition: box-shadow 0.2s ease !important; }
+            .tz-hub-card:hover { transform: none !important; }
+        }
+    `;
+    document.head.appendChild(style);
+}
+
 export function initTimezoneAssistant() {
+    injectInteractiveStyles();
     const CURRENT_VERSION = "v2.2 Pro"; 
     let visible = false;
     let updateInterval = null;
@@ -204,11 +243,23 @@ export function initTimezoneAssistant() {
     
     const btnLive = document.createElement("div");
     btnLive.textContent = "Monitoramento";
+    btnLive.className = "tz-tab-btn";
+    btnLive.tabIndex = 0;
+    btnLive.setAttribute("role", "tab");
     Object.assign(btnLive.style, styles.tabBtn, styles.tabActive);
-    
+
     const btnPlan = document.createElement("div");
     btnPlan.textContent = "Planejador";
+    btnPlan.className = "tz-tab-btn";
+    btnPlan.tabIndex = 0;
+    btnPlan.setAttribute("role", "tab");
     Object.assign(btnPlan.style, styles.tabBtn);
+
+    [btnLive, btnPlan].forEach(btn => {
+        btn.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") { e.preventDefault(); btn.click(); }
+        });
+    });
 
     tabContainer.appendChild(btnLive);
     tabContainer.appendChild(btnPlan);
@@ -250,22 +301,28 @@ export function initTimezoneAssistant() {
         const chip = document.createElement("div");
         chip.textContent = f.label;
         chip.id = `tz-filter-${f.id}`;
+        chip.className = "tz-chip";
+        chip.tabIndex = 0;
+        chip.setAttribute("role", "button");
         Object.assign(chip.style, styles.chip);
-        
+
         if (f.id === activeFilter) Object.assign(chip.style, styles.chipActive);
 
         chip.onclick = () => {
             SoundManager.playClick();
             activeFilter = f.id;
-            
+
             // Atualiza visual dos chips
             Array.from(chipsRow.children).forEach(c => {
                 Object.assign(c.style, styles.chip);
             });
             Object.assign(chip.style, styles.chipActive);
-            
+
             renderLive();
         };
+        chip.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") { e.preventDefault(); chip.click(); }
+        });
 
         chipsRow.appendChild(chip);
     });
@@ -298,7 +355,9 @@ export function initTimezoneAssistant() {
             Object.assign(btnLive.style, styles.tabActive);
             Object.assign(btnPlan.style, styles.tabBtn);
             btnPlan.style.borderBottomColor = 'transparent';
-            
+            btnLive.setAttribute("aria-selected", "true");
+            btnPlan.setAttribute("aria-selected", "false");
+
             viewLive.style.display = 'flex';
             toolbar.style.display = 'flex'; // Mostra toolbar
             viewPlan.style.display = 'none';
@@ -378,6 +437,10 @@ export function initTimezoneAssistant() {
             const isNight = hour < 6 || hour > 18;
 
             const card = document.createElement("div");
+            card.className = "tz-hub-card";
+            card.tabIndex = 0;
+            card.setAttribute("role", "button");
+            card.setAttribute("aria-label", `${hub.name}, ${timeString}`);
             Object.assign(card.style, styles.hubCard);
             if (isPinned) Object.assign(card.style, styles.hubCardPinned);
 
@@ -386,7 +449,7 @@ export function initTimezoneAssistant() {
 
             card.innerHTML = `
                 <div style="display:flex; alignItems:center; gap:16px;">
-                    <div class="cw-pin-btn" style="cursor:pointer; font-size:22px; color:${pinColor}; width:32px; height:32px; display:flex; align-items:center; justify-content:center; border-radius:50%; transition:background 0.2s;">${pinIcon}</div>
+                    <div class="cw-pin-btn tz-pin-btn" tabindex="0" role="button" aria-label="${isPinned ? 'Desafixar' : 'Fixar'} ${hub.name}" style="cursor:pointer; font-size:22px; color:${pinColor}; width:32px; height:32px; display:flex; align-items:center; justify-content:center; border-radius:50%;">${pinIcon}</div>
                     <div style="font-size:32px; filter: drop-shadow(0 2px 4px rgba(0,0,0,0.1));">${hub.flag}</div>
                     <div>
                         <div style="font-size:15px; font-weight:600; color:${COLORS.text}; letter-spacing:-0.2px;">${hub.name}</div>
@@ -403,27 +466,29 @@ export function initTimezoneAssistant() {
                 </div>
             `;
 
-            card.onmouseenter = () => { 
-                card.style.transform = "translateY(-2px)";
-                card.style.boxShadow = "0 6px 12px rgba(60,64,67,0.1)";
-            };
-            card.onmouseleave = () => { 
-                card.style.transform = "translateY(0)";
-                card.style.boxShadow = "0 2px 6px rgba(60,64,67,0.05)";
-            };
-
             const btnPin = card.querySelector('.cw-pin-btn');
-            btnPin.onmouseenter = () => { btnPin.style.backgroundColor = "#F1F3F4"; };
-            btnPin.onmouseleave = () => { btnPin.style.backgroundColor = "transparent"; };
             btnPin.onclick = (e) => {
                 e.stopPropagation();
                 togglePin(hub.id);
             };
+            btnPin.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    togglePin(hub.id);
+                }
+            });
 
             card.onclick = () => {
                 selectedHubId = hub.id;
                 switchTab('plan');
             };
+            card.addEventListener("keydown", (e) => {
+                if ((e.key === "Enter" || e.key === " ") && e.target === card) {
+                    e.preventDefault();
+                    card.click();
+                }
+            });
 
             viewLive.appendChild(card);
         });
@@ -619,8 +684,10 @@ export function initTimezoneAssistant() {
         toggleGenieAnimation(visible, popup, 'cw-btn-timezone'); 
         
         if (visible) {
+            lockBodyScroll();
             switchTab('live');
         } else {
+            unlockBodyScroll();
             stopClock();
         }
     }


### PR DESCRIPTION
## Summary
- Full UI/UX audit (6 phases): sound/haptic wiring, keyboard nav & accessibility, scroll-lock on every module popup, illustrated empty states, Ctrl/Cmd+K command palette with PT-BR search, case-streak badge, "recently used" quick-copy in Personal Library, inline Google logo, and assorted bugfixes found via live browser testing.
- Motion-system audit (5 phases): fixed the splash/pill desync (the headline finding), added `will-change` at high-traffic sites, unified motion curves onto 4 canonical tokens, full `prefers-reduced-motion` coverage, and structural cleanup (`transition: all` scoping, timing-mismatch fixes, removal of the self-referential hover-transform flicker anti-pattern).

## Test plan
- [x] `npm run dev` / `npm run build` clean across all touched files
- [x] `node --check` on every modified src file
- [x] Playwright smoke pass: onboarding flow, all 6 touched module popups open/close via Esc, command palette PT-BR search, hover-transform behavior, splash/pill timing fix — zero console/page errors
- [x] Re-verified the splash/pill desync fix empirically (opacity/DOM-order sampling across the full splash lifecycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)