### PR TITLE
fix(configs): profile card stuck on generic fallback (LDAP race at boot)

### DIFF
--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -1,7 +1,7 @@
 // src/modules/configs/configs-assistant.js
 
 import { stylePopup, showToast } from "../shared/utils.js";
-import { getPageData, getAgentEmail } from "../shared/page-data.js";
+import { getAgentEmail, captureNameWithMagic } from "../shared/page-data.js";
 import { fetchUserProfile } from "../shared/data-service.js"; // Importação crucial adicionada
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
@@ -165,6 +165,17 @@ export function initConfigsAssistant() {
         `;
         (async () => {
             try {
+                // renderUserProfile() roda no boot, síncrono, logo depois de
+                // initConfigsAssistant() ser chamado em app.js - a captura real
+                // da identidade (captureNameWithMagic, disparada dentro de
+                // playStartupAnimation) só começa ~200ms depois e nunca é
+                // esperada ali. Sem esse guard, getAgentEmail() sempre voltava
+                // null nesse ponto, o LDAP caía no fallback "user", e como
+                // isso só roda uma vez, o card ficava preso no genérico pra
+                // sempre (mesmo abrindo Configs bem depois, com a identidade
+                // já capturada). Mesmo guard que getPageData() já usa.
+                if (!getAgentEmail()) await captureNameWithMagic();
+
                 // Busca o LDAP real do usuário logado
                 const agentEmail = getAgentEmail();
                 const ldap = agentEmail ? agentEmail.split('@')[0] : "user";


### PR DESCRIPTION
## Summary

- O card de perfil do Configs sempre caía no fallback genérico ("Perfil não localizado" / badges "Agent"/"PT" genéricas), nunca o nome/dados reais da planilha "People".
- Causa: `renderUserProfile()` (`configs-assistant.js`) roda de forma síncrona dentro de `initConfigsAssistant()`, chamado imediatamente no boot (`app.js`). A captura real da identidade (`captureNameWithMagic()`, que lê nome/e-mail do menu de perfil do CRM) só começa ~200ms depois, dentro de `playStartupAnimation()` — chamada logo antes mas nunca aguardada (`const splashDone = playStartupAnimation();`, sem `await`).
- Resultado: `getAgentEmail()` sempre retornava `null` no exato momento em que `renderUserProfile()` o lia, o LDAP caía no fallback literal `"user"`, a busca na planilha "People" nunca encontrava esse LDAP, e o backend devolvia o perfil-fallback genérico dele mesmo. Como `renderUserProfile()` só roda uma vez (no boot, não a cada abertura do popup), o card ficava preso nesse estado pro resto da sessão — mesmo abrindo Configs bem depois, com a identidade real já disponível.
- Confirmado via Playwright: antes do fix, os logs mostravam `"Buscando perfil para: user"` disparando **antes** de `"Identidade confirmada -> <email>"` sequer aparecer. Depois do fix, a ordem se inverte e o LDAP real é usado.
- Fix: adicionado o mesmo guard que `getPageData()` já usa em `page-data.js` (`await captureNameWithMagic()` se a identidade ainda não foi capturada) antes de ler `getAgentEmail()` aqui. O arquivo já importava `getPageData` com esse propósito mas nunca chamava — troquei pelo import direto de `captureNameWithMagic()`.

## Test plan

- [x] Build local (`npm run dev`) sem erros
- [x] Playwright: comparei a ordem dos logs `"Identidade confirmada"` vs `"Buscando perfil para"` antes/depois do fix — confirmando que o LDAP usado passou de `"user"` (fallback) para o real (`jules`, no mock)
- [ ] Testar no CRM real com uma conta cadastrada na planilha People (o repo roda injetado em produção de terceiros — ver `docs/WORKFLOW.md`; não tenho acesso de rede ao Apps Script/Sheets real neste ambiente)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc

---
_Generated by [Claude Code](https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc)_