### PR TITLE
fix(notes): make próximos passos e considerações opcionais em Education Only

### DIFF
--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -477,10 +477,11 @@ export const SUBSTATUS_TEMPLATES = {
         }
     },
     'SO_Education_Only': {
-        status: 'SO', 
+        status: 'SO',
         name: 'SO - Education Only',
         requiresTasks: true,
         templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'DUVIDAS', 'RESOLUCOES', 'PROXIMOS_PASSOS', 'CONSIDERACOES', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS'],
+        extraOptionalFields: ['PROXIMOS_PASSOS', 'CONSIDERACOES'],
         fieldPrefixes: {
             'REASON_COMMENTS': 'Consultoria utilizada para tirar dúvidas do anunciante.'
         }


### PR DESCRIPTION
## Summary
- No template SO - Education Only, os campos "Próximos passos" e "Considerações adicionais" apareciam sempre no formulário mesmo não sendo obrigatórios.
- Move os dois pra `extraOptionalFields`, o mesmo mecanismo já usado em SO - Implementation Only, que os esconde por padrão atrás do botão de "adicionar campo".

## Test plan
- [x] Confirmado via `getEffectiveOptionalFields` que os campos agora entram na lista de opcionais pro template SO_Education_Only.
- [ ] Conferir visualmente no formulário de notas que os campos somem por padrão e voltam ao clicar em "adicionar campo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)