### PR TITLE
fix(notes): always confirm deleting a case-notes field

### DIFF
--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -49,19 +49,12 @@ export function buildDynamicForm(subStatusKey, container, state) {
             btnDelete.style.cssText = `font-size: 14px; background: ${COLORS.bgInput}; border: none; color: ${COLORS.textSub}; cursor: pointer; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-left: auto; transition: all 0.2s ${EASE};`;
             btnDelete.onmouseenter = () => { btnDelete.style.background = COLORS.error; btnDelete.style.color = COLORS.surface; };
             btnDelete.onmouseleave = () => { btnDelete.style.background = COLORS.bgInput; btnDelete.style.color = COLORS.textSub; };
-            // Só confirma se o campo já tem conteúdo digitado: nesse caso o
-            // texto some do output final ao remover o campo, então vale a
-            // pena checar. Campo vazio continua removendo direto, sem
-            // atrapalhar a velocidade por nada.
             btnDelete.onclick = async (e) => {
                 e.preventDefault();
                 SoundManager.playClick();
-                const currentValue = (state.formData[fieldId] || "").trim();
-                if (currentValue) {
-                    const fieldLabel = labelText.textContent.replace(/:\s*$/, "").trim();
-                    const confirmed = await confirmDialog(`Remover o campo "${fieldLabel}"? O texto digitado será perdido.`, { danger: true, confirmText: "Remover" });
-                    if (!confirmed) return;
-                }
+                const fieldLabel = labelText.textContent.replace(/:\s*$/, "").trim();
+                const confirmed = await confirmDialog(`Remover o campo "${fieldLabel}"?`, { danger: true, confirmText: "Remover" });
+                if (!confirmed) return;
                 state.removeField(fieldName);
                 buildDynamicForm(subStatusKey, container, state);
             };


### PR DESCRIPTION
## Summary
- Follow-up to #256. That PR only showed the delete confirmation when the field already had text typed in, so testing on an empty field (the most natural first click) skipped the dialog and looked like the feature wasn't working.
- Removes the "only if filled" condition — every click on the field's "x" now goes through `confirmDialog`, matching the original request and the pattern used elsewhere in the app (drafts, broadcast, personal library all confirm unconditionally).

## Test plan
- [x] `npx esbuild src/app.js --bundle` builds cleanly.
- [x] Verified the confirmation string is present in the bundle output unconditionally (no longer gated behind a content check).
- [ ] Manual smoke test in the CRM: click "x" on both an empty and a filled optional Case Notes field — confirm the modal appears both times, and Cancel/Remove behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)