### PR TITLE
feat(notes): add dedicated "Tentativa de ligação" field to IN_Not_Reachable

### DIFF
--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -73,7 +73,8 @@ export const translations = {
         'evidencias_contato': 'Evidências de Contato',
         'ligacao_1': 'Ligação 1',
         'ligacao_2': 'Ligação 2',
-        'mensagem_am': 'Mensagem para AM'
+        'mensagem_am': 'Mensagem para AM',
+        'tentativa_ligacao': '📞 Tentativa de ligação:'
     },
     'es': {
         'idioma': 'Idioma:',
@@ -144,7 +145,8 @@ export const translations = {
         'evidencias_contato': 'Evidencias de Contacto',
         'ligacao_1': 'Llamada 1',
         'ligacao_2': 'Llamada 2',
-        'mensagem_am': 'Mensaje para AM'
+        'mensagem_am': 'Mensaje para AM',
+        'tentativa_ligacao': '📞 Intento de llamada:'
     }
 };
 
@@ -419,10 +421,14 @@ export const SUBSTATUS_TEMPLATES = {
         templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'COMENTARIOS', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS']
     },
     'IN_Not_Reachable': {
-        status: 'IN', 
+        status: 'IN',
         name: 'IN - Not Reachable',
         requiresTasks: false,
-        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'COMENTARIOS', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS']
+        // TENTATIVA_LIGACAO: input simples e dedicado pro link de evidência
+        // da tentativa de ligação (pedido direto, ver histórico) - SCREENSHOTS_LIST
+        // não serve pra isso, é a lista de screenshots gerada a partir de
+        // tasks selecionadas no catálogo (TASKS_DB), não um campo livre.
+        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'COMENTARIOS', 'TENTATIVA_LIGACAO', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS']
     },
     'IN_Not_Interested': {
         status: 'IN', 
@@ -741,7 +747,6 @@ export const scenarioSnippets = {
         'field-REASON_COMMENTS': "Sem resposta ao 2 Day Rule.",
         'field-ON_CALL': "N/A",
         'field-COMENTARIOS': "• O caso foi gerado e entrei na chamada no horário agendado.\n• O anunciante não compareceu à reunião.\n• Segui o protocolo de espera (BAU): realizei duas tentativas de ligação, sem sucesso.\n• Nenhuma das ligações foi atendida (ex: Caixa Postal).\n• Caso inativado após 2 Day Rule.",
-        'field-SCREENSHOTS': "• Tentativa 1 - \n• Tentativa 2  - \n• Tentativa 3 - ",
         'field-GTM_GA4_VERIFICADO': "N/A"
     },
     'quickfill-in-2-6-final': {


### PR DESCRIPTION
## Summary

- `quickfill-in-no-show-bau` tentava escrever num campo (`field-SCREENSHOTS`) que não existe mais — foi renomeado pra `SCREENSHOTS_LIST` em algum momento e o snippet nunca foi atualizado. Achado ao investigar o pedido do usuário.
- E `SCREENSHOTS_LIST` não serve pro caso de qualquer forma: é uma lista de screenshots gerada automaticamente a partir das tasks selecionadas no catálogo (`TASKS_DB`), sem jeito de injetar um item avulso via snippet.
- Em vez de forçar isso no mecanismo de tasks, adicionei um campo dedicado e simples: `TENTATIVA_LIGACAO`, um input de linha única (não lista com marcadores) sempre visível em `IN_Not_Reachable`, com o label "📞 Tentativa de ligação:". Removida a referência morta `field-SCREENSHOTS` do `quickfill-in-no-show-bau` — o campo novo é um campo de template normal, preenchido direto pelo agente.

## Test plan

- [x] Build local (`npm run dev`) sem erros
- [x] Playwright: confirmei que o campo aparece com o label certo em `IN_Not_Reachable`, que o chip do `no-show-bau` continua preenchendo os outros campos normalmente, e que o valor digitado no campo novo é aceito e listado corretamente

## Observação

`quickfill-in-nrp-bau`, `quickfill-in-2-6-final` e `quickfill-in-not-reachable-no-return` (mesmo substatus) têm a mesma referência morta a `field-SCREENSHOTS` — deixei sem mexer, fora do escopo do que foi pedido aqui.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc

---
_Generated by [Claude Code](https://claude.ai/code/session_014KBfr8wDfUn7kzAYGaYRUc)_