### PR TITLE
fix(notes): campos opcionais em NI - Attempted Contact

### DIFF
--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -407,10 +407,11 @@ export const SUBSTATUS_TEMPLATES = {
         }
     },
     'NI_Attempted_Contact': {
-        status: 'NI', 
-        name: 'NI - Attempted Contact', 
+        status: 'NI',
+        name: 'NI - Attempted Contact',
         requiresTasks: false,
-        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'CONTEXTO_CALL', 'TASKS_SOLICITADAS', 'IMPEDIMENTO_CLIENTE', 'MINHA_ACAO', 'CONSIDERACOES', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS']
+        templateFields: ['SPEAKEASY_ID', 'ON_CALL', 'label_substatus', 'REASON_COMMENTS', 'CONTEXTO_CALL', 'TASKS_SOLICITADAS', 'IMPEDIMENTO_CLIENTE', 'MINHA_ACAO', 'CONSIDERACOES', 'GTM_GA4_VERIFICADO', 'TAGS_IMPLEMENTED', 'SCREENSHOTS_LIST', 'MULTIPLE_CIDS'],
+        extraOptionalFields: ['TASKS_SOLICITADAS', 'IMPEDIMENTO_CLIENTE', 'MINHA_ACAO', 'CONSIDERACOES']
     },
 
     // --- IN (Inactive) ---


### PR DESCRIPTION
## Summary
- No substatus NI - Attempted Contact, os campos "Considerações", "Minha ação", "Impedimento do cliente" e "Tasks solicitadas" apareciam sempre no formulário mesmo não sendo obrigatórios.
- Move os quatro pra `extraOptionalFields`, o mesmo mecanismo já usado em SO - Implementation Only e SO - Education Only (#248), escondendo-os por padrão atrás do botão "+ adicionar campo".

## Test plan
- [x] Confirmado via `getEffectiveOptionalFields` que os 4 campos entram na lista de opcionais pro template NI_Attempted_Contact.
- [ ] Conferir visualmente no formulário de notas que os campos somem por padrão e voltam ao clicar em "+ adicionar campo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)