### PR TITLE
feat(notes): confirm before deleting a filled case-notes field

### DIFF
--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -4,6 +4,7 @@ import { fetchAndInsertSpeakeasyId } from "../automation/case-log-scraper.js";
 import { enableAutoBullet } from "../components/bullet-editor.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
 import { SoundManager } from "../../shared/sound-manager.js";
+import { confirmDialog } from "../../shared/utils.js";
 
 export function buildDynamicForm(subStatusKey, container, state) {
     container.innerHTML = "";
@@ -48,13 +49,19 @@ export function buildDynamicForm(subStatusKey, container, state) {
             btnDelete.style.cssText = `font-size: 14px; background: ${COLORS.bgInput}; border: none; color: ${COLORS.textSub}; cursor: pointer; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-left: auto; transition: all 0.2s ${EASE};`;
             btnDelete.onmouseenter = () => { btnDelete.style.background = COLORS.error; btnDelete.style.color = COLORS.surface; };
             btnDelete.onmouseleave = () => { btnDelete.style.background = COLORS.bgInput; btnDelete.style.color = COLORS.textSub; };
-            // Sem confirmDialog aqui: remover um campo opcional é reversível
-            // num clique só (o chip "+ campo" reaparece logo abaixo), então
-            // bloquear com um modal só atrapalhava a velocidade sem
-            // proteger nada de fato irreversível.
-            btnDelete.onclick = (e) => {
+            // Só confirma se o campo já tem conteúdo digitado: nesse caso o
+            // texto some do output final ao remover o campo, então vale a
+            // pena checar. Campo vazio continua removendo direto, sem
+            // atrapalhar a velocidade por nada.
+            btnDelete.onclick = async (e) => {
                 e.preventDefault();
                 SoundManager.playClick();
+                const currentValue = (state.formData[fieldId] || "").trim();
+                if (currentValue) {
+                    const fieldLabel = labelText.textContent.replace(/:\s*$/, "").trim();
+                    const confirmed = await confirmDialog(`Remover o campo "${fieldLabel}"? O texto digitado será perdido.`, { danger: true, confirmText: "Remover" });
+                    if (!confirmed) return;
+                }
                 state.removeField(fieldName);
                 buildDynamicForm(subStatusKey, container, state);
             };


### PR DESCRIPTION
## Summary
- Adds a confirmation step before removing an optional Case Notes field that already has text typed into it, so an accidental click on the field's "x" doesn't silently drop content from the note output.
- Uses the project's custom `confirmDialog` (per `specs/ui-ux/dom-standards.md`, native `window.confirm` is banned), matching the pattern already used for drafts/broadcast/personal-library deletions.
- Empty fields still delete instantly — no confirmation friction when there's nothing to lose.

## Test plan
- [x] `npx esbuild src/app.js --bundle` builds cleanly with no errors.
- [x] Confirmed the new confirmation string appears in the bundled output.
- [ ] Manual smoke test in the CRM: type text into an optional Case Notes field, click "x", verify the custom modal appears and Cancel/Remove both behave correctly; verify an empty field still deletes without a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)