### PR TITLE
fix(tl-dashboard): alinhamento do link de caso e foto na atividade recente

### DIFF
--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -361,7 +361,11 @@
 
         .reason-box .material-symbols-rounded { color: var(--gemini-purple); font-size: 20px; }
 
-        .link { color: var(--gemini-blue); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; transition: opacity 0.2s; position: relative; z-index: 2; }
+        /* vertical-align: middle - sem isso, o inline-flex alinha pelo baseline
+           do próprio conteúdo (o ícone, não texto), o que deixa o link (e a
+           setinha de "abrir") mais baixo que o texto ao redor quando embutido
+           no meio de uma frase (atividade recente, card do histórico). */
+        .link { color: var(--gemini-blue); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; vertical-align: middle; transition: opacity 0.2s; position: relative; z-index: 2; }
 
         /* Busca - única, compartilhada entre as 3 abas (fila e histórico) */
         .search-bar {
@@ -465,6 +469,13 @@
             border-bottom: 1px solid var(--border-subtle);
         }
         .activity-row:last-child, .top-agent-row:last-child { border-bottom: none; }
+
+        .activity-row-main {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 2px;
+        }
 
         .top-agent-row {
             display: flex;
@@ -1626,12 +1637,16 @@
                 return;
             }
             el.innerHTML = list.map(a => {
-                const tlLdap = a.processedBy ? a.processedBy.split('@')[0] : 'alguém';
+                const tlLdapRaw = a.processedBy ? a.processedBy.split('@')[0] : '';
+                const tlLdap = tlLdapRaw || 'alguém';
                 const agentLdap = a.agentEmail ? a.agentEmail.split('@')[0] : 'agente desconhecido';
                 const verb = ACTIVITY_VERB_BY_ACTION[a.action] || 'processou';
                 return `
                 <div class="activity-row">
-                    <div class="text-primary" style="font-size: 13px; font-weight: 500; margin-bottom: 0;">${escapeHtml(tlLdap)} ${verb} <span style="font-weight: 400;">${caseLinkHtml(a.caseId)}</span></div>
+                    <div class="activity-row-main">
+                        ${avatarImgHtml(tlLdapRaw, 20)}
+                        <div class="text-primary" style="font-size: 13px; font-weight: 500;">${escapeHtml(tlLdap)} ${verb} <span style="font-weight: 400;">${caseLinkHtml(a.caseId)}</span></div>
+                    </div>
                     <div class="text-secondary" style="font-size: 11px;">solicitado por ${escapeHtml(agentLdap)} · ${timeAgo(a.processedAt)}</div>
                 </div>`;
             }).join('');


### PR DESCRIPTION
## Resumo

- \`.link\` ganha \`vertical-align: middle\` - corrige a setinha "abrir caso" (arrow_outward) aparecendo mais baixa que o texto ao redor quando embutida no meio de uma frase (atividade recente, card do histórico).
- "Atividade recente" agora mostra a foto do TL (quem teve a atividade) ao lado do LDAP, mesmo padrão de foto+fallback já usado no resto do painel.

## Test plan

- [ ] Conferir visualmente se o ícone de link do caso está alinhado com o texto ao redor na atividade recente e no histórico
- [ ] Conferir se a foto do TL aparece ao lado do nome em cada linha de "Atividade recente"

🤖 Generated with [Claude Code](https://claude.com/claude-code)