### PR TITLE
feat(notes): quick-launch note presets via Ctrl+K

### DIFF
--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -713,6 +713,14 @@ export const scenarioSnippets = {
     'quickfill-ni-attempted-2day': {
         type: 'bau',
         substatus: ['NI_Attempted_Contact'],
+        // Atalho de Ctrl+K (Quick Launch): ver notes-assistant.js#openWithPreset.
+        quickLaunch: {
+            status: 'NI',
+            subStatus: 'NI_Attempted_Contact',
+            label: 'NI Attempted — Início 2 Day Rule',
+            keywords: '2 day ligacao attempted contact inicio',
+            focusIds: ['field-SPEAKEASY_ID', 'evidence-l1', 'evidence-l2', 'evidence-msg']
+        },
         'field-REASON_COMMENTS': "Attempted Contact (Início 2 Day Rule)",
         'field-CONTEXTO_CALL': "• Fiz a primeira tentativa de ligação, sem sucesso.\n• Enviei uma message no chat para o AM.\n• Aguardei 5 minutos e fiz a segunda tentativa de ligação, novamente sem sucesso.\n• Aguardei mais 5 minutos e agora farei o acompanhamento 2 Day Rule.",
         'field-SCREENSHOTS': "• MSG AM -\n• Tentativa 1 -\n• Tentativa 2 -"
@@ -739,6 +747,17 @@ export const scenarioSnippets = {
     'quickfill-in-no-show-bau': {
         type: 'bau',
         substatus: ['IN_Not_Reachable'],
+        // Atalho de Ctrl+K (Quick Launch): abre o Case Notes já no status/substatus
+        // certo e com este cenário aplicado - ver notes-assistant.js#openWithPreset.
+        // focusIds: campo pra focar/realçar como "ainda falta preencher" depois de
+        // aplicar o preset, em ordem de prioridade.
+        quickLaunch: {
+            status: 'IN',
+            subStatus: 'IN_Not_Reachable',
+            label: 'IN Not Reachable — Finalização 2 Day Rule',
+            keywords: '2 day finalizacao nao atendeu ligacoes reachable',
+            focusIds: ['field-SPEAKEASY_ID']
+        },
         'field-REASON_COMMENTS': "Sem resposta ao 2 Day Rule.",
         'field-ON_CALL': "N/A",
         'field-COMENTARIOS': "• O caso foi gerado e entrei na chamada no horário agendado.\n• O anunciante não compareceu à reunião.\n• Segui o protocolo de espera (BAU): realizei duas tentativas de ligação, sem sucesso.\n• Nenhuma das ligações foi atendida (ex: Caixa Postal).\n• Caso inativado após 2 Day Rule.",

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -13,7 +13,7 @@ import { createDraftsManager } from "./drafts/draft-ui.js";
 import { createSplitTransferComponent } from "./components/split-transfer.js";
 import { DraftService } from "./drafts/draft-service.js";
 import { SoundManager } from "../shared/sound-manager.js";
-import { enableFilledCheck, lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
+import { enableFilledCheck, lockBodyScroll, unlockBodyScroll, markPendingField } from "../shared/dom-utils.js";
 import { getPageData } from "../shared/page-data.js";
 import {
     SUBSTATUS_TEMPLATES,
@@ -945,6 +945,61 @@ export function initCaseNotesAssistant() {
         notesState.isDirty = false;
     }
 
+    // Quick Launch (Ctrl+K -> preset de nota): abre o Case Notes já no
+    // status/substatus certo e com o cenário mais usado aplicado, pra quem
+    // hoje copia e cola essas notas em vez de passar pelo fluxo normal. Não
+    // reimplementa nada - só encadeia as mesmas peças que o clique manual já
+    // usa (troca de select, onSubStatusChange, clique no chip do cenário),
+    // então herda de graça qualquer ajuste futuro nelas.
+    async function openWithPreset(scenarioId) {
+        const scenario = scenarioSnippets[scenarioId];
+        const preset = scenario && scenario.quickLaunch;
+        if (!preset) return;
+
+        if (notesState.isDirty) {
+            const confirmed = await confirmDialog("Isso vai substituir o rascunho atual da nota. Deseja continuar?");
+            if (!confirmed) return;
+        }
+
+        const wasVisible = notesState.visible;
+        if (!wasVisible) toggleVisibility();
+        resetModule();
+
+        // Se o popup ainda não estava aberto, dá tempo do voo do genie
+        // (~550ms, ver animations.js) terminar antes de mexer nos campos -
+        // trocar os selects no meio da animação de abertura ficava estranho.
+        if (!wasVisible) await wait(550);
+
+        const mainSelect = content.querySelector('#main-status-select');
+        const subSelect = content.querySelector('#sub-status-select');
+        mainSelect.value = preset.status;
+        notesState.setStatus(preset.status);
+        updateSubStatusOptions(preset.status, subSelect);
+
+        await wait(60);
+
+        subSelect.value = preset.subStatus;
+        notesState.setSubStatus(preset.subStatus);
+        onSubStatusChange(preset.subStatus);
+
+        await wait(160);
+
+        // Clique real no chip (não chama applyScenario direto): assim o
+        // cenário aparece visualmente selecionado, com o mesmo som de clique
+        // de sempre - igual a um agente teria feito na mão.
+        const chip = scenariosContainer.querySelector(`[data-id="${scenarioId}"]`);
+        if (chip) chip.click();
+
+        await wait(120);
+        SoundManager.playSuccess();
+
+        const pendingId = (preset.focusIds || []).find((id) => {
+            const el = document.getElementById(id);
+            return el && !el.value.trim();
+        });
+        if (pendingId) markPendingField(document.getElementById(pendingId));
+    }
+
     function t(key) {
         return translations[notesState.currentLang]?.[key] || translations['pt']?.[key] || key;
     }
@@ -1069,5 +1124,9 @@ export function initCaseNotesAssistant() {
 
     document.body.appendChild(popup);
 
+    // Pendurado na própria função (em vez de trocar o retorno por um objeto)
+    // pra não quebrar os callers existentes que chamam initCaseNotesAssistant()
+    // esperando só a função de toggle (app.js, command-center.js, command-palette.js).
+    toggleVisibility.openWithPreset = openWithPreset;
     return toggleVisibility;
 }

--- a/src/modules/shared/command-palette.js
+++ b/src/modules/shared/command-palette.js
@@ -8,6 +8,7 @@
 
 import { SoundManager } from './sound-manager.js';
 import { lockBodyScroll, unlockBodyScroll } from './dom-utils.js';
+import { scenarioSnippets } from '../notes/data/notes-data.js';
 
 const ICONS = {
     notes: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`,
@@ -23,6 +24,7 @@ const ICONS = {
     enter: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 10 4 15 9 20"></polyline><path d="M20 4v7a4 4 0 0 1-4 4H4"></path></svg>`,
     arrowDown: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>`,
     arrowUp: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>`,
+    bolt: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>`,
 };
 
 function injectStyles() {
@@ -70,6 +72,8 @@ function injectStyles() {
         .cw-palette-item-icon { width: 32px; height: 32px; border-radius: 9px; background: #F1F3F4; display: flex; align-items: center; justify-content: center; flex-shrink: 0; color: #5F6368; transition: background-color 0.1s ease, color 0.1s ease; }
         .cw-palette-item-icon svg { width: 18px; height: 18px; }
         .cw-palette-item.selected .cw-palette-item-icon { background: #FFFFFF; color: #1A73E8; }
+        .cw-palette-item-icon--preset { background: #FEF7E0; color: #F9A825; }
+        .cw-palette-item.selected .cw-palette-item-icon--preset { background: #FFFFFF; color: #F9A825; }
         .cw-palette-item-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
         .cw-palette-item-label { font-size: 14px; font-weight: 600; color: #202124; }
         .cw-palette-item-hint { font-size: 12px; color: #5F6368; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -93,6 +97,25 @@ export function initCommandPalette(actions) {
         return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
     }
 
+    // Atalhos de nota (Quick Launch): qualquer scenarioSnippet com um
+    // `quickLaunch` cadastrado em notes-data.js vira automaticamente uma
+    // entrada aqui - escalar pra mais notas é só adicionar o campo lá, sem
+    // tocar neste arquivo. Entram na mesma busca textual dos módulos, só com
+    // ícone de raio pra se destacar visualmente do resto.
+    const notePresets = (typeof actions.toggleNotes === 'function' && typeof actions.toggleNotes.openWithPreset === 'function')
+        ? Object.entries(scenarioSnippets)
+            .filter(([, data]) => data.quickLaunch)
+            .map(([scenarioId, data]) => ({
+                id: `note-preset-${scenarioId}`,
+                label: data.quickLaunch.label,
+                hint: 'Atalho de nota · abre pré-preenchida',
+                keywords: `nota atalho preset ${data.quickLaunch.keywords || ''}`,
+                icon: ICONS.bolt,
+                isPreset: true,
+                run: () => actions.toggleNotes.openWithPreset(scenarioId)
+            }))
+        : [];
+
     const ALL_ACTIONS = [
         { id: 'notes', label: 'Case Notes', hint: 'Montar a nota técnica do caso', keywords: 'notas nota caso anotacoes', icon: ICONS.notes, run: actions.toggleNotes },
         { id: 'bauform', label: 'BAU Form', hint: 'Solicitação de criação/descarte BAU', keywords: 'bau formulario solicitacao criacao descarte', icon: ICONS.bauform, run: actions.toggleBAUForm },
@@ -103,6 +126,7 @@ export function initCommandPalette(actions) {
         { id: 'timezone', label: 'Fusos Horários', hint: 'Monitoramento e planejador de chamada', keywords: 'fuso horario timezone', icon: ICONS.timezone, run: actions.toggleTimezone },
         { id: 'broadcast', label: 'Avisos', hint: 'Comunicados e disponibilidade BAU', keywords: 'avisos broadcast comunicados disponibilidade', icon: ICONS.broadcast, run: () => actions.broadcastControl && actions.broadcastControl.toggle() },
         { id: 'configs', label: 'Configurações', hint: 'Perfil, som e preferências', keywords: 'configuracoes config preferencias perfil som', icon: ICONS.configs, run: actions.toggleConfigs },
+        ...notePresets,
     ]
         .filter(a => typeof a.run === 'function')
         .map(a => ({ ...a, _haystack: normalize(`${a.label} ${a.hint} ${a.keywords}`) }));
@@ -147,7 +171,7 @@ export function initCommandPalette(actions) {
             const item = document.createElement('div');
             item.className = 'cw-palette-item' + (idx === selectedIndex ? ' selected' : '');
             item.innerHTML = `
-                <span class="cw-palette-item-icon">${action.icon}</span>
+                <span class="cw-palette-item-icon${action.isPreset ? ' cw-palette-item-icon--preset' : ''}">${action.icon}</span>
                 <span class="cw-palette-item-text">
                     <span class="cw-palette-item-label">${action.label}</span>
                     <span class="cw-palette-item-hint">${action.hint}</span>

--- a/src/modules/shared/dom-utils.js
+++ b/src/modules/shared/dom-utils.js
@@ -139,6 +139,41 @@ export function enableArrowKeyNav(container, itemSelector) {
     });
 }
 
+// Realce "pendente" (Quick Launch): pulso âmbar breve pra marcar o campo que
+// ficou proposital/vazio depois de um preset do Ctrl+K preencher o resto da
+// nota - o oposto do check verde acima (isso já está pronto): aqui é "isso
+// ainda falta". Genérico o bastante pra qualquer módulo usar em qualquer input.
+let pendingFieldStylesInjected = false;
+function injectPendingFieldStyles() {
+    if (pendingFieldStylesInjected || document.getElementById('cw-pending-field-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'cw-pending-field-styles';
+    style.textContent = `
+        @keyframes cwPendingPulse {
+            0%, 100% { box-shadow: 0 0 0 0 rgba(251, 188, 5, 0.45); }
+            50% { box-shadow: 0 0 0 6px rgba(251, 188, 5, 0); }
+        }
+        .cw-quicklaunch-pending {
+            border-color: #FBBC05 !important;
+            animation: cwPendingPulse 1.1s ease-out 2;
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .cw-quicklaunch-pending { animation: none !important; }
+        }
+    `;
+    document.head.appendChild(style);
+    pendingFieldStylesInjected = true;
+}
+
+export function markPendingField(el, { duration = 2400 } = {}) {
+    if (!el) return;
+    injectPendingFieldStyles();
+    el.classList.add('cw-quicklaunch-pending');
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.focus({ preventScroll: true });
+    setTimeout(() => el.classList.remove('cw-quicklaunch-pending'), duration);
+}
+
 export function enableFilledCheck(input, { minLength = 2 } = {}) {
     injectFilledCheckStyles();
 


### PR DESCRIPTION
## Summary
- Agentes copiavam e colavam as duas notas mais usadas (NI Attempted / início do 2 Day Rule, IN Not Reachable / finalização do 2 Day Rule) em vez de passar pelo fluxo normal do Case Notes, porque era mais rápido. Agora Ctrl+K abre o Case Notes já pré-preenchido para esses dois cenários.
- `quickLaunch` é um campo opcional em qualquer `scenarioSnippet` (`notes-data.js`) — adicionar mais atalhos depois não exige tocar em nenhum outro arquivo, eles aparecem automaticamente na busca do Ctrl+K.
- `openWithPreset()` reaproveita a troca de status/substatus e o clique real no chip do cenário (mesmo som/estado visual de um clique manual), bloqueia sobrescrita de rascunho não salvo com o `confirmDialog` já existente, e foca/realça (pulso âmbar) o primeiro campo intencionalmente deixado vazio (ex: SE ID).
- Ícone de raio diferencia os atalhos de nota dos 9 módulos no palette.

## Test plan
- [x] Smoke test end-to-end com Playwright injetando o bundle (esbuild) no `mock-crm.html` (mesmo mecanismo do `generate-portfolio.py`, já que o app roda como bookmarklet sobre o CRM real): busca no Ctrl+K encontra os dois atalhos → Enter abre o Case Notes com status/substatus corretos e campos preenchidos → foco cai no SE ID → destaque âmbar aplicado.
- [x] Guard-rail de rascunho não salvo: confirmado que o `confirmDialog` dispara antes de sobrescrever um rascunho em edição.
- [x] Rebasado e testado novamente contra a ponta atual de `refactor-structure` (que já mudou `scenarioSnippets` para o novo filtro por `substatus: [...]` desde a análise inicial) — os dois presets continuam renderizando o chip certo com esse novo filtro.
- [x] `node --check` (ESM) limpo nos 4 arquivos alterados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)