### PR TITLE
feat(notes): deleted case-notes fields reappear as re-add chips

### DIFF
--- a/src/modules/notes/core/form-builder.js
+++ b/src/modules/notes/core/form-builder.js
@@ -1,5 +1,5 @@
 // src/modules/notes/core/form-builder.js
-import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations, getEffectiveRequiredFields, getEffectiveOptionalFields } from "../data/notes-data.js";
+import { SUBSTATUS_TEMPLATES, textareaListFields, textareaParagraphFields, translations, getEffectiveRequiredFields } from "../data/notes-data.js";
 import { fetchAndInsertSpeakeasyId } from "../automation/case-log-scraper.js";
 import { enableAutoBullet } from "../components/bullet-editor.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "../notes-styles.js";
@@ -96,12 +96,13 @@ export function buildDynamicForm(subStatusKey, container, state) {
         container.appendChild(consentSelect);
     }
 
-    // Campos opcionais do template (ver optionalFields em data/notes-data.js)
-    // que ainda não estão ativos: ficam escondidos por padrão pra reduzir a
-    // carga cognitiva, mas continuam a 1 clique de distância.
-    const optionalNow = getEffectiveOptionalFields(templateData);
+    // Campos não-obrigatórios do template que não estão ativos no momento —
+    // seja porque começam escondidos por padrão (ver optionalFields em
+    // data/notes-data.js) ou porque o agente os removeu pelo botão "✕" —
+    // ficam disponíveis aqui a 1 clique de distância, permitindo desfazer
+    // a remoção.
     const hiddenOptional = (templateData.templateFields || []).filter(
-        (fieldName) => optionalNow.includes(fieldName) && !state.activeFields.includes(fieldName)
+        (fieldName) => !requiredNow.includes(fieldName) && !state.activeFields.includes(fieldName)
     );
     if (hiddenOptional.length > 0) {
         const t = (key) => translations[state.currentLang]?.[key] || translations["pt"]?.[key] || key;


### PR DESCRIPTION
## Summary
- Follow-up to #256/#261. Those added a confirmation before deleting a Case Notes field, but the delete itself was still a dead end for most fields: only the two universal low-value fields (`GTM_GA4_VERIFICADO`, `MULTIPLE_CIDS`) reappeared as "+ campo" chips after being removed. Any other deletable field (`SPEAKEASY_ID`, `MOTIVO_REAGENDAMENTO`, `CONTEXTO_CALL`, etc.) just vanished, with no way back short of re-selecting the substatus template.
- `hiddenOptional` in `form-builder.js` now includes any non-required template field that isn't currently active, regardless of whether it started hidden or was actively deleted — so every "x" click can be undone with one click on its "+ campo" chip.
- `state.removeField()` already leaves the typed value in `formData` untouched, so re-adding a field restores its previous text too, not just an empty input.

## Test plan
- [x] `npx esbuild src/app.js --bundle` builds cleanly.
- [ ] Manual smoke test in the CRM: pick a substatus, type text into an optional field like `SPEAKEASY_ID`, delete it (confirm the dialog), verify a "+ Speakeasy ID" chip appears below and clicking it restores the field with the previously typed text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)