### PR TITLE
fix(tl-dashboard): atividade recente mostra caso e LDAPs, não o anunciante

### DIFF
--- a/gas-backend/BAU_Dashboard.js
+++ b/gas-backend/BAU_Dashboard.js
@@ -148,7 +148,7 @@ function getRecentActivity(limit) {
     activity.push({
       id: String(row[0] || ""),
       caseId: String(row[4] || ""),
-      advName: String(row[7] || ""),
+      agentEmail: String(row[2] || ""),
       status: String(row[3] || ""),
       action: String(row[20] || ""),
       processedBy: String(row[18] || ""),

--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -1594,12 +1594,14 @@
                 return;
             }
             el.innerHTML = list.map(a => {
-                const who = a.processedBy ? a.processedBy.split('@')[0] : 'alguém';
+                const tlLdap = a.processedBy ? a.processedBy.split('@')[0] : 'alguém';
+                const agentLdap = a.agentEmail ? a.agentEmail.split('@')[0] : 'agente desconhecido';
                 const verb = ACTIVITY_VERB_BY_ACTION[a.action] || 'processou';
+                const caseLabel = a.caseId ? ('#' + a.caseId) : 'caso sem ID';
                 return `
                 <div class="activity-row">
-                    <div class="text-primary" style="font-size: 13px; font-weight: 500; margin-bottom: 0;">${escapeHtml(who)} ${verb} <span style="font-weight: 400;">${escapeHtml(a.advName || a.caseId)}</span></div>
-                    <div class="text-secondary" style="font-size: 11px;">${timeAgo(a.processedAt)}</div>
+                    <div class="text-primary" style="font-size: 13px; font-weight: 500; margin-bottom: 0;">${escapeHtml(tlLdap)} ${verb} <span style="font-weight: 400;">${escapeHtml(caseLabel)}</span></div>
+                    <div class="text-secondary" style="font-size: 11px;">solicitado por ${escapeHtml(agentLdap)} · ${timeAgo(a.processedAt)}</div>
                 </div>`;
             }).join('');
         }


### PR DESCRIPTION
## Resumo

- \`getRecentActivity()\` agora retorna \`agentEmail\` (quem abriu o caso) no lugar de \`advName\`.
- O feed "Atividade recente" do painel lateral passa a mostrar \`<TL> <ação> #<caso>\` + \`solicitado por <agente>\`, em LDAP - dado operacional (quem pediu, quem decidiu, qual caso) em vez do nome do anunciante.

## Test plan

- [ ] Aprovar/descartar um caso e conferir que o feed mostra o número do caso, o LDAP do agente solicitante e o LDAP do TL que decidiu

🤖 Generated with [Claude Code](https://claude.com/claude-code)