### PR TITLE
fix(tl-dashboard): histórico stale e foto quebrada em Ativos agora

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -1205,7 +1205,11 @@
             document.getElementById('history-panel').style.display = isHistory ? 'flex' : 'none';
             if (isHistory) {
                 document.getElementById('loader').style.display = 'none';
-                loadHistory();
+                // force=true: sem isso, loadHistory() só busca dados na
+                // primeira visita à aba (historyLoaded trava depois disso) -
+                // um caso aprovado/descartado depois da primeira visita nunca
+                // aparecia até a página inteira ser recarregada.
+                loadHistory(true);
             } else {
                 renderCases();
             }
@@ -1551,12 +1555,21 @@
                 el.innerHTML = '<div class="text-secondary" style="font-size: 13px;">Só você, por enquanto.</div>';
                 return;
             }
-            el.innerHTML = list.map(u => `
+            const fallbackIcon = 'https://fonts.gstatic.com/s/i/googlematerialsymbolsrounded/person/24px.svg';
+            el.innerHTML = list.map(u => {
+                const ldap = u.ldap || '';
+                // Nunca src="" - alguns navegadores reinterpretam um src vazio
+                // como um pedido pra própria página atual, o que aparecia como
+                // "imagem quebrada". Sem ldap, vai direto pro ícone genérico
+                // em vez de tentar montar uma URL de foto inválida.
+                const photoUrl = ldap ? ('https://moma-teams-photos.corp.google.com/photos/' + encodeURIComponent(ldap) + '?sz=600') : fallbackIcon;
+                return `
                 <div class="active-tl-row">
                     <span class="presence-dot"></span>
-                    <img src="https://moma-teams-photos.corp.google.com/photos/${encodeURIComponent(u.ldap)}?sz=600" class="agent-photo" style="width: 24px; height: 24px;" onerror="this.src='https://fonts.gstatic.com/s/i/googlematerialsymbolsrounded/person/24px.svg'">
-                    <span class="text-secondary" style="color: var(--text-primary); font-size: 13px;">${escapeHtml(u.ldap)}</span>
-                </div>`).join('');
+                    <img src="${photoUrl}" class="agent-photo" style="width: 24px; height: 24px;" referrerpolicy="no-referrer" onerror="this.src='${fallbackIcon}'">
+                    <span class="text-secondary" style="color: var(--text-primary); font-size: 13px;">${escapeHtml(ldap || 'desconhecido')}</span>
+                </div>`;
+            }).join('');
         }
 
         const ACTIVITY_VERB_BY_ACTION = {


### PR DESCRIPTION
## Resumo

- **Histórico não atualizava**: `switchTab('HISTORY')` chamava `loadHistory()` sem forçar - a função só busca dados na primeira visita à aba (`historyLoaded` trava depois disso). Um caso aprovado/descartado após a primeira visita nunca aparecia sem recarregar a página inteira. Agora força um refetch a cada entrada na aba.
- **Foto quebrada em "Ativos agora"**: dois reforços - nunca monta `src=""` (fallback direto pro ícone genérico quando não há ldap) e adiciona `referrerpolicy="no-referrer"` no `<img>`, mitigação padrão pra endpoint de foto corp que rejeita embed sem esse header quando a página roda dentro do iframe sandboxado do Apps Script.

## Test plan

- [ ] Abrir Histórico, aprovar um caso na aba Criação, voltar pro Histórico e confirmar que o caso aparece sem recarregar a página
- [ ] Conferir se a foto de perfil em "Ativos agora" carrega corretamente (ou cai no ícone genérico sem ficar quebrada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)