### PR TITLE
feat(notes): add AS_Reschedule_1 snippet for lack of GTM install access

### DIFF
--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -836,6 +836,11 @@ export const scenarioSnippets = {
         substatus: ['AS_Reschedule_1'],
         'field-MOTIVO_REAGENDAMENTO': '• Precisamos reagendar o caso, já que o tempo foi insuficiente para terminar as Tasks\n• Implementamos [descrever o que foi feito]'
     },
+    'quickfill-as-no-access': {
+        type: 'all',
+        substatus: ['AS_Reschedule_1'],
+        'field-MOTIVO_REAGENDAMENTO': '• Precisamos reagendar o caso, já que o(a) anunciante não tinha acesso ao site, ao código ou ao CMS necessários para a instalação do Google Tag Manager'
+    },
 
     // --- AS_Acceptable_Reschedule: fator maior (sem internet/luz, saúde) ---
     // [NOVO] Rascunho - substatus estava sem nenhum cenário. PDF dá exemplos


### PR DESCRIPTION
## Summary
- PR #247 was merged before this follow-up commit was pushed to the same branch, so it never landed in `refactor-structure`. This PR carries just that one commit.
- Adds `quickfill-as-no-access` under `AS_Reschedule_1`: a reschedule snippet for when the advertiser has no access to the website/code/CMS needed to install GTM.
- The equivalent NI_Awaiting_Inputs snippet (`quickfill-ni-cms-access`) is intentionally left untouched — both are kept per explicit request, covering the two possible flows (reschedule the call vs. leave the case pending).

## Test plan
- [x] `npm run build` succeeds
- [x] Verified built bundle contains the new `quickfill-as-no-access` entry with `substatus:["AS_Reschedule_1"]`
- [ ] Manual check in app: select AS - Reschedule 1 and confirm the new chip appears and fills MOTIVO_REAGENDAMENTO correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)