### PR TITLE
feat(content-central): fundação da Central de Conteúdo + módulo de Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ dist/
 .idx/
 test-results/
 
+# Payload de semeadura da Central de Conteúdo: derivado do próprio código
+# por `npm run seed:links`, não é fonte.
+links-seed.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -1,0 +1,830 @@
+// =========================================================
+// ARQUIVO: ContentAPI.gs (Central de Conteúdo)
+// Fase 0 (fundação + controle de acesso) e Fase 1 (Links).
+//
+// Regra central do módulo: o app em produção só enxerga linhas de
+// Content_Items com status 'live'. Rascunho e proposta pendente vivem
+// exclusivamente em Content_Drafts, numa aba que a leitura pública nunca
+// toca - a barreira é estrutural, não uma regra de UI que dê pra burlar
+// chamando o endpoint na mão.
+// =========================================================
+
+const SHEET_CONTENT_ITEMS = "Content_Items";
+const SHEET_CONTENT_DRAFTS = "Content_Drafts";
+const SHEET_CONTENT_ACCESS = "Content_Access";
+
+// Módulos gerenciáveis. Adicionar um módulo novo é acrescentar uma string
+// aqui - não uma aba nova, que é justamente a dívida que Tips/Broadcast/
+// Database_Snippets acumularam ao ganhar cada um seu próprio schema.
+const CONTENT_MODULES = ['links', 'call_script', 'email_template', 'case_note_snippet'];
+
+// Idiomas aceitos na coluna `lang`. 'ALL' = vale para todos (caso dos links,
+// cujo par PT/ES mora no próprio valor do item).
+const CONTENT_LANGS = ['ALL', 'PT', 'ES', 'EN'];
+
+const CONTENT_STATUS = {
+  DRAFT: 'draft',
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  LIVE: 'live',
+  ARCHIVED: 'archived'
+};
+
+// Matriz de papéis. É o ponto de partida: quem entra em Content_Access recebe
+// um destes papéis, e o ADMIN ajusta a lista de pessoas pela aba "Acessos" da
+// tela sem precisar de deploy novo.
+const CONTENT_ROLES = {
+  ADMIN: {
+    propose: CONTENT_MODULES,
+    approve: true,
+    manageAccess: true,
+    // Única exceção à regra de "não aprova a própria proposta": hoje o ADMIN é
+    // o único papel ativo, e travar o próprio fluxo não protegeria ninguém.
+    // A aprovação continua indo pro log como qualquer outra.
+    selfApprove: true
+  },
+  TL: {
+    propose: CONTENT_MODULES,
+    approve: true,
+    manageAccess: false,
+    selfApprove: false
+  },
+  QA: {
+    propose: ['call_script', 'case_note_snippet'],
+    approve: false,
+    manageAccess: false,
+    selfApprove: false
+  },
+  WFM: {
+    propose: ['links'],
+    approve: false,
+    manageAccess: false,
+    selfApprove: false
+  }
+};
+
+// Semente de acesso: sem isso a tela nasce inacessível para todo mundo,
+// inclusive para quem precisa cadastrar os demais.
+const CONTENT_BOOTSTRAP_ADMIN = 'lucaste';
+
+// TTL da trava de edição de rascunho. O Sheets não tem lock por linha, então
+// a trava é cooperativa: expira sozinha pra nunca deixar um item preso caso
+// alguém feche a aba no meio da edição.
+const CONTENT_LOCK_TTL_MS = 10 * 60 * 1000;
+
+// `Lineage` é a identidade estável do item ao longo das versões - o `ID` muda a
+// cada publicação (cada versão é uma linha nova) e `Key` não serve: em links
+// `Key` é a categoria, compartilhada por dezenas de itens. Sem essa coluna, um
+// rollback arquivaria a categoria inteira em vez de um link só.
+const CONTENT_ITEMS_HEADERS = [
+  "ID", "Module", "Key", "Field", "Lang", "Label", "Value",
+  "Version", "Status", "Published_By", "Published_At", "Sort_Order", "Lineage"
+];
+
+const CONTENT_DRAFTS_HEADERS = [
+  "Draft_ID", "Item_ID", "Module", "Key", "Field", "Lang", "Label", "Value",
+  "Status", "Proposed_By", "Proposed_At", "Reviewed_By", "Reviewed_At",
+  "Review_Note", "Locked_By", "Locked_At", "Sort_Order", "Action"
+];
+
+// O que a proposta faz com o item quando aprovada. Coluna explícita em vez de
+// inferir pelo valor vazio: "tirar do ar" e "publicar um valor em branco" são
+// intenções diferentes, e adivinhar erraria uma das duas.
+const CONTENT_ACTIONS = {
+  UPSERT: 'upsert',
+  REMOVE: 'remove'
+};
+
+const CONTENT_ACCESS_HEADERS = ["LDAP", "Role", "Active", "Granted_By", "Granted_At"];
+
+// =========================================================
+//  INFRAESTRUTURA (abas)
+// =========================================================
+
+function getContentSheet_(name) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(name);
+
+  if (!sheet) {
+    sheet = ss.insertSheet(name);
+    if (name === SHEET_CONTENT_ITEMS) sheet.appendRow(CONTENT_ITEMS_HEADERS);
+    else if (name === SHEET_CONTENT_DRAFTS) sheet.appendRow(CONTENT_DRAFTS_HEADERS);
+    else if (name === SHEET_CONTENT_ACCESS) {
+      sheet.appendRow(CONTENT_ACCESS_HEADERS);
+      // Semeia o ADMIN inicial junto com a aba, pra tela nunca nascer trancada.
+      sheet.appendRow([CONTENT_BOOTSTRAP_ADMIN, 'ADMIN', true, 'system', new Date().toISOString()]);
+    }
+    sheet.setFrozenRows(1);
+  }
+
+  return sheet;
+}
+
+// Converte a aba inteira em objetos chaveados pelo header, pra nenhum handler
+// depender de índice numérico de coluna (a fragilidade que o schema do
+// BAU_form_data já cobra caro hoje).
+function readContentRows_(sheetName) {
+  const sheet = getContentSheet_(sheetName);
+  const values = sheet.getDataRange().getValues();
+  if (values.length < 2) return [];
+
+  const headers = values[0].map(function (h) { return String(h).trim(); });
+  const rows = [];
+
+  for (let i = 1; i < values.length; i++) {
+    const obj = { _row: i + 1 };
+    for (let c = 0; c < headers.length; c++) {
+      obj[headers[c]] = values[i][c];
+    }
+    rows.push(obj);
+  }
+
+  return rows;
+}
+
+function findContentRow_(sheetName, idHeader, id) {
+  const rows = readContentRows_(sheetName);
+  const target = String(id || "").trim();
+  for (let i = 0; i < rows.length; i++) {
+    if (String(rows[i][idHeader]).trim() === target) return rows[i];
+  }
+  return null;
+}
+
+function contentNow_() {
+  return new Date().toISOString();
+}
+
+function newContentId_(prefix) {
+  return prefix + "_" + new Date().getTime() + "_" + Math.floor(Math.random() * 1000);
+}
+
+// =========================================================
+//  IDENTIDADE E PERMISSÃO
+// =========================================================
+
+// Identidade sempre do servidor. Nenhum handler aceita LDAP por parâmetro:
+// é o mesmo princípio já aplicado em assertCallerIsOverhead() no Código.js -
+// quem chama não escolhe quem é.
+function getCallerLdap_() {
+  const email = Session.getActiveUser().getEmail();
+  const ldap = email ? email.split('@')[0].toLowerCase().trim() : "";
+  if (!ldap) throw new Error("Não foi possível identificar o usuário autenticado.");
+  return ldap;
+}
+
+function getContentRoleForLdap_(ldap) {
+  const rows = readContentRows_(SHEET_CONTENT_ACCESS);
+  const target = String(ldap || "").toLowerCase().trim();
+
+  for (let i = 0; i < rows.length; i++) {
+    const rowLdap = String(rows[i].LDAP || "").toLowerCase().trim();
+    const active = String(rows[i].Active).toUpperCase().trim();
+
+    if (rowLdap === target && (active === 'TRUE' || active === '1')) {
+      const role = String(rows[i].Role || "").toUpperCase().trim();
+      if (CONTENT_ROLES[role]) return role;
+    }
+  }
+
+  return null; // Sem linha ativa = sem acesso. Não há papel padrão.
+}
+
+// Sessão da tela: papel + o que ele pode fazer. O front usa isso pra decidir o
+// que renderizar, mas cada ação é revalidada no servidor - a UI é conveniência,
+// não a fronteira de segurança.
+function getContentSession() {
+  const ldap = getCallerLdap_();
+  const role = getContentRoleForLdap_(ldap);
+
+  if (!role) {
+    return { ldap: ldap, role: null, hasAccess: false };
+  }
+
+  const perms = CONTENT_ROLES[role];
+  return {
+    ldap: ldap,
+    role: role,
+    hasAccess: true,
+    canApprove: perms.approve,
+    canManageAccess: perms.manageAccess,
+    canSelfApprove: perms.selfApprove,
+    proposableModules: perms.propose,
+    modules: CONTENT_MODULES,
+    langs: CONTENT_LANGS
+  };
+}
+
+// Porta única de todas as ações de escrita. Devolve { ldap, role, perms } pra
+// quem chamou não precisar reconsultar a planilha.
+function assertContentRole_(action, module) {
+  const ldap = getCallerLdap_();
+  const role = getContentRoleForLdap_(ldap);
+
+  if (!role) throw new Error("Acesso negado: você não tem permissão na Central de Conteúdo.");
+
+  const perms = CONTENT_ROLES[role];
+
+  if (action === 'propose') {
+    if (perms.propose.indexOf(module) === -1) {
+      throw new Error("Acesso negado: seu papel (" + role + ") não edita o módulo '" + module + "'.");
+    }
+  } else if (action === 'approve') {
+    if (!perms.approve) throw new Error("Acesso negado: seu papel (" + role + ") não aprova mudanças.");
+  } else if (action === 'manageAccess') {
+    if (!perms.manageAccess) throw new Error("Acesso negado: apenas o ADMIN gerencia acessos.");
+  }
+
+  return { ldap: ldap, role: role, perms: perms };
+}
+
+function assertValidModule_(module) {
+  if (CONTENT_MODULES.indexOf(module) === -1) {
+    throw new Error("Módulo desconhecido: " + module);
+  }
+}
+
+// Auditoria reaproveita a aba Logs que já existe (mesma de logEvent()), em vez
+// de criar um log paralelo só deste módulo.
+function logContentEvent_(ldap, action, label, value) {
+  try {
+    handleLog({
+      user: ldap,
+      version: 'content-central',
+      category: 'ContentCentral',
+      action: action,
+      label: label,
+      value: value
+    });
+  } catch (e) {
+    // Log nunca derruba a operação principal.
+  }
+}
+
+// =========================================================
+//  LEITURA
+// =========================================================
+
+function mapItemRow_(row) {
+  return {
+    id: String(row.ID || ""),
+    module: String(row.Module || ""),
+    key: String(row.Key || ""),
+    field: String(row.Field || ""),
+    lang: String(row.Lang || "ALL"),
+    label: String(row.Label || ""),
+    value: String(row.Value || ""),
+    version: Number(row.Version) || 1,
+    status: String(row.Status || ""),
+    publishedBy: String(row.Published_By || ""),
+    publishedAt: String(row.Published_At || ""),
+    sortOrder: Number(row.Sort_Order) || 0,
+    // Linhas semeadas antes desta coluna existir caem no próprio ID, que é
+    // exatamente a lineage de um item que nunca foi versionado.
+    lineage: String(row.Lineage || row.ID || "")
+  };
+}
+
+function mapDraftRow_(row) {
+  return {
+    draftId: String(row.Draft_ID || ""),
+    itemId: String(row.Item_ID || ""),
+    module: String(row.Module || ""),
+    key: String(row.Key || ""),
+    field: String(row.Field || ""),
+    lang: String(row.Lang || "ALL"),
+    label: String(row.Label || ""),
+    value: String(row.Value || ""),
+    status: String(row.Status || ""),
+    proposedBy: String(row.Proposed_By || ""),
+    proposedAt: String(row.Proposed_At || ""),
+    reviewedBy: String(row.Reviewed_By || ""),
+    reviewedAt: String(row.Reviewed_At || ""),
+    reviewNote: String(row.Review_Note || ""),
+    lockedBy: String(row.Locked_By || ""),
+    lockedAt: String(row.Locked_At || ""),
+    sortOrder: Number(row.Sort_Order) || 0,
+    action: String(row.Action || CONTENT_ACTIONS.UPSERT)
+  };
+}
+
+// Itens publicados de um módulo - o que a tela mostra como "no ar".
+function listContentItems(module) {
+  assertContentRole_('read', module);
+  assertValidModule_(module);
+
+  return readContentRows_(SHEET_CONTENT_ITEMS)
+    .filter(function (r) {
+      return String(r.Module).trim() === module && String(r.Status).trim() === CONTENT_STATUS.LIVE;
+    })
+    .map(mapItemRow_)
+    .sort(function (a, b) { return a.sortOrder - b.sortOrder; });
+}
+
+// Todas as versões de um item (a linhagem), da mais nova para a mais antiga.
+// Reverter não precisa de rota especial: é reaprovar uma versão que já existe.
+function listContentItemHistory(lineage, module) {
+  assertContentRole_('read', module);
+  const target = String(lineage || "").trim();
+
+  return readContentRows_(SHEET_CONTENT_ITEMS)
+    .filter(function (r) { return String(r.Lineage || r.ID) === target; })
+    .map(mapItemRow_)
+    .sort(function (a, b) { return b.version - a.version; });
+}
+
+function listContentDrafts(module) {
+  const session = assertContentRole_('read', module);
+  const drafts = readContentRows_(SHEET_CONTENT_DRAFTS)
+    .filter(function (r) {
+      const st = String(r.Status).trim();
+      return String(r.Module).trim() === module &&
+        (st === CONTENT_STATUS.DRAFT || st === CONTENT_STATUS.PENDING);
+    })
+    .map(mapDraftRow_);
+
+  // Quem não aprova só enxerga os próprios rascunhos; pendências alheias não
+  // são assunto seu e poluiriam a fila.
+  if (!session.perms.approve) {
+    return drafts.filter(function (d) { return d.proposedBy === session.ldap; });
+  }
+
+  return drafts;
+}
+
+// Fila de revisão: tudo que está pendente, de todos os módulos.
+function listPendingApprovals() {
+  const session = assertContentRole_('approve', null);
+
+  return readContentRows_(SHEET_CONTENT_DRAFTS)
+    .filter(function (r) { return String(r.Status).trim() === CONTENT_STATUS.PENDING; })
+    .map(mapDraftRow_)
+    .map(function (d) {
+      // O aprovador precisa ver o valor atual ao lado do proposto - sem isso a
+      // revisão vira "confie no texto novo", que é exatamente o que o fluxo
+      // de aprovação existe pra evitar.
+      const current = d.itemId ? findContentRow_(SHEET_CONTENT_ITEMS, 'ID', d.itemId) : null;
+      d.currentValue = current ? String(current.Value || "") : "";
+      d.currentLabel = current ? String(current.Label || "") : "";
+      d.isNew = !d.itemId;
+      d.isSelfProposed = (d.proposedBy === session.ldap);
+      d.canReview = session.perms.selfApprove || !d.isSelfProposed;
+      return d;
+    })
+    .sort(function (a, b) { return String(a.proposedAt).localeCompare(String(b.proposedAt)); });
+}
+
+// =========================================================
+//  ESCRITA (rascunho -> pendente -> aprovado)
+// =========================================================
+
+function isLockHeldByOther_(draftRow, ldap) {
+  const lockedBy = String(draftRow.Locked_By || "").trim();
+  if (!lockedBy || lockedBy === ldap) return false;
+
+  const lockedAt = new Date(draftRow.Locked_At);
+  if (isNaN(lockedAt.getTime())) return false;
+
+  return (new Date().getTime() - lockedAt.getTime()) < CONTENT_LOCK_TTL_MS;
+}
+
+/**
+ * Cria ou atualiza um rascunho. Nunca toca em Content_Items - é o que garante
+ * que editar aqui não altera nada em produção.
+ *
+ * payload: { draftId?, itemId?, module, key, field?, lang, label, value, sortOrder? }
+ */
+function saveContentDraft(payload) {
+  const p = payload || {};
+  const session = assertContentRole_('propose', p.module);
+  assertValidModule_(p.module);
+
+  if (CONTENT_LANGS.indexOf(p.lang || 'ALL') === -1) {
+    throw new Error("Idioma inválido: " + p.lang);
+  }
+  if (!String(p.label || "").trim()) {
+    throw new Error("Dê um título ao item antes de salvar.");
+  }
+
+  const sheet = getContentSheet_(SHEET_CONTENT_DRAFTS);
+  const now = contentNow_();
+
+  if (p.draftId) {
+    const existing = findContentRow_(SHEET_CONTENT_DRAFTS, 'Draft_ID', p.draftId);
+    if (!existing) throw new Error("Rascunho não encontrado: " + p.draftId);
+
+    if (String(existing.Status).trim() === CONTENT_STATUS.PENDING) {
+      throw new Error("Este item já está em revisão. Cancele o envio antes de editar.");
+    }
+    if (existing.Proposed_By !== session.ldap && !session.perms.approve) {
+      throw new Error("Este rascunho é de outra pessoa.");
+    }
+    if (isLockHeldByOther_(existing, session.ldap)) {
+      throw new Error("Alguém está editando este item agora (" + existing.Locked_By + "). Tente em alguns minutos.");
+    }
+
+    const row = existing._row;
+    sheet.getRange(row, 5).setValue(p.field || "");
+    sheet.getRange(row, 6).setValue(p.lang || 'ALL');
+    sheet.getRange(row, 7).setValue(p.label || "");
+    sheet.getRange(row, 8).setValue(p.value || "");
+    sheet.getRange(row, 9).setValue(CONTENT_STATUS.DRAFT);
+    sheet.getRange(row, 15).setValue(session.ldap);
+    sheet.getRange(row, 16).setValue(now);
+
+    logContentEvent_(session.ldap, 'draft_update', p.module + '/' + p.key, p.draftId);
+    return { status: 'success', draftId: p.draftId };
+  }
+
+  const draftId = newContentId_('drf');
+  sheet.appendRow([
+    draftId,
+    p.itemId || "",
+    p.module,
+    p.key || "",
+    p.field || "",
+    p.lang || 'ALL',
+    p.label || "",
+    p.value || "",
+    CONTENT_STATUS.DRAFT,
+    session.ldap,
+    now,
+    "", "", "",
+    session.ldap,
+    now,
+    Number(p.sortOrder) || 0,
+    CONTENT_ACTIONS.UPSERT
+  ]);
+
+  logContentEvent_(session.ldap, 'draft_create', p.module + '/' + (p.key || 'novo'), draftId);
+  return { status: 'success', draftId: draftId };
+}
+
+// Manda o rascunho para a fila de revisão.
+function submitContentDraft(draftId) {
+  const existing = findContentRow_(SHEET_CONTENT_DRAFTS, 'Draft_ID', draftId);
+  if (!existing) throw new Error("Rascunho não encontrado.");
+
+  const session = assertContentRole_('propose', String(existing.Module).trim());
+
+  if (existing.Proposed_By !== session.ldap && !session.perms.approve) {
+    throw new Error("Este rascunho é de outra pessoa.");
+  }
+  if (String(existing.Status).trim() !== CONTENT_STATUS.DRAFT) {
+    throw new Error("Só um rascunho pode ser enviado para revisão.");
+  }
+
+  const sheet = getContentSheet_(SHEET_CONTENT_DRAFTS);
+  sheet.getRange(existing._row, 9).setValue(CONTENT_STATUS.PENDING);
+  sheet.getRange(existing._row, 11).setValue(contentNow_());
+  // Solta a trava: em revisão ninguém mais edita mesmo.
+  sheet.getRange(existing._row, 15).setValue("");
+  sheet.getRange(existing._row, 16).setValue("");
+
+  logContentEvent_(session.ldap, 'draft_submit', String(existing.Module) + '/' + String(existing.Key), draftId);
+  notifyApprovers_(existing, session.ldap);
+
+  return { status: 'success' };
+}
+
+// Avisa quem pode aprovar. Sem isso, "pendente" pode ficar parado indefinidamente
+// sem ninguém perceber - o fluxo de aprovação vira um limbo em vez de um portão.
+function notifyApprovers_(draftRow, proposedBy) {
+  try {
+    const approvers = readContentRows_(SHEET_CONTENT_ACCESS)
+      .filter(function (r) {
+        const role = String(r.Role || "").toUpperCase().trim();
+        const active = String(r.Active).toUpperCase().trim();
+        return CONTENT_ROLES[role] && CONTENT_ROLES[role].approve && (active === 'TRUE' || active === '1');
+      })
+      .map(function (r) { return String(r.LDAP).trim() + "@google.com"; })
+      .filter(function (mail) { return mail.indexOf(proposedBy + "@") !== 0; });
+
+    if (!approvers.length) return;
+
+    MailApp.sendEmail({
+      to: approvers.join(","),
+      subject: "📝 Central de Conteúdo: proposta aguardando revisão",
+      htmlBody: "<p><strong>" + proposedBy + "</strong> propôs uma alteração em <strong>" +
+        String(draftRow.Module) + "</strong> (" + String(draftRow.Label) + ").</p>" +
+        "<p>Abra a Central de Conteúdo para revisar e aprovar.</p>",
+      name: "Cases Wizard"
+    });
+  } catch (e) {
+    // Falha de e-mail não pode impedir o envio para revisão.
+  }
+}
+
+/**
+ * Aprova uma proposta: arquiva a versão live anterior e publica a nova.
+ * É o único caminho pelo qual algo chega a Content_Items com status 'live'.
+ */
+function approveContentDraft(draftId, note) {
+  const draft = findContentRow_(SHEET_CONTENT_DRAFTS, 'Draft_ID', draftId);
+  if (!draft) throw new Error("Proposta não encontrada.");
+
+  const session = assertContentRole_('approve', String(draft.Module).trim());
+
+  if (String(draft.Status).trim() !== CONTENT_STATUS.PENDING) {
+    throw new Error("Só propostas pendentes podem ser aprovadas.");
+  }
+
+  // A regra de não-autoaprovação, com a exceção explícita do ADMIN.
+  if (String(draft.Proposed_By).trim() === session.ldap && !session.perms.selfApprove) {
+    throw new Error("Você não pode aprovar a própria proposta. Peça a revisão de outra pessoa.");
+  }
+
+  const itemsSheet = getContentSheet_(SHEET_CONTENT_ITEMS);
+  const now = contentNow_();
+  const action = String(draft.Action || CONTENT_ACTIONS.UPSERT);
+  let version = 1;
+  let newItemId = "";
+  let lineage = "";
+
+  // Arquiva a versão no ar (não apaga): reverter depois é reaprovar esta linha.
+  if (draft.Item_ID) {
+    const current = findContentRow_(SHEET_CONTENT_ITEMS, 'ID', draft.Item_ID);
+    if (current) {
+      version = (Number(current.Version) || 1) + 1;
+      lineage = String(current.Lineage || current.ID);
+      itemsSheet.getRange(current._row, 9).setValue(CONTENT_STATUS.ARCHIVED);
+    }
+  }
+
+  // Numa remoção o trabalho termina aqui: arquivar já tira do ar, porque a
+  // leitura pública só enxerga 'live'. Publicar uma linha nova de valor vazio
+  // deixaria um item fantasma na lista do agente.
+  if (action !== CONTENT_ACTIONS.REMOVE) {
+    newItemId = newContentId_('itm');
+    itemsSheet.appendRow([
+      newItemId,
+      String(draft.Module),
+      String(draft.Key),
+      String(draft.Field || ""),
+      String(draft.Lang || 'ALL'),
+      String(draft.Label || ""),
+      String(draft.Value || ""),
+      version,
+      CONTENT_STATUS.LIVE,
+      session.ldap,
+      now,
+      Number(draft.Sort_Order) || 0,
+      // Item novo inaugura a própria linhagem; edição herda a de quem substitui.
+      lineage || newItemId
+    ]);
+  }
+
+  const draftsSheet = getContentSheet_(SHEET_CONTENT_DRAFTS);
+  draftsSheet.getRange(draft._row, 9).setValue(CONTENT_STATUS.APPROVED);
+  draftsSheet.getRange(draft._row, 12).setValue(session.ldap);
+  draftsSheet.getRange(draft._row, 13).setValue(now);
+  draftsSheet.getRange(draft._row, 14).setValue(note || "");
+
+  const selfFlag = (String(draft.Proposed_By).trim() === session.ldap) ? ' (autoaprovação ADMIN)' : '';
+  logContentEvent_(
+    session.ldap,
+    action === CONTENT_ACTIONS.REMOVE ? 'approve_removal' : 'approve',
+    String(draft.Module) + '/' + String(draft.Key) + selfFlag,
+    'v' + version + ' por ' + String(draft.Proposed_By)
+  );
+
+  return { status: 'success', itemId: newItemId, version: version, action: action };
+}
+
+function rejectContentDraft(draftId, note) {
+  const draft = findContentRow_(SHEET_CONTENT_DRAFTS, 'Draft_ID', draftId);
+  if (!draft) throw new Error("Proposta não encontrada.");
+
+  const session = assertContentRole_('approve', String(draft.Module).trim());
+
+  if (String(draft.Status).trim() !== CONTENT_STATUS.PENDING) {
+    throw new Error("Só propostas pendentes podem ser rejeitadas.");
+  }
+  if (!String(note || "").trim()) {
+    throw new Error("Explique o motivo da rejeição para quem propôs.");
+  }
+
+  const sheet = getContentSheet_(SHEET_CONTENT_DRAFTS);
+  // Volta para 'draft', não some: quem propôs corrige e reenvia sem redigitar.
+  sheet.getRange(draft._row, 9).setValue(CONTENT_STATUS.DRAFT);
+  sheet.getRange(draft._row, 12).setValue(session.ldap);
+  sheet.getRange(draft._row, 13).setValue(contentNow_());
+  sheet.getRange(draft._row, 14).setValue(note);
+
+  logContentEvent_(session.ldap, 'reject', String(draft.Module) + '/' + String(draft.Key), note);
+  return { status: 'success' };
+}
+
+/**
+ * Kill switch: republica uma versão arquivada sem passar pela fila de revisão.
+ * Fora do fluxo normal de propósito - existe para resposta a incidente, quando
+ * algo ruim passou e o custo de esperar uma segunda revisão é alto demais.
+ */
+function rollbackContentItem(archivedItemId) {
+  const archived = findContentRow_(SHEET_CONTENT_ITEMS, 'ID', archivedItemId);
+  if (!archived) throw new Error("Versão não encontrada.");
+
+  const session = assertContentRole_('approve', String(archived.Module).trim());
+  const sheet = getContentSheet_(SHEET_CONTENT_ITEMS);
+  const now = contentNow_();
+  const lineage = String(archived.Lineage || archived.ID);
+
+  // Arquiva só o que estiver no ar para ESTA linhagem. Filtrar por Key aqui
+  // derrubaria a categoria inteira quando o módulo usa Key como agrupador.
+  readContentRows_(SHEET_CONTENT_ITEMS).forEach(function (r) {
+    if (String(r.Lineage || r.ID) === lineage && String(r.Status).trim() === CONTENT_STATUS.LIVE) {
+      sheet.getRange(r._row, 9).setValue(CONTENT_STATUS.ARCHIVED);
+    }
+  });
+
+  const maxVersion = readContentRows_(SHEET_CONTENT_ITEMS)
+    .filter(function (r) { return String(r.Lineage || r.ID) === lineage; })
+    .reduce(function (acc, r) { return Math.max(acc, Number(r.Version) || 1); }, 1);
+
+  const newItemId = newContentId_('itm');
+  sheet.appendRow([
+    newItemId,
+    String(archived.Module),
+    String(archived.Key),
+    String(archived.Field || ""),
+    String(archived.Lang || 'ALL'),
+    String(archived.Label || ""),
+    String(archived.Value || ""),
+    maxVersion + 1,
+    CONTENT_STATUS.LIVE,
+    session.ldap,
+    now,
+    Number(archived.Sort_Order) || 0,
+    lineage
+  ]);
+
+  logContentEvent_(
+    session.ldap,
+    'rollback',
+    String(archived.Module) + '/' + String(archived.Key),
+    'restaurou v' + (Number(archived.Version) || 1)
+  );
+
+  return { status: 'success', itemId: newItemId };
+}
+
+// Arquiva o item no ar (a tela chama isso de "tirar do ar"). Passa pela fila
+// como qualquer mudança: cria um rascunho de remoção em vez de apagar direto.
+function requestContentRemoval(itemId, reason) {
+  const item = findContentRow_(SHEET_CONTENT_ITEMS, 'ID', itemId);
+  if (!item) throw new Error("Item não encontrado.");
+
+  const session = assertContentRole_('propose', String(item.Module).trim());
+  const sheet = getContentSheet_(SHEET_CONTENT_DRAFTS);
+  const now = contentNow_();
+  const draftId = newContentId_('drf');
+
+  sheet.appendRow([
+    draftId,
+    itemId,
+    String(item.Module),
+    String(item.Key),
+    String(item.Field || ""),
+    String(item.Lang || 'ALL'),
+    "[REMOVER] " + String(item.Label || ""),
+    "",
+    CONTENT_STATUS.PENDING,
+    session.ldap,
+    now,
+    "", "",
+    reason || "",
+    "", "",
+    Number(item.Sort_Order) || 0,
+    CONTENT_ACTIONS.REMOVE
+  ]);
+
+  logContentEvent_(session.ldap, 'removal_request', String(item.Module) + '/' + String(item.Key), reason || "");
+  return { status: 'success', draftId: draftId };
+}
+
+// =========================================================
+//  GERENCIAR ACESSOS (só ADMIN)
+// =========================================================
+
+function listContentAccess() {
+  assertContentRole_('manageAccess', null);
+
+  return readContentRows_(SHEET_CONTENT_ACCESS).map(function (r) {
+    return {
+      ldap: String(r.LDAP || ""),
+      role: String(r.Role || "").toUpperCase(),
+      active: String(r.Active).toUpperCase() === 'TRUE' || String(r.Active) === '1',
+      grantedBy: String(r.Granted_By || ""),
+      grantedAt: String(r.Granted_At || "")
+    };
+  });
+}
+
+function saveContentAccess(ldap, role, active) {
+  const session = assertContentRole_('manageAccess', null);
+  const targetLdap = String(ldap || "").toLowerCase().trim().split('@')[0];
+  const targetRole = String(role || "").toUpperCase().trim();
+
+  if (!targetLdap) throw new Error("Informe o LDAP da pessoa.");
+  if (!CONTENT_ROLES[targetRole]) throw new Error("Papel inválido: " + role);
+
+  // Trava de pé-na-porta: o ADMIN não pode remover a si mesmo e deixar a
+  // Central sem ninguém que consiga conceder acesso de volta.
+  if (targetLdap === session.ldap && active === false) {
+    throw new Error("Você não pode remover o próprio acesso de ADMIN.");
+  }
+
+  const sheet = getContentSheet_(SHEET_CONTENT_ACCESS);
+  const existing = findContentRow_(SHEET_CONTENT_ACCESS, 'LDAP', targetLdap);
+  const isActive = (active !== false);
+
+  if (existing) {
+    sheet.getRange(existing._row, 2).setValue(targetRole);
+    sheet.getRange(existing._row, 3).setValue(isActive);
+    sheet.getRange(existing._row, 4).setValue(session.ldap);
+    sheet.getRange(existing._row, 5).setValue(contentNow_());
+  } else {
+    sheet.appendRow([targetLdap, targetRole, isActive, session.ldap, contentNow_()]);
+  }
+
+  logContentEvent_(session.ldap, 'access_change', targetLdap, targetRole + (isActive ? ' ativo' : ' inativo'));
+  return { status: 'success' };
+}
+
+// =========================================================
+//  LEITURA PÚBLICA (consumida pelo bookmarklet via JSONP)
+// =========================================================
+
+// Único ponto de leitura aberto ao app do agente. Devolve apenas 'live' - e não
+// aceita nenhum parâmetro de status, para não existir sequer a possibilidade de
+// alguém pedir o conteúdo pendente pela URL.
+function handleContentPublicRead(p) {
+  const module = String((p && p.module) || "").trim();
+  assertValidModule_(module);
+
+  const items = readContentRows_(SHEET_CONTENT_ITEMS)
+    .filter(function (r) {
+      return String(r.Module).trim() === module && String(r.Status).trim() === CONTENT_STATUS.LIVE;
+    })
+    .map(mapItemRow_)
+    .sort(function (a, b) { return a.sortOrder - b.sortOrder; });
+
+  return { status: 'success', module: module, items: items };
+}
+
+// =========================================================
+//  SEMEADURA (Fase 1: migra o LINKS_DB hardcoded para a planilha)
+// =========================================================
+
+/**
+ * Publica direto em Content_Items, sem passar pela fila. É migração de conteúdo
+ * que já está em produção hoje (o LINKS_DB do bundle), não mudança nova - por
+ * isso não há o que revisar. Roda uma vez; chamadas seguintes não duplicam.
+ *
+ * payload: JSON string { module, items: [{ key, field?, lang?, label, value, sortOrder? }] }
+ */
+function seedContentModule(payloadJson) {
+  const session = assertContentRole_('approve', null);
+  const payload = (typeof payloadJson === 'string') ? JSON.parse(payloadJson) : payloadJson;
+  const module = String(payload.module || "").trim();
+
+  assertValidModule_(module);
+  assertContentRole_('propose', module);
+
+  const existing = readContentRows_(SHEET_CONTENT_ITEMS).filter(function (r) {
+    return String(r.Module).trim() === module && String(r.Status).trim() === CONTENT_STATUS.LIVE;
+  });
+
+  if (existing.length) {
+    return { status: 'skipped', reason: 'Módulo já semeado (' + existing.length + ' itens no ar).' };
+  }
+
+  const sheet = getContentSheet_(SHEET_CONTENT_ITEMS);
+  const now = contentNow_();
+  const rows = (payload.items || []).map(function (it, idx) {
+    const id = newContentId_('itm');
+    return [
+      id,
+      module,
+      String(it.key || ""),
+      String(it.field || ""),
+      String(it.lang || 'ALL'),
+      String(it.label || ""),
+      String(it.value || ""),
+      1,
+      CONTENT_STATUS.LIVE,
+      session.ldap,
+      now,
+      Number(it.sortOrder) || idx,
+      id // Cada item semeado inaugura a própria linhagem.
+    ];
+  });
+
+  if (rows.length) {
+    sheet.getRange(sheet.getLastRow() + 1, 1, rows.length, CONTENT_ITEMS_HEADERS.length).setValues(rows);
+  }
+
+  logContentEvent_(session.ldap, 'seed', module, rows.length + ' itens');
+  return { status: 'success', seeded: rows.length };
+}

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -1,0 +1,1275 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Central de Conteúdo - Powered by Cases Wizard</title>
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+        rel="stylesheet" />
+    <style>
+        /* Tokens copiados do TLDashboard.html de propósito, não importados dele:
+           lá o CSS é inline num arquivo de ~2000 linhas, e extrair um parcial
+           compartilhado sem regressão custaria mais agora do que a duplicação.
+           A origem é a mesma, então a identidade visual não diverge. */
+        :root {
+            --bg-base: #F1F3F4;
+            --surface-level-1: #FFFFFF;
+            --surface-level-2: #F8F9FA;
+            --surface-level-3: #E8EAED;
+            --border-subtle: #DADCE0;
+
+            --text-primary: #202124;
+            --text-secondary: #5F6368;
+            --text-tertiary: #5F6368;
+
+            --gemini-blue: #1A73E8;
+            --gemini-blue-light: #E8F0FE;
+            --gemini-purple: #9B72CB;
+            --gemini-gradient: linear-gradient(90deg, #4285f4, #9b72cb, #d96570);
+
+            --success: #1E8E3E;
+            --success-light: #E6F4EA;
+            --danger: #D93025;
+            --danger-light: #FCE8E6;
+            --warning: #F9AB00;
+            --warning-light: #FEF7E0;
+            --warning-text: #B06000;
+
+            --radius-sm: 8px;
+            --radius-md: 16px;
+            --radius-lg: 24px;
+            --radius-pill: 100px;
+
+            --nav-bg: #3D3D3D;
+            --nav-surface: #333333;
+            --nav-border: rgba(255, 255, 255, 0.15);
+            --nav-text-primary: #E3E3E3;
+            --nav-text-secondary: #9AA0A6;
+
+            --spring-expressive: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            --spring-functional: cubic-bezier(0.2, 0, 0, 1);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Google Sans', system-ui, sans-serif;
+            background-color: var(--bg-base);
+            margin: 0;
+            color: var(--text-primary);
+            -webkit-font-smoothing: antialiased;
+            overflow-x: hidden;
+        }
+
+        .ambient-glow {
+            position: fixed;
+            top: -20vh;
+            left: 10vw;
+            width: 80vw;
+            height: 50vh;
+            background: radial-gradient(ellipse at center, rgba(66, 133, 244, 0.06) 0%, rgba(241, 243, 244, 0) 70%);
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        /* --- Top nav --- */
+        .topnav {
+            background: rgba(61, 61, 61, 0.95);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            padding: 0 32px;
+            height: 72px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            border-bottom: 1px solid var(--nav-border);
+            background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.05), transparent);
+        }
+
+        .topnav::after {
+            content: '';
+            position: absolute;
+            bottom: -1px;
+            left: 0;
+            width: 100%;
+            height: 1px;
+            background: var(--gemini-gradient);
+            opacity: 0.7;
+        }
+
+        .brand-main {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 20px;
+            font-weight: 500;
+            letter-spacing: -0.5px;
+            color: var(--nav-text-primary);
+        }
+
+        .user-chip {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--nav-text-secondary);
+            font-size: 13px;
+        }
+
+        .role-badge {
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid var(--nav-border);
+            color: var(--nav-text-primary);
+            padding: 4px 12px;
+            border-radius: var(--radius-pill);
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.6px;
+        }
+
+        /* --- Layout --- */
+        .wrap {
+            max-width: 1180px;
+            margin: 0 auto;
+            padding: 32px;
+        }
+
+        .page-head {
+            margin-bottom: 24px;
+        }
+
+        .page-head h1 {
+            font-size: 28px;
+            font-weight: 500;
+            margin: 0 0 6px;
+            letter-spacing: -0.5px;
+        }
+
+        .page-head p {
+            margin: 0;
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* --- Tabs --- */
+        .tab-section {
+            display: flex;
+            gap: 8px;
+            border-bottom: 1px solid var(--border-subtle);
+            margin-bottom: 24px;
+            flex-wrap: wrap;
+        }
+
+        .tab-btn {
+            background: transparent;
+            border: none;
+            border-bottom: 2px solid transparent;
+            padding: 12px 18px;
+            font-family: inherit;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            transition: color .2s var(--spring-functional), border-color .2s var(--spring-functional);
+        }
+
+        .tab-btn:hover {
+            color: var(--text-primary);
+        }
+
+        .tab-btn.active {
+            color: var(--gemini-blue);
+            border-bottom-color: var(--gemini-blue);
+        }
+
+        .tab-btn:focus-visible {
+            outline: 2px solid var(--gemini-blue);
+            outline-offset: 2px;
+            border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+        }
+
+        .count-chip {
+            background: var(--danger);
+            color: #fff;
+            border-radius: var(--radius-pill);
+            font-size: 11px;
+            font-weight: 700;
+            padding: 1px 7px;
+            min-width: 18px;
+            text-align: center;
+        }
+
+        .count-chip.zero {
+            display: none;
+        }
+
+        /* --- Cards --- */
+        .card {
+            background: var(--surface-level-1);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-md);
+            padding: 20px 24px;
+            margin-bottom: 16px;
+        }
+
+        .card-title {
+            font-size: 15px;
+            font-weight: 500;
+            margin: 0 0 4px;
+        }
+
+        .card-sub {
+            font-size: 13px;
+            color: var(--text-secondary);
+            margin: 0;
+        }
+
+        .row-between {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        /* --- Buttons --- */
+        .btn {
+            font-family: inherit;
+            font-size: 14px;
+            font-weight: 500;
+            border-radius: var(--radius-pill);
+            padding: 9px 20px;
+            border: 1px solid transparent;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            transition: background .2s var(--spring-functional), box-shadow .2s var(--spring-functional);
+        }
+
+        .btn:focus-visible {
+            outline: 2px solid var(--gemini-blue);
+            outline-offset: 2px;
+        }
+
+        .btn-primary {
+            background: var(--gemini-blue);
+            color: #fff;
+        }
+
+        .btn-primary:hover {
+            box-shadow: 0 1px 6px rgba(26, 115, 232, .45);
+        }
+
+        .btn-ghost {
+            background: transparent;
+            color: var(--gemini-blue);
+            border-color: var(--border-subtle);
+        }
+
+        .btn-ghost:hover {
+            background: var(--gemini-blue-light);
+        }
+
+        .btn-danger {
+            background: transparent;
+            color: var(--danger);
+            border-color: var(--danger-light);
+        }
+
+        .btn-danger:hover {
+            background: var(--danger-light);
+        }
+
+        .btn-success {
+            background: var(--success);
+            color: #fff;
+        }
+
+        .btn:disabled {
+            opacity: .45;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        .btn-sm {
+            font-size: 13px;
+            padding: 6px 14px;
+        }
+
+        /* --- Forms --- */
+        label.fld {
+            display: block;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            margin: 14px 0 5px;
+        }
+
+        input[type=text],
+        input[type=url],
+        select,
+        textarea {
+            width: 100%;
+            font-family: inherit;
+            font-size: 14px;
+            color: var(--text-primary);
+            background: var(--surface-level-2);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            padding: 10px 12px;
+        }
+
+        input:focus,
+        select:focus,
+        textarea:focus {
+            outline: 2px solid var(--gemini-blue);
+            outline-offset: -1px;
+            background: var(--surface-level-1);
+        }
+
+        textarea {
+            min-height: 90px;
+            resize: vertical;
+        }
+
+        .grid-2 {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0 16px;
+        }
+
+        @media (max-width: 700px) {
+            .grid-2 {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        /* --- Status pills --- */
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: .4px;
+            padding: 3px 10px;
+            border-radius: var(--radius-pill);
+            text-transform: uppercase;
+        }
+
+        .pill.live {
+            background: var(--success-light);
+            color: var(--success);
+        }
+
+        .pill.draft {
+            background: var(--surface-level-3);
+            color: var(--text-secondary);
+        }
+
+        .pill.pending {
+            background: var(--warning-light);
+            color: var(--warning-text);
+        }
+
+        .pill.archived {
+            background: var(--danger-light);
+            color: var(--danger);
+        }
+
+        /* --- Diff --- */
+        .diff {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+            margin: 14px 0;
+        }
+
+        @media (max-width: 700px) {
+            .diff {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .diff-side {
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            padding: 12px 14px;
+            background: var(--surface-level-2);
+            overflow-x: auto;
+        }
+
+        .diff-side.new {
+            border-color: var(--success);
+            background: var(--success-light);
+        }
+
+        .diff-label {
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: .5px;
+            text-transform: uppercase;
+            color: var(--text-secondary);
+            margin-bottom: 6px;
+        }
+
+        .diff-side.new .diff-label {
+            color: var(--success);
+        }
+
+        .diff-body {
+            font-size: 13px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-family: 'Roboto Mono', ui-monospace, monospace;
+        }
+
+        /* --- Item list --- */
+        .item-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 0;
+            border-bottom: 1px solid var(--border-subtle);
+            flex-wrap: wrap;
+        }
+
+        .item-row:last-child {
+            border-bottom: none;
+        }
+
+        .item-main {
+            min-width: 0;
+            flex: 1;
+        }
+
+        .item-name {
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        .item-meta {
+            font-size: 12px;
+            color: var(--text-secondary);
+            word-break: break-all;
+        }
+
+        .cat-head {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin: 26px 0 4px;
+            font-size: 13px;
+            font-weight: 700;
+            letter-spacing: .6px;
+            text-transform: uppercase;
+            color: var(--text-secondary);
+        }
+
+        .cat-head:first-of-type {
+            margin-top: 6px;
+        }
+
+        /* --- States --- */
+        .state {
+            text-align: center;
+            padding: 64px 24px;
+            color: var(--text-secondary);
+        }
+
+        .state .material-symbols-rounded {
+            font-size: 44px;
+            color: var(--border-subtle);
+            display: block;
+            margin: 0 auto 12px;
+        }
+
+        .state h2 {
+            font-size: 18px;
+            font-weight: 500;
+            color: var(--text-primary);
+            margin: 0 0 6px;
+        }
+
+        .state p {
+            margin: 0 auto;
+            max-width: 44ch;
+            font-size: 14px;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        /* --- Toast --- */
+        #toast {
+            position: fixed;
+            bottom: 28px;
+            left: 50%;
+            transform: translate(-50%, 20px);
+            background: #202124;
+            color: #fff;
+            padding: 12px 22px;
+            border-radius: var(--radius-pill);
+            font-size: 14px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity .25s var(--spring-functional), transform .25s var(--spring-functional);
+            z-index: 999;
+            max-width: 90vw;
+            text-align: center;
+        }
+
+        #toast.show {
+            opacity: 1;
+            transform: translate(-50%, 0);
+        }
+
+        #toast.err {
+            background: var(--danger);
+        }
+
+        /* --- Modal --- */
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(32, 33, 36, .5);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 200;
+            padding: 24px;
+        }
+
+        .modal {
+            background: var(--surface-level-1);
+            border-radius: var(--radius-lg);
+            padding: 28px;
+            width: 100%;
+            max-width: 560px;
+            max-height: 88vh;
+            overflow-y: auto;
+        }
+
+        .modal h2 {
+            font-size: 20px;
+            font-weight: 500;
+            margin: 0 0 4px;
+        }
+
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 24px;
+        }
+
+        .skeleton {
+            height: 58px;
+            border-radius: var(--radius-sm);
+            background: linear-gradient(90deg, var(--surface-level-2) 25%, var(--surface-level-3) 50%, var(--surface-level-2) 75%);
+            background-size: 200% 100%;
+            animation: shimmer 1.4s infinite;
+            margin-bottom: 10px;
+        }
+
+        @keyframes shimmer {
+            to {
+                background-position: -200% 0;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+
+            *,
+            *::before,
+            *::after {
+                animation-duration: .01ms !important;
+                transition-duration: .01ms !important;
+            }
+        }
+
+        .note {
+            background: var(--gemini-blue-light);
+            border-left: 3px solid var(--gemini-blue);
+            border-radius: var(--radius-sm);
+            padding: 12px 16px;
+            font-size: 13px;
+            color: var(--text-primary);
+            margin-bottom: 18px;
+        }
+
+        .note.warn {
+            background: var(--warning-light);
+            border-left-color: var(--warning);
+        }
+    </style>
+</head>
+
+<body>
+    <div class="ambient-glow"></div>
+
+    <nav class="topnav">
+        <div class="brand-main">
+            <span class="material-symbols-rounded">tune</span>
+            Central de Conteúdo
+        </div>
+        <div class="user-chip">
+            <span id="user-ldap"></span>
+            <span class="role-badge hidden" id="user-role"></span>
+        </div>
+    </nav>
+
+    <div class="wrap">
+        <!-- Estado de carregamento inicial -->
+        <div id="boot-state" class="state">
+            <span class="material-symbols-rounded">hourglass_top</span>
+            <h2>Verificando seu acesso…</h2>
+            <p>Só um instante.</p>
+        </div>
+
+        <!-- Sem permissão -->
+        <div id="denied-state" class="state hidden">
+            <span class="material-symbols-rounded">lock</span>
+            <h2>Você não tem acesso à Central de Conteúdo</h2>
+            <p>Peça a um ADMIN para liberar seu LDAP. Enquanto isso, nada aqui fica visível.</p>
+        </div>
+
+        <!-- App -->
+        <main id="app" class="hidden">
+            <div class="page-head">
+                <h1>Gerenciar conteúdo</h1>
+                <p>Toda alteração vira um rascunho e só chega ao app depois de aprovada.</p>
+            </div>
+
+            <div class="tab-section" role="tablist">
+                <button class="tab-btn active" role="tab" data-tab="links" onclick="switchTab('links')">
+                    <span class="material-symbols-rounded" style="font-size:19px">link</span> Links
+                </button>
+                <button class="tab-btn" role="tab" data-tab="approvals" onclick="switchTab('approvals')">
+                    <span class="material-symbols-rounded" style="font-size:19px">rule</span> Aprovações
+                    <span class="count-chip zero" id="pending-count">0</span>
+                </button>
+                <button class="tab-btn hidden" role="tab" data-tab="access" onclick="switchTab('access')" id="tab-access">
+                    <span class="material-symbols-rounded" style="font-size:19px">manage_accounts</span> Acessos
+                </button>
+                <button class="tab-btn" role="tab" data-tab="soon" onclick="switchTab('soon')">
+                    <span class="material-symbols-rounded" style="font-size:19px">schedule</span> Próximos módulos
+                </button>
+            </div>
+
+            <!-- TAB: Links -->
+            <section id="pane-links">
+                <div class="note" id="links-note">
+                    Editar aqui não altera o app. A mudança entra como proposta e vai para a aba
+                    <strong>Aprovações</strong>.
+                </div>
+                <div class="row-between" style="margin-bottom:8px">
+                    <div>
+                        <div class="card-title">Links no ar</div>
+                        <p class="card-sub" id="links-summary">Carregando…</p>
+                    </div>
+                    <button class="btn btn-primary" id="links-new-btn" onclick="openLinkEditor(null)">
+                        <span class="material-symbols-rounded" style="font-size:19px">add</span> Novo link
+                    </button>
+                </div>
+                <div class="card" id="links-list">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+            </section>
+
+            <!-- TAB: Aprovações -->
+            <section id="pane-approvals" class="hidden">
+                <div id="approvals-list">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+            </section>
+
+            <!-- TAB: Acessos -->
+            <section id="pane-access" class="hidden">
+                <div class="note warn">
+                    Quem entra aqui passa a ver e propor conteúdo. Papéis <strong>ADMIN</strong> e
+                    <strong>TL</strong> também aprovam.
+                </div>
+                <div class="card">
+                    <div class="card-title">Conceder ou alterar acesso</div>
+                    <div class="grid-2">
+                        <div>
+                            <label class="fld" for="acc-ldap">LDAP</label>
+                            <input type="text" id="acc-ldap" placeholder="ex.: lucaste" autocomplete="off">
+                        </div>
+                        <div>
+                            <label class="fld" for="acc-role">Papel</label>
+                            <select id="acc-role">
+                                <option value="ADMIN">ADMIN — edita tudo, aprova, gerencia acessos</option>
+                                <option value="TL">TL — edita tudo e aprova</option>
+                                <option value="QA">QA — propõe call script e case notes</option>
+                                <option value="WFM">WFM — propõe links</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div style="margin-top:18px">
+                        <button class="btn btn-primary" onclick="saveAccess()">Salvar acesso</button>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-title" style="margin-bottom:8px">Pessoas com acesso</div>
+                    <div id="access-list"></div>
+                </div>
+            </section>
+
+            <!-- TAB: Próximos módulos -->
+            <section id="pane-soon" class="hidden">
+                <div class="card">
+                    <div class="card-title">Ainda não migrados</div>
+                    <p class="card-sub" style="margin-bottom:16px">
+                        A fundação (papéis, rascunho, aprovação, versionamento) já serve os quatro módulos —
+                        falta migrar o conteúdo de cada um para a planilha.
+                    </p>
+                    <div class="item-row">
+                        <div class="item-main">
+                            <div class="item-name">Call Script</div>
+                            <div class="item-meta">Roteiro por segmento e fluxo. Primeira edição prevista: preencher a
+                                seção de Implementação que falta em ES.</div>
+                        </div>
+                        <span class="pill draft">Fase 2</span>
+                    </div>
+                    <div class="item-row">
+                        <div class="item-main">
+                            <div class="item-name">Case Notes</div>
+                            <div class="item-meta">Trechos prontos por campo da nota, escolhidos a partir dos campos que
+                                já existem hoje.</div>
+                        </div>
+                        <span class="pill draft">Fase 3</span>
+                    </div>
+                    <div class="item-row">
+                        <div class="item-main">
+                            <div class="item-name">E-mails do assistente</div>
+                            <div class="item-meta">Editor ciente de placeholder e preview do HTML antes de publicar. Não
+                                inclui os e-mails de CR nem os enviados pelo Dashboard de TL.</div>
+                        </div>
+                        <span class="pill draft">Fase 4</span>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <div id="modal-root"></div>
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script>
+        var SESSION = null;
+        var LIVE_LINKS = [];
+        var MY_DRAFTS = [];
+
+        var CATEGORY_LABELS = {
+            tasks: 'Tarefas', ads: 'Ads', analytics: 'GA4', shopping: 'Shop',
+            tech: 'Tech', hr: 'RH', lm: 'Forms', qa: 'QA', suporte: 'Ajuda'
+        };
+
+        function toast(msg, isErr) {
+            var t = document.getElementById('toast');
+            t.textContent = msg;
+            t.className = isErr ? 'show err' : 'show';
+            setTimeout(function () { t.className = ''; }, isErr ? 5200 : 3200);
+        }
+
+        function esc(s) {
+            return String(s == null ? '' : s)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
+
+        // O valor de um link é JSON no campo `value`: assim name/url/desc/desc_es
+        // viajam como um item só e o par PT/ES fica junto do link que descreve,
+        // em vez de num mapa paralelo como o LINK_DESC_ES de hoje.
+        function parseLinkValue(raw) {
+            try {
+                var v = JSON.parse(raw || '{}');
+                return { name: v.name || '', url: v.url || '', desc: v.desc || '', desc_es: v.desc_es || '' };
+            } catch (e) {
+                return { name: '', url: '', desc: '', desc_es: '' };
+            }
+        }
+
+        // A UI é conveniência, não a fronteira: o servidor recusa a ação de
+        // qualquer jeito. Esconder o botão evita oferecer algo que vai falhar.
+        function canPropose(module) {
+            return !!(SESSION && SESSION.proposableModules &&
+                SESSION.proposableModules.indexOf(module) !== -1);
+        }
+
+        function switchTab(tab) {
+            ['links', 'approvals', 'access', 'soon'].forEach(function (t) {
+                var pane = document.getElementById('pane-' + t);
+                if (pane) pane.classList.toggle('hidden', t !== tab);
+            });
+            document.querySelectorAll('.tab-btn').forEach(function (b) {
+                b.classList.toggle('active', b.dataset.tab === tab);
+            });
+            if (tab === 'approvals') loadApprovals();
+            if (tab === 'access') loadAccess();
+        }
+
+        // --- Boot ---
+        function boot() {
+            google.script.run
+                .withSuccessHandler(function (s) {
+                    SESSION = s;
+                    document.getElementById('boot-state').classList.add('hidden');
+                    document.getElementById('user-ldap').textContent = s.ldap || '';
+
+                    if (!s.hasAccess) {
+                        document.getElementById('denied-state').classList.remove('hidden');
+                        return;
+                    }
+
+                    var badge = document.getElementById('user-role');
+                    badge.textContent = s.role;
+                    badge.classList.remove('hidden');
+
+                    document.getElementById('app').classList.remove('hidden');
+                    if (s.canManageAccess) document.getElementById('tab-access').classList.remove('hidden');
+
+                    if (!canPropose('links')) {
+                        document.getElementById('links-new-btn').classList.add('hidden');
+                        document.getElementById('links-note').textContent =
+                            'Seu papel (' + s.role + ') vê os links, mas não propõe alterações neste módulo.';
+                    }
+
+                    loadLinks();
+                    if (s.canApprove) loadPendingCount();
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('boot-state').classList.add('hidden');
+                    document.getElementById('denied-state').classList.remove('hidden');
+                    toast(err.message || 'Falha ao verificar acesso.', true);
+                })
+                .getContentSession();
+        }
+
+        // --- Links ---
+        function loadLinks() {
+            google.script.run
+                .withSuccessHandler(function (items) {
+                    LIVE_LINKS = items || [];
+                    google.script.run
+                        .withSuccessHandler(function (drafts) {
+                            MY_DRAFTS = drafts || [];
+                            renderLinks();
+                        })
+                        .withFailureHandler(function () { MY_DRAFTS = []; renderLinks(); })
+                        .listContentDrafts('links');
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('links-list').innerHTML =
+                        '<div class="state"><span class="material-symbols-rounded">error</span>' +
+                        '<h2>Não foi possível carregar os links</h2><p>' + esc(err.message) + '</p></div>';
+                })
+                .listContentItems('links');
+        }
+
+        function draftForItem(itemId) {
+            for (var i = 0; i < MY_DRAFTS.length; i++) {
+                if (MY_DRAFTS[i].itemId === itemId) return MY_DRAFTS[i];
+            }
+            return null;
+        }
+
+        function renderLinks() {
+            var host = document.getElementById('links-list');
+            var summary = document.getElementById('links-summary');
+
+            if (!LIVE_LINKS.length) {
+                summary.textContent = 'Nenhum link publicado ainda.';
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded">link_off</span>' +
+                    '<h2>Nenhum link na planilha ainda</h2>' +
+                    '<p>Enquanto isso o app segue usando a lista embutida no código. ' +
+                    'Rode a semeadura (seedContentModule) ou crie o primeiro link aqui.</p></div>';
+                return;
+            }
+
+            var byCat = {};
+            LIVE_LINKS.forEach(function (it) {
+                (byCat[it.key] = byCat[it.key] || []).push(it);
+            });
+
+            var pend = MY_DRAFTS.length;
+            summary.textContent = LIVE_LINKS.length + ' links publicados' +
+                (pend ? ' · ' + pend + ' com alteração em andamento' : '');
+
+            var html = '';
+            Object.keys(byCat).sort().forEach(function (cat) {
+                html += '<div class="cat-head">' + esc(CATEGORY_LABELS[cat] || cat) +
+                    ' <span class="pill draft">' + byCat[cat].length + '</span></div>';
+
+                byCat[cat].forEach(function (it) {
+                    var v = parseLinkValue(it.value);
+                    var d = draftForItem(it.id);
+                    var badge = '';
+                    if (d) {
+                        badge = d.status === 'pending'
+                            ? '<span class="pill pending">em revisão</span>'
+                            : '<span class="pill draft">rascunho</span>';
+                    }
+
+                    var actions = canPropose('links')
+                        ? '<div style="display:flex;gap:8px">' +
+                        '<button class="btn btn-ghost btn-sm" onclick="openLinkEditor(\'' + it.id + '\')">Editar</button>' +
+                        '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Tirar do ar</button>' +
+                        '</div>'
+                        : '';
+
+                    html += '<div class="item-row">' +
+                        '<div class="item-main">' +
+                        '<div class="item-name">' + esc(v.name) + ' ' + badge + '</div>' +
+                        '<div class="item-meta">' + esc(v.desc) + ' — ' + esc(v.url) + '</div>' +
+                        '</div>' + actions + '</div>';
+                });
+            });
+
+            host.innerHTML = html;
+        }
+
+        function closeModal() {
+            document.getElementById('modal-root').innerHTML = '';
+        }
+
+        function openLinkEditor(itemId) {
+            var item = null;
+            for (var i = 0; i < LIVE_LINKS.length; i++) {
+                if (LIVE_LINKS[i].id === itemId) item = LIVE_LINKS[i];
+            }
+
+            var existingDraft = itemId ? draftForItem(itemId) : null;
+            var src = existingDraft || item;
+            var v = parseLinkValue(src ? src.value : '{}');
+            var cat = src ? src.key : 'tasks';
+
+            var catOptions = Object.keys(CATEGORY_LABELS).map(function (k) {
+                return '<option value="' + k + '"' + (k === cat ? ' selected' : '') + '>' +
+                    esc(CATEGORY_LABELS[k]) + '</option>';
+            }).join('');
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" role="dialog" aria-modal="true">' +
+                '<h2>' + (item ? 'Editar link' : 'Novo link') + '</h2>' +
+                '<p class="card-sub">Isso cria uma proposta. O link no ar só muda depois da aprovação.</p>' +
+                (existingDraft && existingDraft.status === 'pending'
+                    ? '<div class="note warn" style="margin-top:14px">Este item já está em revisão. Cancele o envio para editar de novo.</div>'
+                    : '') +
+                '<label class="fld" for="lnk-name">Nome</label>' +
+                '<input type="text" id="lnk-name" value="' + esc(v.name) + '">' +
+                '<label class="fld" for="lnk-url">URL</label>' +
+                '<input type="url" id="lnk-url" value="' + esc(v.url) + '">' +
+                '<div class="grid-2">' +
+                '<div><label class="fld" for="lnk-desc">Descrição (PT)</label>' +
+                '<input type="text" id="lnk-desc" value="' + esc(v.desc) + '"></div>' +
+                '<div><label class="fld" for="lnk-desc-es">Descrição (ES)</label>' +
+                '<input type="text" id="lnk-desc-es" value="' + esc(v.desc_es) + '"></div>' +
+                '</div>' +
+                '<label class="fld" for="lnk-cat">Categoria</label>' +
+                '<select id="lnk-cat">' + catOptions + '</select>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-primary" id="lnk-save">Salvar e enviar para revisão</button>' +
+                '</div></div></div>';
+
+            document.getElementById('lnk-save').onclick = function () {
+                submitLink(itemId, existingDraft ? existingDraft.draftId : null, this);
+            };
+            document.getElementById('lnk-name').focus();
+        }
+
+        function submitLink(itemId, draftId, btn) {
+            var name = document.getElementById('lnk-name').value.trim();
+            var url = document.getElementById('lnk-url').value.trim();
+
+            if (!name) return toast('Dê um nome ao link.', true);
+            if (!/^https?:\/\/|^http:\/\/go\//i.test(url)) {
+                return toast('A URL precisa começar com http:// ou https://', true);
+            }
+
+            var payload = {
+                draftId: draftId || '',
+                itemId: itemId || '',
+                module: 'links',
+                key: document.getElementById('lnk-cat').value,
+                lang: 'ALL',
+                label: name,
+                value: JSON.stringify({
+                    name: name,
+                    url: url,
+                    desc: document.getElementById('lnk-desc').value.trim(),
+                    desc_es: document.getElementById('lnk-desc-es').value.trim()
+                })
+            };
+
+            btn.disabled = true;
+            btn.textContent = 'Enviando…';
+
+            google.script.run
+                .withSuccessHandler(function (res) {
+                    google.script.run
+                        .withSuccessHandler(function () {
+                            closeModal();
+                            toast('Proposta enviada para revisão.');
+                            loadLinks();
+                            loadPendingCount();
+                        })
+                        .withFailureHandler(function (err) {
+                            btn.disabled = false;
+                            btn.textContent = 'Salvar e enviar para revisão';
+                            toast(err.message, true);
+                        })
+                        .submitContentDraft(res.draftId);
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.textContent = 'Salvar e enviar para revisão';
+                    toast(err.message, true);
+                })
+                .saveContentDraft(payload);
+        }
+
+        function askRemoval(itemId) {
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" role="dialog" aria-modal="true">' +
+                '<h2>Tirar este link do ar?</h2>' +
+                '<p class="card-sub">Também passa por aprovação. Nada é apagado — a versão fica arquivada e pode voltar.</p>' +
+                '<label class="fld" for="rm-reason">Motivo</label>' +
+                '<textarea id="rm-reason" placeholder="ex.: ferramenta descontinuada"></textarea>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-danger" id="rm-go">Enviar para revisão</button>' +
+                '</div></div></div>';
+
+            document.getElementById('rm-go').onclick = function () {
+                var reason = document.getElementById('rm-reason').value.trim();
+                if (!reason) return toast('Explique o motivo.', true);
+                this.disabled = true;
+
+                google.script.run
+                    .withSuccessHandler(function () {
+                        closeModal();
+                        toast('Pedido de remoção enviado.');
+                        loadLinks();
+                        loadPendingCount();
+                    })
+                    .withFailureHandler(function (err) { toast(err.message, true); })
+                    .requestContentRemoval(itemId, reason);
+            };
+        }
+
+        // --- Aprovações ---
+        function loadPendingCount() {
+            if (!SESSION || !SESSION.canApprove) return;
+            google.script.run
+                .withSuccessHandler(function (list) {
+                    var chip = document.getElementById('pending-count');
+                    chip.textContent = (list || []).length;
+                    chip.classList.toggle('zero', !(list || []).length);
+                })
+                .withFailureHandler(function () { })
+                .listPendingApprovals();
+        }
+
+        function loadApprovals() {
+            var host = document.getElementById('approvals-list');
+
+            if (!SESSION.canApprove) {
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded">visibility_off</span>' +
+                    '<h2>Seu papel não revisa propostas</h2>' +
+                    '<p>Suas próprias propostas aparecem na aba do módulo, com o selo “em revisão”.</p></div>';
+                return;
+            }
+
+            host.innerHTML = '<div class="skeleton"></div><div class="skeleton"></div>';
+
+            google.script.run
+                .withSuccessHandler(function (list) {
+                    if (!list || !list.length) {
+                        host.innerHTML =
+                            '<div class="state"><span class="material-symbols-rounded">task_alt</span>' +
+                            '<h2>Nada esperando revisão</h2><p>Toda proposta enviada aparece aqui.</p></div>';
+                        return;
+                    }
+
+                    host.innerHTML = list.map(function (d) {
+                        var cur = d.currentValue ? prettyValue(d.currentValue) : '(item novo)';
+                        var neu = d.value ? prettyValue(d.value) : '(remoção — item sai do ar)';
+                        var selfNote = d.isSelfProposed
+                            ? (d.canReview
+                                ? '<div class="note warn">Proposta sua. Como ADMIN, você pode aprovar mesmo assim — fica registrado como autoaprovação.</div>'
+                                : '<div class="note warn">Proposta sua. Outra pessoa precisa revisar.</div>')
+                            : '';
+
+                        return '<div class="card">' +
+                            '<div class="row-between">' +
+                            '<div><div class="card-title">' + esc(d.label) + '</div>' +
+                            '<p class="card-sub">' + esc(d.module) + ' · ' + esc(d.key) +
+                            ' · proposto por <strong>' + esc(d.proposedBy) + '</strong></p></div>' +
+                            '<span class="pill pending">pendente</span>' +
+                            '</div>' + selfNote +
+                            '<div class="diff">' +
+                            '<div class="diff-side"><div class="diff-label">Hoje no ar</div>' +
+                            '<div class="diff-body">' + esc(cur) + '</div></div>' +
+                            '<div class="diff-side new"><div class="diff-label">Proposto</div>' +
+                            '<div class="diff-body">' + esc(neu) + '</div></div>' +
+                            '</div>' +
+                            '<div class="modal-actions" style="margin-top:8px">' +
+                            '<button class="btn btn-danger btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',false)">Rejeitar</button>' +
+                            '<button class="btn btn-success btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',true)"' +
+                            (d.canReview ? '' : ' disabled') + '>Aprovar e publicar</button>' +
+                            '</div></div>';
+                    }).join('');
+                })
+                .withFailureHandler(function (err) {
+                    host.innerHTML = '<div class="state"><span class="material-symbols-rounded">error</span>' +
+                        '<h2>Falha ao carregar a fila</h2><p>' + esc(err.message) + '</p></div>';
+                })
+                .listPendingApprovals();
+        }
+
+        // Links chegam como JSON; mostrar o objeto cru na revisão atrapalha mais
+        // do que ajuda, então viram linhas legíveis.
+        function prettyValue(raw) {
+            try {
+                var v = JSON.parse(raw);
+                if (v && v.url) {
+                    return 'Nome: ' + v.name + '\nURL: ' + v.url +
+                        '\nDescrição (PT): ' + (v.desc || '—') +
+                        '\nDescrição (ES): ' + (v.desc_es || '—');
+                }
+                return raw;
+            } catch (e) {
+                return raw;
+            }
+        }
+
+        function reviewDraft(draftId, approve) {
+            if (approve) {
+                google.script.run
+                    .withSuccessHandler(function (res) {
+                        toast(res.action === 'remove'
+                            ? 'Item retirado do ar. A versão fica arquivada e pode voltar.'
+                            : 'Publicado (versão ' + res.version + ').');
+                        loadApprovals();
+                        loadPendingCount();
+                        loadLinks();
+                    })
+                    .withFailureHandler(function (err) { toast(err.message, true); })
+                    .approveContentDraft(draftId, '');
+                return;
+            }
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" role="dialog" aria-modal="true">' +
+                '<h2>Rejeitar proposta</h2>' +
+                '<p class="card-sub">Volta como rascunho para quem propôs, com o seu comentário.</p>' +
+                '<label class="fld" for="rej-note">Motivo</label>' +
+                '<textarea id="rej-note" placeholder="o que precisa mudar"></textarea>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-danger" id="rej-go">Rejeitar</button>' +
+                '</div></div></div>';
+
+            document.getElementById('rej-go').onclick = function () {
+                var note = document.getElementById('rej-note').value.trim();
+                if (!note) return toast('Explique o motivo para quem propôs.', true);
+                this.disabled = true;
+
+                google.script.run
+                    .withSuccessHandler(function () {
+                        closeModal();
+                        toast('Proposta devolvida ao autor.');
+                        loadApprovals();
+                        loadPendingCount();
+                    })
+                    .withFailureHandler(function (err) { toast(err.message, true); })
+                    .rejectContentDraft(draftId, note);
+            };
+        }
+
+        // --- Acessos ---
+        function loadAccess() {
+            if (!SESSION.canManageAccess) return;
+
+            google.script.run
+                .withSuccessHandler(function (list) {
+                    var host = document.getElementById('access-list');
+                    host.innerHTML = (list || []).map(function (a) {
+                        return '<div class="item-row">' +
+                            '<div class="item-main">' +
+                            '<div class="item-name">' + esc(a.ldap) + '</div>' +
+                            '<div class="item-meta">concedido por ' + esc(a.grantedBy) + '</div>' +
+                            '</div>' +
+                            '<div style="display:flex;gap:8px;align-items:center">' +
+                            '<span class="pill ' + (a.active ? 'live' : 'archived') + '">' +
+                            esc(a.role) + (a.active ? '' : ' · inativo') + '</span>' +
+                            (a.ldap === SESSION.ldap ? '' :
+                                '<button class="btn btn-ghost btn-sm" onclick="toggleAccess(\'' +
+                                esc(a.ldap) + '\',\'' + esc(a.role) + '\',' + (!a.active) + ')">' +
+                                (a.active ? 'Desativar' : 'Reativar') + '</button>') +
+                            '</div></div>';
+                    }).join('');
+                })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .listContentAccess();
+        }
+
+        function saveAccess() {
+            var ldap = document.getElementById('acc-ldap').value.trim();
+            if (!ldap) return toast('Informe o LDAP.', true);
+
+            google.script.run
+                .withSuccessHandler(function () {
+                    document.getElementById('acc-ldap').value = '';
+                    toast('Acesso salvo.');
+                    loadAccess();
+                })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .saveContentAccess(ldap, document.getElementById('acc-role').value, true);
+        }
+
+        function toggleAccess(ldap, role, active) {
+            google.script.run
+                .withSuccessHandler(function () {
+                    toast('Acesso atualizado.');
+                    loadAccess();
+                })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .saveContentAccess(ldap, role, active);
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeModal();
+        });
+
+        // O bridge do google.script.run nem sempre está pronto no window.onload -
+        // mesma lição que o TLDashboard aprendeu ao vivo com a primeira chamada.
+        document.addEventListener('DOMContentLoaded', boot);
+    </script>
+</body>
+
+</html>

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -26,6 +26,18 @@ function doGet(e) {
       .addMetaTag('viewport', 'width=device-width, initial-scale=1');
   }
 
+  // Central de Conteúdo - página própria, deliberadamente fora do TLDashboard:
+  // aquele arquivo já é monolítico, e o dashboard de TL é um braço do processo
+  // de casos, não o lugar de gerenciar o conteúdo do produto inteiro.
+  // Quem não tem papel em Content_Access vê a tela responder "sem acesso" -
+  // o gate real é por ação, no ContentAPI.gs.
+  if (e.parameter.page === 'content') {
+    return HtmlService.createHtmlOutputFromFile('ContentDashboard')
+      .setTitle('Cases Wizard | Central de Conteúdo')
+      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+      .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+  }
+
   
   
   let result = {};
@@ -178,6 +190,13 @@ function doGet(e) {
          result = { status: 'success', action: 'delete' };
        } else { result = { status: 'error', msg: 'ID not found' }; }
     }
+    // 7. MÓDULO: Central de Conteúdo (leitura pública)
+    // Só devolve itens com status 'live'. Não existe parâmetro de status aqui
+    // de propósito: conteúdo em revisão não tem rota de leitura nenhuma.
+    else if (op === 'content_public') {
+      result = handleContentPublicRead(p);
+    }
+
     // 6. MÓDULO: Perfil de Usuário e Permissões (LDAP)
     else if (op === 'get_user_profile') {
       const userEmail = p.user || "";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "esbuild src/app.js --bundle --minify --outfile=dist/bundle.js",
     "dev": "esbuild src/app.js --bundle --outfile=dist/bundle-dev.js",
-    "portfolio": "python3 generate-portfolio.py"
+    "portfolio": "python3 generate-portfolio.py",
+    "test:content": "node scripts/test-content-api.js",
+    "seed:links": "node scripts/generate-links-seed.mjs"
   },
   "dependencies": {
     "esbuild": "^0.27.4",

--- a/scripts/generate-links-seed.mjs
+++ b/scripts/generate-links-seed.mjs
@@ -1,0 +1,92 @@
+// scripts/generate-links-seed.mjs
+//
+// Gera o payload de semeadura do módulo "links" a partir do LINKS_DB que hoje
+// está embutido em src/modules/links/links-assistant.js, já casando cada
+// descrição com a tradução correspondente em LINK_DESC_ES.
+//
+// Por que ler o arquivo em vez de importar o módulo: links-assistant.js importa
+// utilitários que tocam `document` no topo, e não roda fora do navegador. Extrair
+// só os dois literais de dados evita subir um DOM falso só pra isso.
+//
+// Uso:
+//   node scripts/generate-links-seed.mjs > links-seed.json
+//
+// Depois: abra a Central de Conteúdo no Apps Script e rode
+//   seedContentModule(<conteúdo do arquivo>)
+// uma única vez. A função ignora chamadas repetidas se o módulo já tiver
+// itens no ar, então não há risco de duplicar.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+    resolve(here, '../src/modules/links/links-assistant.js'),
+    'utf8'
+);
+
+// Recorta um literal de objeto pelo nome, contando chaves para achar o fim.
+// Uma regex sozinha não dá conta: os valores contêm `{` e `}` dentro de strings.
+function extractObjectLiteral(name) {
+    const start = source.indexOf(`const ${name} = {`);
+    if (start === -1) throw new Error(`Não encontrei ${name} em links-assistant.js`);
+
+    const open = source.indexOf('{', start);
+    let depth = 0;
+    let inString = null;
+
+    for (let i = open; i < source.length; i++) {
+        const ch = source[i];
+        const prev = source[i - 1];
+
+        if (inString) {
+            if (ch === inString && prev !== '\\') inString = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'" || ch === '`') { inString = ch; continue; }
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return source.slice(open, i + 1);
+        }
+    }
+
+    throw new Error(`Literal de ${name} não fecha`);
+}
+
+// eslint-disable-next-line no-eval
+const LINKS_DB = eval(`(${extractObjectLiteral('LINKS_DB')})`);
+// eslint-disable-next-line no-eval
+const LINK_DESC_ES = eval(`(${extractObjectLiteral('LINK_DESC_ES')})`);
+
+const items = [];
+let order = 0;
+
+for (const [category, group] of Object.entries(LINKS_DB)) {
+    for (const link of group.links) {
+        items.push({
+            key: category,
+            lang: 'ALL',
+            label: link.name,
+            value: JSON.stringify({
+                name: link.name,
+                url: link.url,
+                desc: link.desc || '',
+                // A tradução vem do mapa que hoje é global; ao migrar, ela passa
+                // a morar junto do link e vira editável pela tela.
+                desc_es: LINK_DESC_ES[link.desc] || ''
+            }),
+            sortOrder: order++
+        });
+    }
+}
+
+const missingEs = items.filter(i => !JSON.parse(i.value).desc_es).length;
+
+process.stderr.write(
+    `${items.length} links em ${Object.keys(LINKS_DB).length} categorias` +
+    (missingEs ? ` · ${missingEs} sem tradução ES\n` : '\n')
+);
+
+process.stdout.write(JSON.stringify({ module: 'links', items }, null, 2));

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -1,0 +1,317 @@
+// scripts/test-content-api.js
+//
+// Harness local para exercitar a máquina de estados do ContentAPI.gs, que não
+// tem como rodar no Apps Script sem uma planilha de verdade. Stub mínimo de
+// SpreadsheetApp/Session/MailApp, o suficiente pra provar as regras que a
+// Central de Conteúdo existe pra garantir:
+//   - rascunho e proposta pendente nunca aparecem na leitura pública;
+//   - só o ADMIN aprova a própria proposta (e isso vai pro log);
+//   - aprovar uma remoção arquiva o item, não publica uma linha vazia;
+//   - rollback e histórico agem sobre um item, não sobre a categoria inteira;
+//   - quem não tem papel ativo não lê nem escreve nada.
+//
+// Uso: npm run test:content
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.join(__dirname, '..', 'gas-backend', 'ContentAPI.js');
+
+// ---- Stub de planilha ----
+class FakeRange {
+  constructor(sheet, row, col) { this.sheet = sheet; this.row = row; this.col = col; }
+  setValue(v) { this.sheet._data[this.row - 1][this.col - 1] = v; return this; }
+  setValues(rows) {
+    rows.forEach((r, i) => {
+      const target = this.row - 1 + i;
+      while (this.sheet._data.length <= target) this.sheet._data.push([]);
+      this.sheet._data[target] = r.slice();
+    });
+    return this;
+  }
+  getValues() { return this.sheet._data.map(r => r.slice()); }
+}
+
+class FakeSheet {
+  constructor(name) { this.name = name; this._data = []; }
+  appendRow(row) { this._data.push(row.slice()); }
+  getDataRange() { return new FakeRange(this, 1, 1); }
+  getRange(row, col) { return new FakeRange(this, row, col); }
+  getLastRow() { return this._data.length; }
+  setFrozenRows() { return this; }
+}
+
+class FakeSpreadsheet {
+  constructor() { this.sheets = {}; }
+  getSheetByName(n) { return this.sheets[n] || null; }
+  insertSheet(n) { return (this.sheets[n] = new FakeSheet(n)); }
+}
+
+// ---- Ambiente ----
+let CURRENT_USER = 'lucaste@google.com';
+const SS = new FakeSpreadsheet();
+const SENT_MAIL = [];
+const LOGGED = [];
+
+const sandbox = {
+  SpreadsheetApp: { getActiveSpreadsheet: () => SS },
+  Session: { getActiveUser: () => ({ getEmail: () => CURRENT_USER }) },
+  MailApp: { sendEmail: (o) => SENT_MAIL.push(o) },
+  handleLog: (p) => LOGGED.push(p),
+  console,
+};
+
+const code = fs.readFileSync(SRC, 'utf8');
+const vm = require('node:vm');
+const ctx = vm.createContext(sandbox);
+vm.runInContext(code, ctx);
+
+const api = sandbox;
+
+// ---- Runner ----
+let pass = 0, fail = 0;
+function check(name, fn) {
+  try { fn(); console.log('  ✓ ' + name); pass++; }
+  catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+function eq(a, b, m) {
+  const A = JSON.stringify(a), B = JSON.stringify(b);
+  if (A !== B) throw new Error((m || '') + ' esperado ' + B + ', veio ' + A);
+}
+function throws(fn, re, m) {
+  try { fn(); } catch (e) {
+    if (re && !re.test(e.message)) throw new Error((m || '') + ' erro inesperado: ' + e.message);
+    return;
+  }
+  throw new Error((m || '') + ' deveria ter lançado erro');
+}
+function as(ldap, fn) { const old = CURRENT_USER; CURRENT_USER = ldap + '@google.com'; try { return fn(); } finally { CURRENT_USER = old; } }
+
+console.log('\n--- Acesso e papéis ---');
+
+check('ADMIN semeado automaticamente na criação da aba', () => {
+  const s = api.getContentSession();
+  eq(s.role, 'ADMIN');
+  eq(s.hasAccess, true);
+  eq(s.canManageAccess, true);
+});
+
+check('LDAP desconhecido não tem acesso nenhum', () => {
+  as('estranho', () => {
+    const s = api.getContentSession();
+    eq(s.hasAccess, false);
+    eq(s.role, null);
+  });
+});
+
+check('LDAP desconhecido não consegue nem listar', () => {
+  as('estranho', () => {
+    throws(() => api.listContentItems('links'), /Acesso negado/);
+  });
+});
+
+check('ADMIN concede acesso a um QA', () => {
+  api.saveContentAccess('quality1', 'QA', true);
+  as('quality1', () => {
+    const s = api.getContentSession();
+    eq(s.role, 'QA');
+    eq(s.canApprove, false);
+    eq(s.proposableModules, ['call_script', 'case_note_snippet']);
+  });
+});
+
+check('QA não propõe em links (fora do seu escopo)', () => {
+  as('quality1', () => {
+    throws(() => api.saveContentDraft({ module: 'links', key: 'tech', label: 'X', value: '{}' }),
+      /não edita o módulo/);
+  });
+});
+
+check('QA não aprova nada', () => {
+  as('quality1', () => {
+    throws(() => api.listPendingApprovals(), /não aprova/);
+  });
+});
+
+check('ADMIN não pode remover o próprio acesso', () => {
+  throws(() => api.saveContentAccess('lucaste', 'ADMIN', false), /não pode remover o próprio/);
+});
+
+console.log('\n--- Rascunho não vaza para produção ---');
+
+let draftId;
+check('salvar rascunho não publica nada', () => {
+  const r = api.saveContentDraft({
+    module: 'links', key: 'tech', lang: 'ALL', label: 'RegExr',
+    value: JSON.stringify({ name: 'RegExr', url: 'https://regexr.com', desc: 'Regex' })
+  });
+  draftId = r.draftId;
+  eq(api.listContentItems('links').length, 0, 'nenhum item live após salvar rascunho:');
+});
+
+check('leitura pública não enxerga rascunho', () => {
+  eq(api.handleContentPublicRead({ module: 'links' }).items.length, 0);
+});
+
+check('enviar para revisão ainda não publica', () => {
+  api.submitContentDraft(draftId);
+  eq(api.listContentItems('links').length, 0, 'nenhum item live após submit:');
+  eq(api.handleContentPublicRead({ module: 'links' }).items.length, 0);
+});
+
+check('proposta aparece na fila de revisão', () => {
+  const q = api.listPendingApprovals();
+  eq(q.length, 1);
+  eq(q[0].proposedBy, 'lucaste');
+  eq(q[0].isNew, true);
+});
+
+console.log('\n--- Autoaprovação ---');
+
+check('ADMIN pode aprovar a própria proposta (exceção pedida)', () => {
+  const q = api.listPendingApprovals();
+  eq(q[0].isSelfProposed, true);
+  eq(q[0].canReview, true, 'ADMIN pode revisar o próprio:');
+  const r = api.approveContentDraft(draftId, '');
+  eq(r.version, 1);
+});
+
+check('só agora o item está no ar', () => {
+  const live = api.listContentItems('links');
+  eq(live.length, 1);
+  eq(live[0].label, 'RegExr');
+  eq(api.handleContentPublicRead({ module: 'links' }).items.length, 1);
+});
+
+check('autoaprovação fica registrada no log', () => {
+  const entry = LOGGED.filter(l => l.action === 'approve').pop();
+  if (!/autoaprovação ADMIN/.test(entry.label)) {
+    throw new Error('log não marcou autoaprovação: ' + entry.label);
+  }
+});
+
+check('TL NÃO pode aprovar a própria proposta', () => {
+  api.saveContentAccess('lider1', 'TL', true);
+  as('lider1', () => {
+    const d = api.saveContentDraft({
+      module: 'links', key: 'tech', lang: 'ALL', label: 'JSFiddle',
+      value: JSON.stringify({ name: 'JSFiddle', url: 'https://jsfiddle.net', desc: 'JS' })
+    });
+    api.submitContentDraft(d.draftId);
+    throws(() => api.approveContentDraft(d.draftId, ''), /não pode aprovar a própria/);
+  });
+});
+
+check('ADMIN aprova a proposta do TL normalmente', () => {
+  const pend = api.listPendingApprovals().filter(d => d.proposedBy === 'lider1');
+  eq(pend.length, 1);
+  api.approveContentDraft(pend[0].draftId, 'ok');
+  eq(api.listContentItems('links').length, 2);
+});
+
+console.log('\n--- Versionamento e rollback ---');
+
+let itemToEdit;
+check('editar item publicado gera v2 e arquiva a v1', () => {
+  itemToEdit = api.listContentItems('links').find(i => i.label === 'RegExr');
+  const d = api.saveContentDraft({
+    itemId: itemToEdit.id, module: 'links', key: 'tech', lang: 'ALL',
+    label: 'RegExr (novo)',
+    value: JSON.stringify({ name: 'RegExr', url: 'https://regexr.com/v2', desc: 'Regex' })
+  });
+  api.submitContentDraft(d.draftId);
+  const r = api.approveContentDraft(d.draftId, '');
+  eq(r.version, 2);
+
+  const live = api.listContentItems('links');
+  eq(live.length, 2, 'ainda 2 itens no ar (não duplicou):');
+  eq(live.find(i => i.key === 'tech' && i.label === 'RegExr (novo)') !== undefined, true);
+});
+
+check('versão anterior fica arquivada, não apagada', () => {
+  const cur = api.listContentItems('links').find(i => i.label === 'RegExr (novo)');
+  const hist = api.listContentItemHistory(cur.lineage, 'links');
+  eq(hist.length, 2, 'duas versões na linhagem:');
+  eq(hist.filter(h => h.status === 'archived').length, 1);
+});
+
+check('histórico é por item, não pela categoria inteira', () => {
+  const regexr = api.listContentItems('links').find(i => i.label === 'RegExr (novo)');
+  const jsfiddle = api.listContentItems('links').find(i => i.label === 'JSFiddle');
+  eq(regexr.key, 'tech');
+  eq(jsfiddle.key, 'tech', 'os dois vivem na mesma categoria:');
+  if (regexr.lineage === jsfiddle.lineage) {
+    throw new Error('itens diferentes não podem compartilhar linhagem');
+  }
+  eq(api.listContentItemHistory(jsfiddle.lineage, 'links').length, 1,
+    'JSFiddle tem só a própria versão:');
+});
+
+check('rollback republica a versão arquivada sem tocar nos vizinhos', () => {
+  const cur = api.listContentItems('links').find(i => i.label === 'RegExr (novo)');
+  const old = api.listContentItemHistory(cur.lineage, 'links')
+    .find(h => h.status === 'archived' && h.label === 'RegExr');
+
+  api.rollbackContentItem(old.id);
+
+  const live = api.listContentItems('links');
+  eq(live.filter(i => i.label === 'RegExr').length, 1, 'a versão antiga voltou ao ar:');
+  eq(live.filter(i => i.label === 'RegExr (novo)').length, 0, 'a v2 saiu do ar:');
+  eq(live.filter(i => i.label === 'JSFiddle').length, 1,
+    'o vizinho da mesma categoria continua no ar:');
+});
+
+console.log('\n--- Remoção (o bug que o teste existe pra travar) ---');
+
+check('remoção arquiva sem publicar item vazio', () => {
+  const before = api.listContentItems('links').length;
+  const target = api.listContentItems('links').find(i => i.label === 'JSFiddle');
+
+  const r = api.requestContentRemoval(target.id, 'ferramenta descontinuada');
+  api.approveContentDraft(r.draftId, '');
+
+  const live = api.listContentItems('links');
+  eq(live.length, before - 1, 'item saiu do ar:');
+  eq(live.filter(i => !i.value || i.value === '').length, 0, 'nenhum item fantasma de valor vazio:');
+});
+
+check('item removido some da leitura pública', () => {
+  const pub = api.handleContentPublicRead({ module: 'links' });
+  eq(pub.items.filter(i => i.label === 'JSFiddle').length, 0);
+});
+
+console.log('\n--- Rejeição ---');
+
+check('rejeitar exige motivo e devolve como rascunho', () => {
+  const d = api.saveContentDraft({
+    module: 'links', key: 'ads', lang: 'ALL', label: 'Teste',
+    value: JSON.stringify({ name: 'Teste', url: 'https://x.com', desc: '' })
+  });
+  api.submitContentDraft(d.draftId);
+
+  throws(() => api.rejectContentDraft(d.draftId, ''), /Explique o motivo/);
+
+  api.rejectContentDraft(d.draftId, 'URL inválida');
+  const drafts = api.listContentDrafts('links');
+  const back = drafts.find(x => x.draftId === d.draftId);
+  eq(back.status, 'draft', 'voltou a ser rascunho:');
+  eq(back.reviewNote, 'URL inválida');
+});
+
+check('rejeitado não entra no ar', () => {
+  eq(api.listContentItems('links').filter(i => i.label === 'Teste').length, 0);
+});
+
+console.log('\n--- Semeadura ---');
+
+check('seed não roda duas vezes no mesmo módulo', () => {
+  const r = api.seedContentModule(JSON.stringify({ module: 'links', items: [] }));
+  eq(r.status, 'skipped', 'módulo já tem itens no ar:');
+});
+
+check('validação de módulo desconhecido', () => {
+  throws(() => api.listContentItems('inexistente'), /Módulo desconhecido/);
+});
+
+console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);
+process.exit(fail ? 1 : 0);

--- a/src/modules/links/links-assistant.js
+++ b/src/modules/links/links-assistant.js
@@ -6,6 +6,7 @@ import { toggleGenieAnimation } from '../shared/animations.js';
 import { SoundManager } from "../shared/sound-manager.js";
 import { lockBodyScroll, unlockBodyScroll, createEmptyState } from "../shared/dom-utils.js";
 import { getLanguage, onLanguageChange } from "../shared/i18n.js";
+import { DataService } from "../shared/data-service.js";
 
 // Descrição de cada link em espanhol, chaveada pelo texto em português.
 // Estão aqui as 60 descrições — inclusive as que ficam iguais nos dois
@@ -77,9 +78,14 @@ const LINK_DESC_ES = {
     'Lista de números': 'Lista de números',
     'Cursos': 'Cursos',
 };
-function linkDesc(desc) {
+// Aceita o objeto do link (não só a string) porque os itens vindos da Central
+// de Conteúdo carregam a tradução em `descEs`, editável na tela. O mapa
+// LINK_DESC_ES acima segue valendo para os links do fallback embutido.
+function linkDesc(link) {
+    const obj = (link && typeof link === 'object') ? link : { desc: link };
+    const desc = obj.desc || '';
     if (getLanguage() !== 'es') return desc;
-    return LINK_DESC_ES[desc] || desc;
+    return obj.descEs || LINK_DESC_ES[desc] || desc;
 }
 
 const LINKS_DICT = {
@@ -231,6 +237,65 @@ const LINKS_DB = {
     ]
   }
 };
+
+// --- HIDRATAÇÃO PELA CENTRAL DE CONTEÚDO ---
+// O LINKS_DB acima deixa de ser a fonte da verdade e passa a ser o fallback:
+// é o que aparece no primeiro load offline, quando ainda não há nem resposta da
+// API nem cache local. Assim que a Central responde, a lista publicada vence.
+//
+// Cada item publicado traz `key` = categoria e `value` = JSON com
+// { name, url, desc, desc_es } — o par PT/ES viaja junto do link que descreve,
+// em vez de num mapa paralelo (LINK_DESC_ES) que precisa ser editado à parte.
+function applyContentItems(items) {
+    if (!Array.isArray(items) || !items.length) return false;
+
+    const rebuilt = {};
+
+    for (const item of items) {
+        const cat = item.key;
+        if (!cat) continue;
+
+        let parsed;
+        try {
+            parsed = JSON.parse(item.value || '{}');
+        } catch (e) {
+            continue; // Item malformado não derruba os outros.
+        }
+        if (!parsed.name || !parsed.url) continue;
+
+        if (!rebuilt[cat]) {
+            rebuilt[cat] = { label: LINKS_DB[cat]?.label || cat, links: [] };
+        }
+        rebuilt[cat].links.push({
+            name: parsed.name,
+            url: parsed.url,
+            desc: parsed.desc || '',
+            descEs: parsed.desc_es || ''
+        });
+    }
+
+    if (!Object.keys(rebuilt).length) return false;
+
+    // Substitui o conteúdo preservando a identidade do objeto: o módulo inteiro
+    // já capturou a referência de LINKS_DB, então reatribuir a const quebraria.
+    for (const key of Object.keys(LINKS_DB)) delete LINKS_DB[key];
+    Object.assign(LINKS_DB, rebuilt);
+    return true;
+}
+
+async function hydrateLinksFromContentCentral(onReady) {
+    // Cache primeiro: a lista renderiza na hora com o que já veio da última vez,
+    // sem esperar a rede — e a resposta fresca corrige depois, se mudou.
+    const cached = DataService.getCachedContent('links');
+    if (applyContentItems(cached)) onReady?.();
+
+    try {
+        const items = await DataService.fetchContentModule('links');
+        if (applyContentItems(items)) onReady?.();
+    } catch (e) {
+        console.warn('Central de Conteúdo indisponível; usando links embutidos.', e);
+    }
+}
 
 const CATEGORY_ICONS = {
     tasks: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>`,
@@ -671,7 +736,7 @@ export function initLinksAssistant() {
               // "resolución" achar o link no idioma que está na tela.
               const filtered = cat.links.filter(l =>
                   l.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                  linkDesc(l.desc).toLowerCase().includes(searchTerm.toLowerCase())
+                  linkDesc(l).toLowerCase().includes(searchTerm.toLowerCase())
               );
               results.push(...filtered.map(l => ({...l, _cat: key})));
           });
@@ -754,7 +819,7 @@ export function initLinksAssistant() {
 
       const desc = document.createElement("div");
       desc.className = "cw-links-card-desc";
-      desc.textContent = linkDesc(link.desc);
+      desc.textContent = linkDesc(link);
 
       meta.appendChild(title);
       meta.appendChild(desc);
@@ -808,6 +873,15 @@ export function initLinksAssistant() {
   document.body.appendChild(popup);
   renderSidebar();
   renderContent();
+
+  // Busca a lista publicada na Central de Conteúdo e repinta quando chegar.
+  // Não bloqueia a abertura: a tela já subiu com o fallback embutido, então o
+  // pior caso (API fora do ar) é continuar exatamente como era antes.
+  hydrateLinksFromContentCentral(() => {
+      renderSidebar();
+      renderContent();
+      updateSidebarVisuals();
+  });
 
   // Retraduz header/busca e refaz sidebar+conteúdo, que já são montados do
   // zero a cada render (inclusive o overlay de histórico, se estiver aberto).

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -15,6 +15,7 @@ const API_URL = isDevelopment
 
 const CACHE_KEY_BROADCAST = "cw_data_broadcast";
 const CACHE_KEY_TIPS = "cw_data_tips";
+const CACHE_KEY_CONTENT_PREFIX = "cw_content_";
 
 const FALLBACK_TIPS = ["Processando...", "Mantenha o foco!", "Aguarde..."];
 
@@ -83,6 +84,38 @@ export const DataService = {
     },
 
     getCachedBroadcasts: () => JSON.parse(localStorage.getItem(CACHE_KEY_BROADCAST) || "[]"),
+
+    // ==========================================
+    // 1.5 CENTRAL DE CONTEÚDO (conteúdo gerenciável)
+    // ==========================================
+    // Busca o conteúdo publicado de um módulo (links, call_script, ...).
+    // O backend só devolve itens 'live' - não existe parâmetro de status aqui,
+    // então nem por engano o app do agente enxerga algo pendente de aprovação.
+    //
+    // Mesmo contrato dos tips: cacheia no localStorage e devolve o cache quando
+    // a API cai. Quem chama continua responsável por ter um fallback embutido
+    // no código para o primeiro load offline, quando não há cache nenhum.
+    fetchContentModule: async (module) => {
+        const cacheKey = `${CACHE_KEY_CONTENT_PREFIX}${module}`;
+        try {
+            const data = await jsonpFetch('content_public', { module });
+            if (data?.status === 'success' && Array.isArray(data.items)) {
+                localStorage.setItem(cacheKey, JSON.stringify(data.items));
+                return data.items;
+            }
+        } catch (err) {
+            console.warn(`Conteúdo '${module}' offline`, err);
+        }
+        return DataService.getCachedContent(module);
+    },
+
+    getCachedContent: (module) => {
+        try {
+            return JSON.parse(localStorage.getItem(`${CACHE_KEY_CONTENT_PREFIX}${module}`) || "null");
+        } catch (e) {
+            return null;
+        }
+    },
     
     getRandomTip: () => {
         let tips = FALLBACK_TIPS;


### PR DESCRIPTION
Tela própria para gerenciar o conteúdo dos módulos sem mexer em código, com controle de acesso por papel e aprovação obrigatória antes de produção.

## Fase 0 — fundação

- **`ContentAPI.gs`**: três abas novas (`Content_Items` / `Content_Drafts` / `Content_Access`) com schema genérico por `module`, em vez de uma aba e um conjunto de `op=` por tipo de conteúdo — a dívida que `Tips`, `Broadcast` e `Database_Snippets` acumularam, cada um com o seu.
- **Papéis ADMIN / TL / QA / WFM**. Identidade sempre de `Session.getActiveUser()`, nunca por parâmetro do cliente — mesmo princípio do `assertCallerIsOverhead()` já usado no resto do backend. Sem linha ativa em `Content_Access`, não há leitura nem escrita.
- **`ContentDashboard.html`** servido por `doGet(page=content)`. Arquivo próprio, deliberadamente fora do `TLDashboard.html`: aquele já é monolítico e é um braço do processo de casos, não o lugar de gerenciar o conteúdo do produto inteiro. Os tokens visuais são copiados de lá, então a identidade não diverge.
- Coluna **`lang`** presente desde já, para não exigir migração da aba depois.

## Segurança das mudanças

- O app em produção só lê `Content_Items` com status `live`. Rascunho e proposta pendente vivem só em `Content_Drafts`, que a leitura pública não toca — a barreira é **estrutural**, não uma regra de UI que dê pra burlar chamando o endpoint na mão.
- Fluxo `draft → pending → live`, com rejeição devolvendo ao autor junto do motivo.
- Sem autoaprovação, **com a exceção explícita do ADMIN** (registrada no log como autoaprovação).
- Versão anterior é **arquivada, nunca apagada**: reverter é reaprovar uma versão que já existe.
- Auditoria na aba `Logs` já existente; e-mail aos aprovadores ao enviar para revisão.

## Fase 1 — Links

- `links-assistant.js` passa a consumir a lista publicada, com o `LINKS_DB` embutido virando **fallback** (mesmo contrato do `FALLBACK_TIPS`): API fora do ar não quebra a tela do agente.
- A tradução ES sai do mapa global `LINK_DESC_ES` e passa a viajar junto de cada link, virando editável pela tela.
- `scripts/generate-links-seed.mjs` gera o payload de migração dos 60 links.

## Testes

`npm run test:content` — 26 casos, todos passando. Harness que stuba `SpreadsheetApp` para exercitar a máquina de estados, já que ela não roda sem uma planilha real.

Ele pegou **dois bugs durante o desenvolvimento**:
1. Aprovar uma remoção publicava uma linha `live` vazia em vez de só arquivar — item fantasma na lista do agente.
2. Rollback e histórico agiam sobre `Key`, que em links é a **categoria** — reverter um link derrubaria os ~10 vizinhos junto. Daí a coluna `Lineage`, identidade estável do item entre versões.

## Depois do merge

A criação das abas roda sozinha no primeiro acesso, mas a **semeadura dos 60 links é manual e única**: `npm run seed:links` gera o payload, e depois roda-se `seedContentModule(...)` no editor do Apps Script. Até lá o app segue com a lista embutida — nada quebra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)