### PR TITLE
fix(motion): rework processing-center loading screen

### DIFF
--- a/src/modules/shared/command-center.js
+++ b/src/modules/shared/command-center.js
@@ -453,38 +453,56 @@ export function initCommandCenter(actions, splashDone) {
             .cw-pill.processing-center {
                 top: 50% !important; left: 50% !important;
                 transform: translate(-50%, -50%) !important;
-                width: 340px !important; 
-                height: auto !important; 
-                min-height: 160px !important; 
-                border-radius: 24px !important; 
-                background: #202124 !important; 
-                padding: 32px 24px !important; 
-                box-shadow: 0 24px 64px rgba(0,0,0,0.6) !important; 
-                display: flex !important; flex-direction: column !important; 
+                width: 340px !important;
+                height: auto !important;
+                min-height: 160px !important;
+                border-radius: 24px !important;
+                /* Liquid Glass, igual ao resto da pill (COLORS.glassBg + blur) -
+                   antes era um preenchimento opaco (#202124) sem backdrop-filter,
+                   uma "laje preta" destoando do resto do sistema visual. */
+                background: rgba(32, 33, 36, 0.82) !important;
+                backdrop-filter: blur(24px) saturate(160%) !important;
+                -webkit-backdrop-filter: blur(24px) saturate(160%) !important;
+                border: 1px solid ${COLORS.glassBorder} !important;
+                padding: 32px 24px !important;
+                box-shadow: 0 24px 64px rgba(0,0,0,0.45) !important;
+                display: flex !important; flex-direction: column !important;
                 justify-content: center !important; align-items: center !important;
                 gap: 0 !important;
                 z-index: 2147483647 !important;
             }
-            .cw-pill.processing-center.collapsed { background: #202124 !important; overflow: visible !important; }
+            .cw-pill.processing-center.collapsed { background: rgba(32, 33, 36, 0.82) !important; overflow: visible !important; }
             .cw-pill.processing-center .cw-main-logo { display: none !important; }
             .cw-pill.processing-center > *:not(.cw-center-stage) { display: none !important; }
-            
-            .cw-center-stage { 
-                display: flex; flex-direction: column; align-items: center; 
+
+            .cw-center-stage {
+                display: flex; flex-direction: column; align-items: center;
                 gap: 20px;
-                width: 100%; opacity: 0; 
+                width: 100%; opacity: 0;
                 animation: fadeIn 0.3s ease forwards 0.1s;
-                position: relative; 
+                position: relative;
             }
             @media (prefers-reduced-motion: reduce) {
                 .cw-center-stage { animation: fadeIn 0.3s ease forwards; }
             }
-            
-            .cw-center-dots { display: flex; gap: 8px; margin-bottom: 4px; }
-            .cw-center-dots span { width: 8px; height: 8px; border-radius: 50%; animation: googleBounce 1.4s infinite ease-in-out both; }
-            .cw-center-dots span:nth-child(1) { background-color: ${COLORS.blue}; animation-delay: -0.32s; }
-            .cw-center-dots span:nth-child(2) { background-color: ${COLORS.red}; animation-delay: -0.16s; }
+
+            .cw-center-dots { display: flex; gap: 10px; margin-bottom: 4px; }
+            /* Coreografia própria (era um "googleBounce" genérico, ease-in-out puro):
+               usa a curva spring já canônica do audit de motion (--cw-ease-spring)
+               pra um overshoot vivo, e soma um scale pulse ao bounce vertical. */
+            .cw-center-dots span {
+                width: 8px; height: 8px; border-radius: 50%;
+                animation: cw-dot-dance 1.1s var(--cw-ease-spring) infinite both;
+                will-change: transform;
+            }
+            .cw-center-dots span:nth-child(1) { background-color: ${COLORS.blue}; animation-delay: -0.22s; }
+            .cw-center-dots span:nth-child(2) { background-color: ${COLORS.red}; animation-delay: -0.11s; }
             .cw-center-dots span:nth-child(3) { background-color: ${COLORS.green}; }
+            @media (prefers-reduced-motion: reduce) {
+                /* Antes não tinha fallback nenhum - as bolinhas ficavam
+                   quicando pra sempre mesmo com reduced-motion ativado. */
+                .cw-center-dots span { animation: cw-dot-fade 1.6s ease-in-out infinite; }
+            }
             
             .cw-center-text { 
                 font-family: 'Google Sans', Roboto, sans-serif;
@@ -595,7 +613,8 @@ export function initCommandCenter(actions, splashDone) {
 
             @keyframes fadeIn { to { opacity: 1; } }
             @keyframes popIn { from { transform: scale(0.5); opacity: 0; } to { transform: scale(1); opacity: 1; } }
-            @keyframes googleBounce { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }
+            @keyframes cw-dot-dance { 0%, 100% { transform: translateY(0) scale(1); } 50% { transform: translateY(-10px) scale(1.2); } }
+            @keyframes cw-dot-fade { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
             @keyframes textSlideUp { to { opacity: 1; transform: translateY(0); } }
         `;
     document.head.appendChild(style);
@@ -951,6 +970,7 @@ export function triggerProcessingAnimation() {
   abortBtn.onclick = (e) => {
     e.stopPropagation();
     window._CW_ABORT_PROCESS = true;
+    SoundManager.stopThinking();
     showToast("Cancelado!", { duration: 3000 });
     stage.remove();
     pill.classList.remove('processing-center');
@@ -958,13 +978,14 @@ export function triggerProcessingAnimation() {
     pill.classList.add('collapsed');
     if (overlay) overlay.classList.remove('active');
   };
-  
+
   stage.appendChild(abortBtn);
   pill.appendChild(stage);
 
   const startTime = Date.now();
   pill.classList.add('processing-center');
   if (overlay) overlay.classList.add('active');
+  SoundManager.startThinking();
 
   return function finish() {
     if (window._CW_ABORT_PROCESS || !pill.contains(stage)) return;
@@ -973,7 +994,8 @@ export function triggerProcessingAnimation() {
 
     setTimeout(() => {
       if (window._CW_ABORT_PROCESS || !pill.contains(stage)) return;
-      
+      SoundManager.stopThinking();
+
       const dots = stage.querySelector('.cw-center-dots');
       const text = stage.querySelector('.cw-center-text');
       const success = stage.querySelector('.cw-center-success');

--- a/src/modules/shared/sound-manager.js
+++ b/src/modules/shared/sound-manager.js
@@ -2,6 +2,8 @@
 
 let audioCtx = null;
 let noiseBufferCache = null;
+let thinkingLoopId = null;
+let thinkingStep = 0;
 
 // Configurações de "Mixagem de Escritório"
 // Volume muito baixo para ser percebido apenas pelo subconsciente
@@ -368,6 +370,53 @@ export const SoundManager = {
             osc.start(start);
             osc.stop(start + n.dur + 0.05);
         });
+    },
+
+    // 7. THINKING (Loop de Espera)
+    // Ref: o balanço das 3 bolinhas do Processing Center.
+    // Um arpejo de 3 notas (acorde maior, sem tensão) tão baixo que só
+    // confirma "ainda trabalhando" no fundo - não vira trilha sonora.
+    // Precisa de start/stop porque é um loop, diferente dos outros sons
+    // (um tiro só, tocam e morrem sozinhos).
+    startThinking: () => {
+        if (muted) return;
+        const ctx = getContext();
+        if (!ctx || thinkingLoopId) return;
+
+        const notes = [523.25, 659.25, 783.99]; // C5, E5, G5
+        thinkingStep = 0;
+
+        const beat = () => {
+            if (muted) return;
+            const t = ctx.currentTime;
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(notes[thinkingStep % notes.length], t);
+
+            gain.gain.setValueAtTime(0, t);
+            gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.15, t + 0.02);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.22);
+
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            osc.start(t);
+            osc.stop(t + 0.25);
+
+            thinkingStep++;
+        };
+
+        beat();
+        // Acompanha o ritmo do cw-dot-dance (1.1s / 3 pontos ≈ 370ms por batida)
+        thinkingLoopId = setInterval(beat, 370);
+    },
+
+    stopThinking: () => {
+        if (thinkingLoopId) {
+            clearInterval(thinkingLoopId);
+            thinkingLoopId = null;
+        }
     },
 
     // Manter compatibilidade com chamadas antigas


### PR DESCRIPTION
## Summary
- Replaces the opaque `#202124` "black square" of the Processing Center loader with the same Liquid Glass treatment (`COLORS.glassBg`/`glassBorder` + `backdrop-filter: blur`) used by the rest of the pill.
- Reworks the dots' bounce: swaps the generic `ease-in-out` for the project's canonical `--cw-ease-spring` token (from the recent motion audit) and adds a scale pulse, so the "dance" feels more deliberate. Also adds the `prefers-reduced-motion` fallback this animation was missing (every sibling in the same stage already had one).
- Adds a subtle looping 3-note arpeggio (`SoundManager.startThinking`/`stopThinking`) synced to the dots' rhythm — the wait state was previously silent; sound only fired on success/error.

## Test plan
- [x] `npm run build` (esbuild) completes without errors
- [ ] Manually trigger note/email generation in the CRM and confirm: glass background reads correctly over the page behind it, dots bounce feels livelier, arpeggio plays at low volume and stops when the checkmark appears, and Cancelar also stops the sound
- [ ] Toggle OS "reduce motion" and confirm the dots switch to the fade fallback instead of bouncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)