### PR TITLE
fix(email): popup width forced to 400px, cramping the layout

### DIFF
--- a/src/modules/email-assistant/email-assistant.js
+++ b/src/modules/email-assistant/email-assistant.js
@@ -237,7 +237,13 @@ export function initEmailAssistant() {
     const popup = document.createElement("div");
     popup.id = "email-assistant-popup";
     popup.classList.add("cw-module-window", "cw-email-popup");
-    Object.assign(popup.style, stylePopup);
+    // stylePopup traz width:400px inline (tamanho genérico dos outros
+    // popups) - sem sobrescrever aqui, esse inline vence o width:850px/
+    // height:650px do .cw-email-popup no CSS (inline sempre bate classe),
+    // e o layout de 2 painéis (320px fixo + preview) fica espremido num
+    // popup real de 400px. Mesmo padrão que call-script/personal-library/
+    // links/etc já aplicam depois do spread de stylePopup.
+    Object.assign(popup.style, stylePopup, { width: "850px", height: "650px" });
     popup.style.display = "none";
     popup.style.flexDirection = "column";
 


### PR DESCRIPTION
## Summary

- O Email Assistant abria espremido: `Object.assign(popup.style, stylePopup)` aplica o `width: "400px"` inline que `stylePopup` (`shared/utils.js`) usa como padrão genérico para popups simples. Estilo inline sempre vence estilo de classe, então isso sobrescrevia o `width: 850px; height: 650px;` declarado em `.cw-email-popup` — o popup real renderizava a 400px de largura, enquanto o layout de 2 painéis (lista fixa de 320px + preview) foi desenhado para 850px.
- Todo módulo irmão que usa `stylePopup` (`call-script`, `personal-library`, `links`, `broadcast`, `configs`, `timezone`, `notes`) já passa um terceiro objeto pro `Object.assign` sobrescrevendo `width`/`height` de volta depois do spread — o `email-assistant` era o único lugar que faltava esse passo.
- Fix: adicionado `{ width: "850px", height: "650px" }` no `Object.assign`, igual ao padrão dos outros módulos.

## Test plan

- [x] Build local (`npm run dev`) sem erros
- [x] Validação visual ao vivo via Playwright (`mock-crm.html` + bundle injetado): medi `getBoundingClientRect()` do popup (850×650, confirmado) e tirei prints do estado vazio e com template selecionado (grid de campos + preview) — nada mais cortado ou espremido
- [ ] Testar no CRM real (o repo roda injetado em produção de terceiros — ver `docs/WORKFLOW.md`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc

---
_Generated by [Claude Code](https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc)_