### PR TITLE
fix(content-central): semeadura executável pelo editor + IDs sem colisão

### DIFF
--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -156,8 +156,13 @@ function contentNow_() {
   return new Date().toISOString();
 }
 
+// Utilities.getUuid() em vez de timestamp + aleatório: a semeadura cria dezenas
+// de linhas dentro do mesmo milissegundo, e sortear 60 números em 1000 valores
+// colide com folga (~5 repetidos, medido no teste). ID repetido é grave aqui
+// porque findContentRow_() devolve a primeira linha que casa - editar um item
+// acabaria editando outro.
 function newContentId_(prefix) {
-  return prefix + "_" + new Date().getTime() + "_" + Math.floor(Math.random() * 1000);
+  return prefix + "_" + Utilities.getUuid();
 }
 
 // =========================================================

--- a/gas-backend/ContentSeed_Links.js
+++ b/gas-backend/ContentSeed_Links.js
@@ -1,4 +1,15 @@
-{
+// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:links (lê o LINKS_DB de src/modules/links/links-assistant.js)
+//
+// Semeia o módulo "links" da Central de Conteúdo com a lista que hoje está
+// embutida no bundle do agente. É migração de conteúdo que já está em produção,
+// não mudança nova - por isso publica direto, sem passar pela fila de revisão.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedLinksNow" no seletor de
+// função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar, então não há risco de duplicar.
+
+const CONTENT_SEED_LINKS = {
   "module": "links",
   "items": [
     {
@@ -422,4 +433,10 @@
       "sortOrder": 59
     }
   ]
+};
+
+function seedLinksNow() {
+  const result = seedContentModule(CONTENT_SEED_LINKS);
+  Logger.log(result);
+  return result;
 }

--- a/scripts/generate-links-seed.mjs
+++ b/scripts/generate-links-seed.mjs
@@ -8,19 +8,20 @@
 // utilitários que tocam `document` no topo, e não roda fora do navegador. Extrair
 // só os dois literais de dados evita subir um DOM falso só pra isso.
 //
-// A saída já está versionada em gas-backend/seeds/links-seed.json, então o
-// caminho normal é abrir aquele arquivo (inclusive pelo GitHub, de qualquer
-// máquina) e copiar o conteúdo. Rode este script apenas para regerar o arquivo
-// depois de mexer no LINKS_DB:
+// Escreve dois arquivos, ambos versionados:
+//   - gas-backend/seeds/links-seed.json  (para inspecionar o conteúdo)
+//   - gas-backend/ContentSeed_Links.js   (o que realmente roda)
 //
-//   npm run seed:links > gas-backend/seeds/links-seed.json
+// Não é preciso copiar nada à mão: o .gs sobe junto com o resto do backend no
+// deploy, e a semeadura é feita escolhendo a função `seedLinksNow` no editor do
+// Apps Script e clicando em Executar. O botão Run só aceita funções sem
+// argumentos, e é por isso que existe esse wrapper em vez de chamar
+// seedContentModule(payload) direto.
 //
-// Depois: no editor do Apps Script, rode uma única vez
-//   seedContentModule(<conteúdo do arquivo>)
-// A função ignora chamadas repetidas se o módulo já tiver itens no ar, então
-// não há risco de duplicar.
+// Rode este script apenas para regerar os arquivos depois de mexer no LINKS_DB:
+//   npm run seed:links
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -87,10 +88,41 @@ for (const [category, group] of Object.entries(LINKS_DB)) {
 }
 
 const missingEs = items.filter(i => !JSON.parse(i.value).desc_es).length;
+const payload = { module: 'links', items };
 
-process.stderr.write(
-    `${items.length} links em ${Object.keys(LINKS_DB).length} categorias` +
-    (missingEs ? ` · ${missingEs} sem tradução ES\n` : '\n')
+// 1) JSON, para inspecionar o conteúdo pelo GitHub sem precisar de checkout.
+writeFileSync(
+    resolve(here, '../gas-backend/seeds/links-seed.json'),
+    JSON.stringify(payload, null, 2) + '\n'
 );
 
-process.stdout.write(JSON.stringify({ module: 'links', items }, null, 2));
+// 2) Arquivo .gs com uma função SEM ARGUMENTOS. É o que torna a semeadura
+// executável de verdade: o botão Run do editor do Apps Script só lista e roda
+// funções sem parâmetros, então não há como passar o JSON na mão por lá.
+const gasFile = `// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:links (lê o LINKS_DB de src/modules/links/links-assistant.js)
+//
+// Semeia o módulo "links" da Central de Conteúdo com a lista que hoje está
+// embutida no bundle do agente. É migração de conteúdo que já está em produção,
+// não mudança nova - por isso publica direto, sem passar pela fila de revisão.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedLinksNow" no seletor de
+// função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar, então não há risco de duplicar.
+
+const CONTENT_SEED_LINKS = ${JSON.stringify(payload, null, 2)};
+
+function seedLinksNow() {
+  const result = seedContentModule(CONTENT_SEED_LINKS);
+  Logger.log(result);
+  return result;
+}
+`;
+
+writeFileSync(resolve(here, '../gas-backend/ContentSeed_Links.js'), gasFile);
+
+process.stdout.write(
+    `${items.length} links em ${Object.keys(LINKS_DB).length} categorias` +
+    (missingEs ? ` · ${missingEs} sem tradução ES` : '') + '\n' +
+    'Gerados: gas-backend/seeds/links-seed.json e gas-backend/ContentSeed_Links.js\n'
+);

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -53,18 +53,26 @@ const SS = new FakeSpreadsheet();
 const SENT_MAIL = [];
 const LOGGED = [];
 
+const LOGGER = [];
+
 const sandbox = {
   SpreadsheetApp: { getActiveSpreadsheet: () => SS },
   Session: { getActiveUser: () => ({ getEmail: () => CURRENT_USER }) },
   MailApp: { sendEmail: (o) => SENT_MAIL.push(o) },
+  Logger: { log: (m) => LOGGER.push(m) },
+  Utilities: { getUuid: () => require('node:crypto').randomUUID() },
   handleLog: (p) => LOGGED.push(p),
   console,
 };
 
-const code = fs.readFileSync(SRC, 'utf8');
 const vm = require('node:vm');
 const ctx = vm.createContext(sandbox);
-vm.runInContext(code, ctx);
+vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+
+// O arquivo de semeadura entra no mesmo escopo global, como no Apps Script -
+// é assim que seedLinksNow() enxerga seedContentModule() sem nenhum import.
+const SEED_SRC = path.join(__dirname, '..', 'gas-backend', 'ContentSeed_Links.js');
+vm.runInContext(fs.readFileSync(SEED_SRC, 'utf8'), ctx);
 
 const api = sandbox;
 
@@ -307,6 +315,45 @@ console.log('\n--- Semeadura ---');
 check('seed não roda duas vezes no mesmo módulo', () => {
   const r = api.seedContentModule(JSON.stringify({ module: 'links', items: [] }));
   eq(r.status, 'skipped', 'módulo já tem itens no ar:');
+});
+
+// A semeadura de verdade precisa de uma planilha limpa, então roda num
+// ambiente próprio. Vale o trabalho: é o caminho que só é exercitado uma vez
+// na vida, em produção, e onde um erro custa caro pra desfazer.
+check('seedLinksNow() popula o módulo numa planilha zerada', () => {
+  const freshSS = new FakeSpreadsheet();
+  const freshCtx = vm.createContext({
+    SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    MailApp: { sendEmail: () => { } },
+    Logger: { log: () => { } },
+    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    handleLog: () => { },
+    console,
+  });
+
+  vm.runInContext(fs.readFileSync(SRC, 'utf8'), freshCtx);
+  vm.runInContext(fs.readFileSync(SEED_SRC, 'utf8'), freshCtx);
+
+  // Exatamente o que o botão Executar do editor faz: chama sem argumentos.
+  const res = freshCtx.seedLinksNow();
+  eq(res.status, 'success');
+  if (res.seeded < 50) throw new Error('semeou só ' + res.seeded + ' itens');
+
+  const live = freshCtx.listContentItems('links');
+  eq(live.length, res.seeded, 'tudo que foi semeado está no ar:');
+
+  // O que o agente realmente recebe depois da semeadura.
+  const pub = freshCtx.handleContentPublicRead({ module: 'links' });
+  eq(pub.items.length, res.seeded);
+
+  const first = JSON.parse(pub.items[0].value);
+  if (!first.name || !first.url) throw new Error('item semeado sem name/url');
+
+  // Cada item precisa de linhagem própria, senão um rollback futuro
+  // arrastaria a categoria inteira junto.
+  const lineages = new Set(live.map(i => i.lineage));
+  eq(lineages.size, live.length, 'linhagens únicas por item:');
 });
 
 check('validação de módulo desconhecido', () => {


### PR DESCRIPTION
## O problema

O botão **Executar** do editor do Apps Script só lista e roda funções **sem argumentos**. Não havia como rodar `seedContentModule(payload)` por lá — a instrução anterior de "colar o JSON na hora de executar" simplesmente não era aplicável.

## A correção

`npm run seed:links` agora gera **dois** arquivos, ambos versionados:

- `gas-backend/ContentSeed_Links.js` — payload embutido + wrapper `seedLinksNow()` sem parâmetros. Sobe junto no deploy do clasp.
- `gas-backend/seeds/links-seed.json` — mantido para inspeção pelo GitHub.

A semeadura vira: escolher **`seedLinksNow`** no seletor de função e clicar em Executar. Nada pra copiar à mão.

## Bug de colisão de IDs (achado pelo novo teste)

`newContentId_()` usava `timestamp + random(0..999)`. A semeadura cria dezenas de linhas **no mesmo milissegundo**, e sortear 60 números em 1000 valores colide com folga: **60 itens geravam só 55 ids distintos**.

ID repetido é grave porque `findContentRow_()` devolve a primeira linha que casa — editar um link poderia acabar editando outro. Passa a usar `Utilities.getUuid()`.

Vale notar que isso afetaria produção mesmo sem a semeadura, só que mais raramente.

## Testes

27 casos (era 26), todos passando. O novo roda `seedLinksNow()` num ambiente com planilha zerada, chamando **sem argumentos** — exatamente o que o botão Executar faz. É o caminho que só é exercitado uma vez na vida, em produção, e onde um erro custa caro pra desfazer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)