### PR TITLE
feat(content-central): Fase 2 — Call Script gerenciável pela Central

### DIFF
--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -657,6 +657,9 @@
                 <button class="tab-btn active" role="tab" data-tab="links" onclick="switchTab('links')">
                     <span class="material-symbols-rounded" style="font-size:19px">link</span> Links
                 </button>
+                <button class="tab-btn" role="tab" data-tab="callscript" onclick="switchTab('callscript')">
+                    <span class="material-symbols-rounded" style="font-size:19px">support_agent</span> Call Script
+                </button>
                 <button class="tab-btn" role="tab" data-tab="approvals" onclick="switchTab('approvals')">
                     <span class="material-symbols-rounded" style="font-size:19px">rule</span> Aprovações
                     <span class="count-chip zero" id="pending-count">0</span>
@@ -686,6 +689,39 @@
                 </div>
                 <div class="card" id="links-list">
                     <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+            </section>
+
+            <!-- TAB: Call Script -->
+            <section id="pane-callscript" class="hidden">
+                <div class="note" id="cs-note">
+                    Cada passo é um item. Editar aqui não altera o app — vai para
+                    <strong>Aprovações</strong> primeiro.
+                </div>
+                <div class="row-between" style="margin-bottom:14px">
+                    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">
+                        <div>
+                            <label class="fld" style="margin-top:0" for="cs-lang">Idioma</label>
+                            <select id="cs-lang" onchange="renderCallScript()">
+                                <option value="PT">PT</option>
+                                <option value="ES">ES</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="cs-flow">Fluxo</label>
+                            <select id="cs-flow" onchange="renderCallScript()">
+                                <option value="BAU">BAU</option>
+                                <option value="LT">LT</option>
+                            </select>
+                        </div>
+                    </div>
+                    <button class="btn btn-primary" id="cs-new-btn" onclick="openStepEditor(null)">
+                        <span class="material-symbols-rounded" style="font-size:19px">add</span> Novo passo
+                    </button>
+                </div>
+                <div class="card" id="cs-list">
                     <div class="skeleton"></div>
                     <div class="skeleton"></div>
                 </div>
@@ -807,6 +843,16 @@
             }
         }
 
+        // Recarrega as listas de conteúdo. Genérico de propósito: aprovar ou
+        // remover algo pode afetar qualquer módulo, e a aba visível nem sempre é
+        // a do item mexido.
+        function refreshContentLists() {
+            loadLinks();
+            if (!document.getElementById('pane-callscript').classList.contains('hidden')) {
+                loadCallScript();
+            }
+        }
+
         // A UI é conveniência, não a fronteira: o servidor recusa a ação de
         // qualquer jeito. Esconder o botão evita oferecer algo que vai falhar.
         function canPropose(module) {
@@ -815,13 +861,14 @@
         }
 
         function switchTab(tab) {
-            ['links', 'approvals', 'access', 'soon'].forEach(function (t) {
+            ['links', 'callscript', 'approvals', 'access', 'soon'].forEach(function (t) {
                 var pane = document.getElementById('pane-' + t);
                 if (pane) pane.classList.toggle('hidden', t !== tab);
             });
             document.querySelectorAll('.tab-btn').forEach(function (b) {
                 b.classList.toggle('active', b.dataset.tab === tab);
             });
+            if (tab === 'callscript') loadCallScript();
             if (tab === 'approvals') loadApprovals();
             if (tab === 'access') loadAccess();
         }
@@ -850,6 +897,11 @@
                         document.getElementById('links-new-btn').classList.add('hidden');
                         document.getElementById('links-note').textContent =
                             'Seu papel (' + s.role + ') vê os links, mas não propõe alterações neste módulo.';
+                    }
+                    if (!canPropose('call_script')) {
+                        document.getElementById('cs-new-btn').classList.add('hidden');
+                        document.getElementById('cs-note').textContent =
+                            'Seu papel (' + s.role + ') vê o roteiro, mas não propõe alterações neste módulo.';
                     }
 
                     loadLinks();
@@ -1071,12 +1123,206 @@
                     .withSuccessHandler(function () {
                         closeModal();
                         toast('Pedido de remoção enviado.');
-                        loadLinks();
+                        refreshContentLists();
                         loadPendingCount();
                     })
                     .withFailureHandler(function (err) { toast(err.message, true); })
                     .requestContentRemoval(itemId, reason);
             };
+        }
+
+        // --- Call Script ---
+        var CS_ITEMS = [];
+        var CS_DRAFTS = [];
+
+        var CS_GROUPS = [
+            { key: 'inicio', label: 'Início' },
+            { key: 'meio', label: 'Implementação (Tag Support)' },
+            { key: 'fim', label: 'Encerramento' }
+        ];
+
+        function loadCallScript() {
+            google.script.run
+                .withSuccessHandler(function (items) {
+                    CS_ITEMS = items || [];
+                    google.script.run
+                        .withSuccessHandler(function (d) { CS_DRAFTS = d || []; renderCallScript(); })
+                        .withFailureHandler(function () { CS_DRAFTS = []; renderCallScript(); })
+                        .listContentDrafts('call_script');
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('cs-list').innerHTML =
+                        '<div class="state"><span class="material-symbols-rounded">error</span>' +
+                        '<h2>Não foi possível carregar o roteiro</h2><p>' + esc(err.message) + '</p></div>';
+                })
+                .listContentItems('call_script');
+        }
+
+        function csDraftForItem(itemId) {
+            for (var i = 0; i < CS_DRAFTS.length; i++) {
+                if (CS_DRAFTS[i].itemId === itemId) return CS_DRAFTS[i];
+            }
+            return null;
+        }
+
+        function renderCallScript() {
+            var host = document.getElementById('cs-list');
+            var lang = document.getElementById('cs-lang').value;
+            var flow = document.getElementById('cs-flow').value;
+
+            var mine = CS_ITEMS.filter(function (i) { return i.lang === lang && i.key === flow; });
+
+            if (!mine.length) {
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded">support_agent</span>' +
+                    '<h2>Nenhum passo publicado para ' + esc(lang + ' ' + flow) + '</h2>' +
+                    '<p>Enquanto isso o app segue com o roteiro embutido no código. ' +
+                    'Rode a semeadura (seedCallScriptNow) ou crie o primeiro passo aqui.</p></div>';
+                return;
+            }
+
+            var html = '';
+            CS_GROUPS.forEach(function (g) {
+                var steps = mine.filter(function (i) { return i.field === g.key; })
+                    .sort(function (a, b) { return a.sortOrder - b.sortOrder; });
+
+                html += '<div class="cat-head">' + esc(g.label) +
+                    ' <span class="pill draft">' + steps.length + '</span></div>';
+
+                // A seção de Implementação ainda não existe em ES: é conteúdo que
+                // nunca chegou, não bug. Dizer isso explicitamente evita que pareça
+                // uma falha de carregamento.
+                if (!steps.length) {
+                    html += '<div class="item-row"><div class="item-main">' +
+                        '<div class="item-meta">Sem passos cadastrados nesta seção. ' +
+                        'Use “Novo passo” para preencher.</div></div></div>';
+                    return;
+                }
+
+                steps.forEach(function (it, idx) {
+                    var d = csDraftForItem(it.id);
+                    var badge = d
+                        ? (d.status === 'pending'
+                            ? '<span class="pill pending">em revisão</span>'
+                            : '<span class="pill draft">rascunho</span>')
+                        : '';
+
+                    var actions = canPropose('call_script')
+                        ? '<div style="display:flex;gap:8px">' +
+                        '<button class="btn btn-ghost btn-sm" onclick="openStepEditor(\'' + it.id + '\')">Editar</button>' +
+                        '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
+                        '</div>'
+                        : '';
+
+                    html += '<div class="item-row">' +
+                        '<div class="item-main">' +
+                        '<div class="item-name">' + (idx + 1) + '. ' + badge + '</div>' +
+                        '<div class="item-meta">' + esc(it.value) + '</div>' +
+                        '</div>' + actions + '</div>';
+                });
+            });
+
+            host.innerHTML = html;
+        }
+
+        function openStepEditor(itemId) {
+            var item = null;
+            for (var i = 0; i < CS_ITEMS.length; i++) {
+                if (CS_ITEMS[i].id === itemId) item = CS_ITEMS[i];
+            }
+
+            var existingDraft = itemId ? csDraftForItem(itemId) : null;
+            var src = existingDraft || item;
+            var lang = document.getElementById('cs-lang').value;
+            var flow = document.getElementById('cs-flow').value;
+            var group = src ? src.field : 'inicio';
+            var text = src ? src.value : '';
+
+            var groupOptions = CS_GROUPS.map(function (g) {
+                return '<option value="' + g.key + '"' + (g.key === group ? ' selected' : '') + '>' +
+                    esc(g.label) + '</option>';
+            }).join('');
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" role="dialog" aria-modal="true">' +
+                '<h2>' + (item ? 'Editar passo' : 'Novo passo') + '</h2>' +
+                '<p class="card-sub">' + esc(lang + ' ' + flow) +
+                ' — vira proposta; o roteiro no ar só muda depois da aprovação.</p>' +
+                (existingDraft && existingDraft.status === 'pending'
+                    ? '<div class="note warn" style="margin-top:14px">Este passo já está em revisão.</div>'
+                    : '') +
+                '<label class="fld" for="cs-group">Seção</label>' +
+                '<select id="cs-group">' + groupOptions + '</select>' +
+                '<label class="fld" for="cs-text">Texto do passo</label>' +
+                '<textarea id="cs-text" placeholder="o que o agente deve dizer ou fazer">' + esc(text) + '</textarea>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-primary" id="cs-save">Salvar e enviar para revisão</button>' +
+                '</div></div></div>';
+
+            document.getElementById('cs-save').onclick = function () {
+                submitStep(itemId, existingDraft ? existingDraft.draftId : null, src, this);
+            };
+            document.getElementById('cs-text').focus();
+        }
+
+        function submitStep(itemId, draftId, src, btn) {
+            var text = document.getElementById('cs-text').value.trim();
+            if (!text) return toast('Escreva o texto do passo.', true);
+
+            var group = document.getElementById('cs-group').value;
+            var lang = document.getElementById('cs-lang').value;
+            var flow = document.getElementById('cs-flow').value;
+
+            // Passo novo vai para o fim da seção; passo existente mantém a posição.
+            var sortOrder;
+            if (src) {
+                sortOrder = src.sortOrder;
+            } else {
+                var inGroup = CS_ITEMS.filter(function (i) {
+                    return i.lang === lang && i.key === flow && i.field === group;
+                });
+                sortOrder = inGroup.reduce(function (max, i) {
+                    return Math.max(max, i.sortOrder);
+                }, 0) + 1;
+            }
+
+            btn.disabled = true;
+            btn.textContent = 'Enviando…';
+
+            google.script.run
+                .withSuccessHandler(function (res) {
+                    google.script.run
+                        .withSuccessHandler(function () {
+                            closeModal();
+                            toast('Proposta enviada para revisão.');
+                            loadCallScript();
+                            loadPendingCount();
+                        })
+                        .withFailureHandler(function (err) {
+                            btn.disabled = false;
+                            btn.textContent = 'Salvar e enviar para revisão';
+                            toast(err.message, true);
+                        })
+                        .submitContentDraft(res.draftId);
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.textContent = 'Salvar e enviar para revisão';
+                    toast(err.message, true);
+                })
+                .saveContentDraft({
+                    draftId: draftId || '',
+                    itemId: itemId || '',
+                    module: 'call_script',
+                    key: flow,
+                    field: group,
+                    lang: lang,
+                    label: text,
+                    value: text,
+                    sortOrder: sortOrder
+                });
         }
 
         // --- Aprovações ---
@@ -1175,7 +1421,7 @@
                             : 'Publicado (versão ' + res.version + ').');
                         loadApprovals();
                         loadPendingCount();
-                        loadLinks();
+                        refreshContentLists();
                     })
                     .withFailureHandler(function (err) { toast(err.message, true); })
                     .approveContentDraft(draftId, '');

--- a/gas-backend/ContentSeed_CallScript.js
+++ b/gas-backend/ContentSeed_CallScript.js
@@ -1,0 +1,591 @@
+// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:call-script (lê o csaChecklistData de
+// src/modules/call-script/call-script-data.js)
+//
+// Semeia o módulo "call_script" da Central de Conteúdo com o roteiro que hoje
+// está embutido no bundle do agente. É migração de conteúdo que já está em
+// produção, não mudança nova - por isso publica direto, sem passar pela fila.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedCallScriptNow" no seletor
+// de função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar, então não há risco de duplicar.
+
+const CONTENT_SEED_CALL_SCRIPT = {
+  "module": "call_script",
+  "items": [
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Apresentação (Nome e Time)",
+      "value": "Apresentação (Nome e Time)",
+      "sortOrder": 0
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Aviso de Gravação e Política de Privacidade",
+      "value": "Aviso de Gravação e Política de Privacidade",
+      "sortOrder": 1
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação de CID e Email",
+      "value": "Confirmação de CID e Email",
+      "sortOrder": 2
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "(Opcional) Validar autenticação da conta via link",
+      "value": "(Opcional) Validar autenticação da conta via link",
+      "sortOrder": 3
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação da Task e do AM",
+      "value": "Confirmação da Task e do AM",
+      "sortOrder": 4
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Informar tempo da ligação (30-45 min)",
+      "value": "Informar tempo da ligação (30-45 min)",
+      "sortOrder": 5
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Pedir para fechar conteúdo sensível (antes de compartilhar)",
+      "value": "Pedir para fechar conteúdo sensível (antes de compartilhar)",
+      "sortOrder": 6
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Validar Backup e Acessos Admin",
+      "value": "Validar Backup e Acessos Admin",
+      "sortOrder": 7
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "value": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "sortOrder": 8
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "value": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "sortOrder": 9
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Confirmar recebimento do acesso",
+      "value": "Confirmar recebimento do acesso",
+      "sortOrder": 10
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "value": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "sortOrder": 11
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "value": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "sortOrder": 12
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Resumo da chamada (o que foi feito e como funciona)",
+      "value": "Resumo da chamada (o que foi feito e como funciona)",
+      "sortOrder": 13
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "value": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "sortOrder": 14
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir para fechar compartilhamento de tela",
+      "value": "Pedir para fechar compartilhamento de tela",
+      "sortOrder": 15
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Próximos passos (Acompanhamento por XX dias)",
+      "value": "Próximos passos (Acompanhamento por XX dias)",
+      "sortOrder": 16
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir consentimento para teste de QA",
+      "value": "Pedir consentimento para teste de QA",
+      "sortOrder": 17
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "value": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "sortOrder": 18
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "value": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "sortOrder": 19
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Despedida",
+      "value": "Despedida",
+      "sortOrder": 20
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Olá [...], eu sou o [...], e faço parte da Equipe de Soluções Técnicas do Google. Tudo bem?",
+      "value": "Olá [...], eu sou o [...], e faço parte da Equipe de Soluções Técnicas do Google. Tudo bem?",
+      "sortOrder": 21
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Nossa ligação poderá ser gravada para fins de treinamento, qualidade e melhorias dos serviços do Google, de acordo com a nossa Política de Privacidade.",
+      "value": "Nossa ligação poderá ser gravada para fins de treinamento, qualidade e melhorias dos serviços do Google, de acordo com a nossa Política de Privacidade.",
+      "sortOrder": 22
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Por questão de segurança preciso que você me informe o seu email e CID (ou número) da conta do Ads, por favor",
+      "value": "Por questão de segurança preciso que você me informe o seu email e CID (ou número) da conta do Ads, por favor",
+      "sortOrder": 23
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação da Task e do AM",
+      "value": "Confirmação da Task e do AM",
+      "sortOrder": 24
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "A consultoria tem uma duração média de 30 a 45 minutos.",
+      "value": "A consultoria tem uma duração média de 30 a 45 minutos.",
+      "sortOrder": 25
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Peço para que compartilhe a tela usando a opção “Tela Inteira”",
+      "value": "Peço para que compartilhe a tela usando a opção “Tela Inteira”",
+      "sortOrder": 26
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Por favor, feche todo e qualquer conteúdo confidencial e sensível (conversas, dados pessoais importantes, etc).",
+      "value": "Por favor, feche todo e qualquer conteúdo confidencial e sensível (conversas, dados pessoais importantes, etc).",
+      "sortOrder": 27
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Possui o backup do seu site e todos os acessos às ferramentas do Google?",
+      "value": "Possui o backup do seu site e todos os acessos às ferramentas do Google?",
+      "sortOrder": 28
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "value": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "sortOrder": 29
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "value": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "sortOrder": 30
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Confirmar recebimento do acesso",
+      "value": "Confirmar recebimento do acesso",
+      "sortOrder": 31
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "value": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "sortOrder": 32
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "value": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "sortOrder": 33
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Resumo da chamada (o que foi feito e como funciona)",
+      "value": "Resumo da chamada (o que foi feito e como funciona)",
+      "sortOrder": 34
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "value": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "sortOrder": 35
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir para fechar compartilhamento de tela",
+      "value": "Pedir para fechar compartilhamento de tela",
+      "sortOrder": 36
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Próximos passos (Acompanhamento por XX dias)",
+      "value": "Próximos passos (Acompanhamento por XX dias)",
+      "sortOrder": 37
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Durante esse tempo, nossa equipe de qualidade poderá realizar um teste de conversão para validar a implementação. Você concorda com esse teste para garantirmos a efetividade da implementação?",
+      "value": "Durante esse tempo, nossa equipe de qualidade poderá realizar um teste de conversão para validar a implementação. Você concorda com esse teste para garantirmos a efetividade da implementação?",
+      "sortOrder": 38
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "value": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "sortOrder": 39
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "value": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "sortOrder": 40
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Despedida",
+      "value": "Despedida",
+      "sortOrder": 41
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Introducción (Nombre y Equipo).",
+      "value": "Introducción (Nombre y Equipo).",
+      "sortOrder": 42
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "La llamada puede ser grabada con fines de entrenamiento y calidad de acuerdo con nuestra política de privacidad.",
+      "value": "La llamada puede ser grabada con fines de entrenamiento y calidad de acuerdo con nuestra política de privacidad.",
+      "sortOrder": 43
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar sitio web registrado en el caso.",
+      "value": "Informar sitio web registrado en el caso.",
+      "sortOrder": 44
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación: Solicitar al Anunciante que confirme los 10 dígitos del CID el email del anunciante.",
+      "value": "Confirmación: Solicitar al Anunciante que confirme los 10 dígitos del CID el email del anunciante.",
+      "sortOrder": 45
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmaciones: Tarea, AM",
+      "value": "Confirmaciones: Tarea, AM",
+      "sortOrder": 46
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar el tiempo que va a durar la reunión.",
+      "value": "Informar el tiempo que va a durar la reunión.",
+      "sortOrder": 47
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación: Copia de seguridad y acceso de ADM",
+      "value": "Confirmación: Copia de seguridad y acceso de ADM",
+      "sortOrder": 48
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Cerrar contenido sensible antes de compartir la pantalla.",
+      "value": "Cerrar contenido sensible antes de compartir la pantalla.",
+      "sortOrder": 49
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Resumen de la llamada.",
+      "value": "Resumen de la llamada.",
+      "sortOrder": 50
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Ayuda adicional.",
+      "value": "Ayuda adicional.",
+      "sortOrder": 51
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Cerrar la pantalla compartida.",
+      "value": "Cerrar la pantalla compartida.",
+      "sortOrder": 52
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Próximos pasos (¿Cuánto tiempo seguirá el caso?)",
+      "value": "Próximos pasos (¿Cuánto tiempo seguirá el caso?)",
+      "sortOrder": 53
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Encuesta de Satisfacción.",
+      "value": "Encuesta de Satisfacción.",
+      "sortOrder": 54
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Estaré monitoreando su caso durante XX días para asegurarme de que todo esté funcionando correctamente. Durante este tiempo, nuestro equipo de calidad podría realizar una prueba de conversión para validar la implementación. ¿Estás de acuerdo con esta prueba para garantizar la efectividad de la implementación? Perfecto, ¡gracias!",
+      "value": "Estaré monitoreando su caso durante XX días para asegurarme de que todo esté funcionando correctamente. Durante este tiempo, nuestro equipo de calidad podría realizar una prueba de conversión para validar la implementación. ¿Estás de acuerdo con esta prueba para garantizar la efectividad de la implementación? Perfecto, ¡gracias!",
+      "sortOrder": 55
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Presentación (Nombre y equipo).",
+      "value": "Presentación (Nombre y equipo).",
+      "sortOrder": 56
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar al cliente sobre la llamada grabada.",
+      "value": "Informar al cliente sobre la llamada grabada.",
+      "sortOrder": 57
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Tiempo de duración de la llamada.",
+      "value": "Tiempo de duración de la llamada.",
+      "sortOrder": 58
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Solicitar al anunciante que confirme lo siguiente: \n A) 10 dígitos de la cuenta \n B) Correo electrónico \n C) Número de teléfono y \n D) Nombre del sitio web.",
+      "value": "Solicitar al anunciante que confirme lo siguiente: \n A) 10 dígitos de la cuenta \n B) Correo electrónico \n C) Número de teléfono y \n D) Nombre del sitio web.",
+      "sortOrder": 59
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "autenticar la cuenta del anunciante en el cases, si corresponde.",
+      "value": "autenticar la cuenta del anunciante en el cases, si corresponde.",
+      "sortOrder": 60
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Términos y condiciones.",
+      "value": "Términos y condiciones.",
+      "sortOrder": 61
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar las Task solicitadas y AM.",
+      "value": "Informar las Task solicitadas y AM.",
+      "sortOrder": 62
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Cerrar contenido sensible.",
+      "value": "Cerrar contenido sensible.",
+      "sortOrder": 63
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación de copia de seguridad y acceso de administrador a las herramientas.",
+      "value": "Confirmación de copia de seguridad y acceso de administrador a las herramientas.",
+      "sortOrder": 64
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Resumen de llamada.",
+      "value": "Resumen de llamada.",
+      "sortOrder": 65
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Ofrecer ayuda adicional.",
+      "value": "Ofrecer ayuda adicional.",
+      "sortOrder": 66
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Dejar de compartir la pantalla.",
+      "value": "Dejar de compartir la pantalla.",
+      "sortOrder": 67
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Pasos siguientes (Si se le hará seguimiento al caso).",
+      "value": "Pasos siguientes (Si se le hará seguimiento al caso).",
+      "sortOrder": 68
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Encuesta de Satisfacción.",
+      "value": "Encuesta de Satisfacción.",
+      "sortOrder": 69
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días.",
+      "value": "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días.",
+      "sortOrder": 70
+    }
+  ]
+};
+
+function seedCallScriptNow() {
+  const result = seedContentModule(CONTENT_SEED_CALL_SCRIPT);
+  Logger.log(result);
+  return result;
+}

--- a/gas-backend/seeds/call-script-seed.json
+++ b/gas-backend/seeds/call-script-seed.json
@@ -1,0 +1,573 @@
+{
+  "module": "call_script",
+  "items": [
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Apresentação (Nome e Time)",
+      "value": "Apresentação (Nome e Time)",
+      "sortOrder": 0
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Aviso de Gravação e Política de Privacidade",
+      "value": "Aviso de Gravação e Política de Privacidade",
+      "sortOrder": 1
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação de CID e Email",
+      "value": "Confirmação de CID e Email",
+      "sortOrder": 2
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "(Opcional) Validar autenticação da conta via link",
+      "value": "(Opcional) Validar autenticação da conta via link",
+      "sortOrder": 3
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação da Task e do AM",
+      "value": "Confirmação da Task e do AM",
+      "sortOrder": 4
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Informar tempo da ligação (30-45 min)",
+      "value": "Informar tempo da ligação (30-45 min)",
+      "sortOrder": 5
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Pedir para fechar conteúdo sensível (antes de compartilhar)",
+      "value": "Pedir para fechar conteúdo sensível (antes de compartilhar)",
+      "sortOrder": 6
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Validar Backup e Acessos Admin",
+      "value": "Validar Backup e Acessos Admin",
+      "sortOrder": 7
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "value": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "sortOrder": 8
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "value": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "sortOrder": 9
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Confirmar recebimento do acesso",
+      "value": "Confirmar recebimento do acesso",
+      "sortOrder": 10
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "value": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "sortOrder": 11
+    },
+    {
+      "key": "BAU",
+      "field": "meio",
+      "lang": "PT",
+      "label": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "value": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "sortOrder": 12
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Resumo da chamada (o que foi feito e como funciona)",
+      "value": "Resumo da chamada (o que foi feito e como funciona)",
+      "sortOrder": 13
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "value": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "sortOrder": 14
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir para fechar compartilhamento de tela",
+      "value": "Pedir para fechar compartilhamento de tela",
+      "sortOrder": 15
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Próximos passos (Acompanhamento por XX dias)",
+      "value": "Próximos passos (Acompanhamento por XX dias)",
+      "sortOrder": 16
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir consentimento para teste de QA",
+      "value": "Pedir consentimento para teste de QA",
+      "sortOrder": 17
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "value": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "sortOrder": 18
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "value": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "sortOrder": 19
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Despedida",
+      "value": "Despedida",
+      "sortOrder": 20
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Olá [...], eu sou o [...], e faço parte da Equipe de Soluções Técnicas do Google. Tudo bem?",
+      "value": "Olá [...], eu sou o [...], e faço parte da Equipe de Soluções Técnicas do Google. Tudo bem?",
+      "sortOrder": 21
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Nossa ligação poderá ser gravada para fins de treinamento, qualidade e melhorias dos serviços do Google, de acordo com a nossa Política de Privacidade.",
+      "value": "Nossa ligação poderá ser gravada para fins de treinamento, qualidade e melhorias dos serviços do Google, de acordo com a nossa Política de Privacidade.",
+      "sortOrder": 22
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Por questão de segurança preciso que você me informe o seu email e CID (ou número) da conta do Ads, por favor",
+      "value": "Por questão de segurança preciso que você me informe o seu email e CID (ou número) da conta do Ads, por favor",
+      "sortOrder": 23
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Confirmação da Task e do AM",
+      "value": "Confirmação da Task e do AM",
+      "sortOrder": 24
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "A consultoria tem uma duração média de 30 a 45 minutos.",
+      "value": "A consultoria tem uma duração média de 30 a 45 minutos.",
+      "sortOrder": 25
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Peço para que compartilhe a tela usando a opção “Tela Inteira”",
+      "value": "Peço para que compartilhe a tela usando a opção “Tela Inteira”",
+      "sortOrder": 26
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Por favor, feche todo e qualquer conteúdo confidencial e sensível (conversas, dados pessoais importantes, etc).",
+      "value": "Por favor, feche todo e qualquer conteúdo confidencial e sensível (conversas, dados pessoais importantes, etc).",
+      "sortOrder": 27
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "PT",
+      "label": "Possui o backup do seu site e todos os acessos às ferramentas do Google?",
+      "value": "Possui o backup do seu site e todos os acessos às ferramentas do Google?",
+      "sortOrder": 28
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "value": "Ofertar Implementação via Tag Support (Acesso Temporário)",
+      "sortOrder": 29
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "value": "Enviar e orientar aceite do email 'Consentimento e autorização...'",
+      "sortOrder": 30
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Confirmar recebimento do acesso",
+      "value": "Confirmar recebimento do acesso",
+      "sortOrder": 31
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "value": "Iniciar Configuração (Aviso de silêncio ~10min)",
+      "sortOrder": 32
+    },
+    {
+      "key": "LT",
+      "field": "meio",
+      "lang": "PT",
+      "label": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "value": "[Caso Recuse] Seguir com Compartilhamento de Tela",
+      "sortOrder": 33
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Resumo da chamada (o que foi feito e como funciona)",
+      "value": "Resumo da chamada (o que foi feito e como funciona)",
+      "sortOrder": 34
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "value": "Oferecer ajuda adicional / Abrir para dúvidas",
+      "sortOrder": 35
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pedir para fechar compartilhamento de tela",
+      "value": "Pedir para fechar compartilhamento de tela",
+      "sortOrder": 36
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Próximos passos (Acompanhamento por XX dias)",
+      "value": "Próximos passos (Acompanhamento por XX dias)",
+      "sortOrder": 37
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Durante esse tempo, nossa equipe de qualidade poderá realizar um teste de conversão para validar a implementação. Você concorda com esse teste para garantirmos a efetividade da implementação?",
+      "value": "Durante esse tempo, nossa equipe de qualidade poderá realizar um teste de conversão para validar a implementação. Você concorda com esse teste para garantirmos a efetividade da implementação?",
+      "sortOrder": 38
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "value": "Alinhar escopo (Técnico vs. Gerente de Contas)",
+      "sortOrder": 39
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "value": "Pesquisa de Satisfação (e confirmar email para envio)",
+      "sortOrder": 40
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "PT",
+      "label": "Despedida",
+      "value": "Despedida",
+      "sortOrder": 41
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Introducción (Nombre y Equipo).",
+      "value": "Introducción (Nombre y Equipo).",
+      "sortOrder": 42
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "La llamada puede ser grabada con fines de entrenamiento y calidad de acuerdo con nuestra política de privacidad.",
+      "value": "La llamada puede ser grabada con fines de entrenamiento y calidad de acuerdo con nuestra política de privacidad.",
+      "sortOrder": 43
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar sitio web registrado en el caso.",
+      "value": "Informar sitio web registrado en el caso.",
+      "sortOrder": 44
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación: Solicitar al Anunciante que confirme los 10 dígitos del CID el email del anunciante.",
+      "value": "Confirmación: Solicitar al Anunciante que confirme los 10 dígitos del CID el email del anunciante.",
+      "sortOrder": 45
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmaciones: Tarea, AM",
+      "value": "Confirmaciones: Tarea, AM",
+      "sortOrder": 46
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar el tiempo que va a durar la reunión.",
+      "value": "Informar el tiempo que va a durar la reunión.",
+      "sortOrder": 47
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación: Copia de seguridad y acceso de ADM",
+      "value": "Confirmación: Copia de seguridad y acceso de ADM",
+      "sortOrder": 48
+    },
+    {
+      "key": "BAU",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Cerrar contenido sensible antes de compartir la pantalla.",
+      "value": "Cerrar contenido sensible antes de compartir la pantalla.",
+      "sortOrder": 49
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Resumen de la llamada.",
+      "value": "Resumen de la llamada.",
+      "sortOrder": 50
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Ayuda adicional.",
+      "value": "Ayuda adicional.",
+      "sortOrder": 51
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Cerrar la pantalla compartida.",
+      "value": "Cerrar la pantalla compartida.",
+      "sortOrder": 52
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Próximos pasos (¿Cuánto tiempo seguirá el caso?)",
+      "value": "Próximos pasos (¿Cuánto tiempo seguirá el caso?)",
+      "sortOrder": 53
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Encuesta de Satisfacción.",
+      "value": "Encuesta de Satisfacción.",
+      "sortOrder": 54
+    },
+    {
+      "key": "BAU",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Estaré monitoreando su caso durante XX días para asegurarme de que todo esté funcionando correctamente. Durante este tiempo, nuestro equipo de calidad podría realizar una prueba de conversión para validar la implementación. ¿Estás de acuerdo con esta prueba para garantizar la efectividad de la implementación? Perfecto, ¡gracias!",
+      "value": "Estaré monitoreando su caso durante XX días para asegurarme de que todo esté funcionando correctamente. Durante este tiempo, nuestro equipo de calidad podría realizar una prueba de conversión para validar la implementación. ¿Estás de acuerdo con esta prueba para garantizar la efectividad de la implementación? Perfecto, ¡gracias!",
+      "sortOrder": 55
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Presentación (Nombre y equipo).",
+      "value": "Presentación (Nombre y equipo).",
+      "sortOrder": 56
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar al cliente sobre la llamada grabada.",
+      "value": "Informar al cliente sobre la llamada grabada.",
+      "sortOrder": 57
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Tiempo de duración de la llamada.",
+      "value": "Tiempo de duración de la llamada.",
+      "sortOrder": 58
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Solicitar al anunciante que confirme lo siguiente: \n A) 10 dígitos de la cuenta \n B) Correo electrónico \n C) Número de teléfono y \n D) Nombre del sitio web.",
+      "value": "Solicitar al anunciante que confirme lo siguiente: \n A) 10 dígitos de la cuenta \n B) Correo electrónico \n C) Número de teléfono y \n D) Nombre del sitio web.",
+      "sortOrder": 59
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "autenticar la cuenta del anunciante en el cases, si corresponde.",
+      "value": "autenticar la cuenta del anunciante en el cases, si corresponde.",
+      "sortOrder": 60
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Términos y condiciones.",
+      "value": "Términos y condiciones.",
+      "sortOrder": 61
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Informar las Task solicitadas y AM.",
+      "value": "Informar las Task solicitadas y AM.",
+      "sortOrder": 62
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Cerrar contenido sensible.",
+      "value": "Cerrar contenido sensible.",
+      "sortOrder": 63
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Confirmación de copia de seguridad y acceso de administrador a las herramientas.",
+      "value": "Confirmación de copia de seguridad y acceso de administrador a las herramientas.",
+      "sortOrder": 64
+    },
+    {
+      "key": "LT",
+      "field": "inicio",
+      "lang": "ES",
+      "label": "Resumen de llamada.",
+      "value": "Resumen de llamada.",
+      "sortOrder": 65
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Ofrecer ayuda adicional.",
+      "value": "Ofrecer ayuda adicional.",
+      "sortOrder": 66
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Dejar de compartir la pantalla.",
+      "value": "Dejar de compartir la pantalla.",
+      "sortOrder": 67
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Pasos siguientes (Si se le hará seguimiento al caso).",
+      "value": "Pasos siguientes (Si se le hará seguimiento al caso).",
+      "sortOrder": 68
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Encuesta de Satisfacción.",
+      "value": "Encuesta de Satisfacción.",
+      "sortOrder": 69
+    },
+    {
+      "key": "LT",
+      "field": "fim",
+      "lang": "ES",
+      "label": "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días.",
+      "value": "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días.",
+      "sortOrder": 70
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "esbuild src/app.js --bundle --outfile=dist/bundle-dev.js",
     "portfolio": "python3 generate-portfolio.py",
     "test:content": "node scripts/test-content-api.js",
-    "seed:links": "node scripts/generate-links-seed.mjs"
+    "test:call-script": "node scripts/test-call-script-roundtrip.mjs",
+    "seed:links": "node scripts/generate-links-seed.mjs",
+    "seed:call-script": "node scripts/generate-call-script-seed.mjs"
   },
   "dependencies": {
     "esbuild": "^0.27.4",

--- a/scripts/generate-call-script-seed.mjs
+++ b/scripts/generate-call-script-seed.mjs
@@ -1,0 +1,145 @@
+// scripts/generate-call-script-seed.mjs
+//
+// Gera a semeadura do módulo "call_script" a partir do csaChecklistData que
+// hoje está embutido em src/modules/call-script/call-script-data.js.
+//
+// Escreve dois arquivos, ambos versionados:
+//   - gas-backend/seeds/call-script-seed.json  (para inspecionar o conteúdo)
+//   - gas-backend/ContentSeed_CallScript.js    (o que realmente roda)
+//
+// A semeadura é feita escolhendo `seedCallScriptNow` no seletor de função do
+// editor do Apps Script e clicando em Executar - o botão Run só aceita funções
+// sem argumentos, daí o wrapper.
+//
+// Rode apenas para regerar os arquivos depois de mexer no csaChecklistData:
+//   npm run seed:call-script
+//
+// --- Normalização aplicada na migração ---
+// Hoje a chave é combinada ("PT BAU", "ES LT"), misturando idioma e fluxo num
+// campo só. Na Central isso vira `lang` (PT/ES) + `key` (BAU/LT), que é o que
+// a coluna `lang` existe para carregar. O front remonta a chave combinada ao
+// ler, então o comportamento não muda.
+//
+// Cada PASSO vira um item próprio (e não a lista inteira num blob), pra poder
+// editar, reordenar e traduzir um passo isolado pela tela.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+    resolve(here, '../src/modules/call-script/call-script-data.js'),
+    'utf8'
+);
+
+// Recorta um literal pelo nome, contando delimitadores. Regex sozinha não
+// serve: os textos dos passos contêm chaves, colchetes e aspas.
+function extractLiteral(name, open, close) {
+    const start = source.indexOf(`const ${name} = ${open}`);
+    if (start === -1) throw new Error(`Não encontrei ${name} em call-script-data.js`);
+
+    const from = source.indexOf(open, start);
+    let depth = 0;
+    let inString = null;
+
+    for (let i = from; i < source.length; i++) {
+        const ch = source[i];
+        const prev = source[i - 1];
+
+        if (inString) {
+            if (ch === inString && prev !== '\\') inString = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'" || ch === '`') { inString = ch; continue; }
+        if (ch === open) depth++;
+        else if (ch === close) {
+            depth--;
+            if (depth === 0) return source.slice(from, i + 1);
+        }
+    }
+
+    throw new Error(`Literal de ${name} não fecha`);
+}
+
+// O objeto referencia TAG_SUPPORT_STEPS_PT (a seção de Tag Support é
+// compartilhada entre BAU e LT em PT), então essa const precisa existir no
+// escopo do eval - senão o literal não resolve.
+const tagSupportLiteral = extractLiteral('TAG_SUPPORT_STEPS_PT', '[', ']');
+const dataLiteral = extractLiteral('csaChecklistData', '{', '}').replace(/^export\s+/, '');
+
+// eslint-disable-next-line no-new-func
+const csaChecklistData = new Function(
+    `const TAG_SUPPORT_STEPS_PT = ${tagSupportLiteral};\nreturn (${dataLiteral});`
+)();
+
+const GROUPS = ['inicio', 'meio', 'fim'];
+const items = [];
+let order = 0;
+
+for (const [combinedKey, groups] of Object.entries(csaChecklistData)) {
+    const [lang, flow] = combinedKey.split(' ');
+
+    for (const group of GROUPS) {
+        const steps = groups[group];
+        if (!steps) continue; // ES ainda não tem `meio` - ver nota abaixo.
+
+        steps.forEach((text, idx) => {
+            items.push({
+                key: flow,        // BAU | LT
+                field: group,     // inicio | meio | fim
+                lang: lang,       // PT | ES
+                label: text,      // o passo é o próprio conteúdo
+                value: text,
+                sortOrder: order++,
+                _stepIndex: idx
+            });
+        });
+    }
+}
+
+// A ausência de `meio` em ES é conteúdo que nunca chegou, não bug - está
+// documentado no próprio call-script-data.js. Fica registrado aqui pra ser o
+// primeiro uso real da Central: dá pra preencher pela tela, sem tocar em código.
+const combos = Object.keys(csaChecklistData);
+const semMeio = combos.filter(k => !csaChecklistData[k].meio);
+
+// `_stepIndex` era só para conferência; não vai para a planilha.
+const clean = items.map(({ _stepIndex, ...rest }) => rest);
+const payload = { module: 'call_script', items: clean };
+
+writeFileSync(
+    resolve(here, '../gas-backend/seeds/call-script-seed.json'),
+    JSON.stringify(payload, null, 2) + '\n'
+);
+
+const gasFile = `// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:call-script (lê o csaChecklistData de
+// src/modules/call-script/call-script-data.js)
+//
+// Semeia o módulo "call_script" da Central de Conteúdo com o roteiro que hoje
+// está embutido no bundle do agente. É migração de conteúdo que já está em
+// produção, não mudança nova - por isso publica direto, sem passar pela fila.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedCallScriptNow" no seletor
+// de função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar, então não há risco de duplicar.
+
+const CONTENT_SEED_CALL_SCRIPT = ${JSON.stringify(payload, null, 2)};
+
+function seedCallScriptNow() {
+  const result = seedContentModule(CONTENT_SEED_CALL_SCRIPT);
+  Logger.log(result);
+  return result;
+}
+`;
+
+writeFileSync(resolve(here, '../gas-backend/ContentSeed_CallScript.js'), gasFile);
+
+process.stdout.write(
+    `${clean.length} passos em ${combos.length} roteiros (${combos.join(', ')})\n` +
+    (semMeio.length
+        ? `Sem a seção "meio" (Tag Support), a preencher pela Central: ${semMeio.join(', ')}\n`
+        : '') +
+    'Gerados: gas-backend/seeds/call-script-seed.json e gas-backend/ContentSeed_CallScript.js\n'
+);

--- a/scripts/test-call-script-roundtrip.mjs
+++ b/scripts/test-call-script-roundtrip.mjs
@@ -1,0 +1,145 @@
+// scripts/test-call-script-roundtrip.mjs
+//
+// Prova que a migração do Call Script é SEM PERDA: semear a planilha a partir do
+// csaChecklistData e depois reconstruir a partir do que foi semeado tem que
+// devolver exatamente o roteiro original - mesmos passos, mesma ordem, mesmas
+// seções, mesmos idiomas e fluxos.
+//
+// É o risco central desta fase. O seed reorganiza a chave combinada ("PT BAU")
+// em colunas separadas (lang + key), e um erro nessa tradução ida-e-volta
+// entregaria ao agente um roteiro fora de ordem ou incompleto - sem quebrar
+// nada visivelmente, que é o pior tipo de falha.
+//
+// Roda o módulo real (não uma cópia da lógica), empacotado com esbuild porque
+// ele importa o DataService, que toca `window` já na carga.
+//
+// Uso: npm run test:call-script
+
+import { build } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// --- Stubs de navegador, o mínimo pra importar o módulo ---
+const store = {};
+globalThis.window = { location: { hostname: 'localhost' } };
+globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+};
+globalThis.document = { createElement: () => ({}), body: { appendChild() { }, contains: () => false } };
+
+const bundled = await build({
+    entryPoints: [resolve(here, '../src/modules/call-script/call-script-data.js')],
+    bundle: true,
+    write: false,
+    format: 'cjs',
+    platform: 'node',
+    logLevel: 'silent',
+});
+
+const mod = { exports: {} };
+// eslint-disable-next-line no-new-func
+new Function('module', 'exports', 'require', bundled.outputFiles[0].text)(mod, mod.exports, require);
+
+const { csaChecklistData, applyCallScriptContent } = mod.exports;
+
+// Snapshot do roteiro original ANTES de qualquer hidratação.
+const original = JSON.parse(JSON.stringify(csaChecklistData));
+
+// O payload que a semeadura publica.
+const seed = JSON.parse(
+    readFileSync(resolve(here, '../gas-backend/seeds/call-script-seed.json'), 'utf8')
+);
+
+// A Central devolve os itens como o backend os entrega ao front.
+const asServed = seed.items.map((it, idx) => ({
+    key: it.key,
+    field: it.field,
+    lang: it.lang,
+    label: it.label,
+    value: it.value,
+    sortOrder: it.sortOrder ?? idx,
+}));
+
+// Embaralha de propósito: a ordem correta tem que vir do sortOrder, não da
+// ordem em que as linhas voltaram da planilha.
+for (let i = asServed.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [asServed[i], asServed[j]] = [asServed[j], asServed[i]];
+}
+
+const applied = applyCallScriptContent(asServed);
+
+let fail = 0;
+function check(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+
+console.log('\n--- Round-trip do Call Script ---');
+
+check('a hidratação foi aplicada', () => {
+    if (!applied) throw new Error('applyCallScriptContent devolveu false');
+});
+
+check('mesmos roteiros, sem sobrar nem faltar', () => {
+    const a = Object.keys(original).sort().join('|');
+    const b = Object.keys(csaChecklistData).sort().join('|');
+    if (a !== b) throw new Error(`esperado ${a}, veio ${b}`);
+});
+
+check('cada roteiro tem as mesmas seções', () => {
+    for (const key of Object.keys(original)) {
+        const a = Object.keys(original[key]).sort().join(',');
+        const b = Object.keys(csaChecklistData[key]).sort().join(',');
+        if (a !== b) throw new Error(`${key}: esperado [${a}], veio [${b}]`);
+    }
+});
+
+check('todos os passos batem, na ordem exata', () => {
+    for (const key of Object.keys(original)) {
+        for (const group of Object.keys(original[key])) {
+            const a = original[key][group];
+            const b = csaChecklistData[key][group];
+
+            if (a.length !== b.length) {
+                throw new Error(`${key}/${group}: ${a.length} passos viraram ${b.length}`);
+            }
+            for (let i = 0; i < a.length; i++) {
+                if (a[i] !== b[i]) {
+                    throw new Error(
+                        `${key}/${group}[${i}] divergiu:\n        original: ${JSON.stringify(a[i])}\n        veio:     ${JSON.stringify(b[i])}`
+                    );
+                }
+            }
+        }
+    }
+});
+
+check('quebras de linha dentro de um passo sobrevivem', () => {
+    // "ES LT" tem um passo com \n separando alternativas (A/B/C/D). Se algum dia
+    // o pipeline achatar isso, o agente lê um passo ilegível na ligação.
+    const comQuebra = Object.values(original)
+        .flatMap(g => Object.values(g).flat())
+        .filter(s => s.includes('\n'));
+
+    if (!comQuebra.length) throw new Error('nenhum passo multilinha no original — teste perdeu o alvo');
+
+    const depois = Object.values(csaChecklistData)
+        .flatMap(g => Object.values(g).flat())
+        .filter(s => s.includes('\n'));
+
+    if (depois.length !== comQuebra.length) {
+        throw new Error(`${comQuebra.length} passos multilinha viraram ${depois.length}`);
+    }
+});
+
+const total = Object.values(original).flatMap(g => Object.values(g).flat()).length;
+console.log('\n' + (fail ? '✗' : '✓') + ` round-trip de ${total} passos, ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -360,5 +360,75 @@ check('validação de módulo desconhecido', () => {
   throws(() => api.listContentItems('inexistente'), /Módulo desconhecido/);
 });
 
+check('seedCallScriptNow() popula o roteiro numa planilha zerada', () => {
+  const freshSS = new FakeSpreadsheet();
+  const freshCtx = vm.createContext({
+    SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    MailApp: { sendEmail: () => { } },
+    Logger: { log: () => { } },
+    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    handleLog: () => { },
+    console,
+  });
+
+  vm.runInContext(fs.readFileSync(SRC, 'utf8'), freshCtx);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, '..', 'gas-backend', 'ContentSeed_CallScript.js'), 'utf8'),
+    freshCtx
+  );
+
+  const res = freshCtx.seedCallScriptNow();
+  eq(res.status, 'success');
+
+  const live = freshCtx.listContentItems('call_script');
+  eq(live.length, res.seeded);
+
+  // A normalização é o ponto da migração: idioma e fluxo deixam de viver
+  // grudados numa chave só ("PT BAU") e passam a ser colunas separadas.
+  const langs = new Set(live.map(i => i.lang));
+  const flows = new Set(live.map(i => i.key));
+  eq([...langs].sort(), ['ES', 'PT']);
+  eq([...flows].sort(), ['BAU', 'LT']);
+
+  const groups = new Set(live.map(i => i.field));
+  [...groups].forEach(g => {
+    if (!['inicio', 'meio', 'fim'].includes(g)) throw new Error('seção inesperada: ' + g);
+  });
+
+  const lineages = new Set(live.map(i => i.lineage));
+  eq(lineages.size, live.length, 'linhagens únicas por passo:');
+});
+
+check('a ordem dos passos sobrevive à semeadura', () => {
+  // Num roteiro, ordem é conteúdo: um passo fora de lugar é um roteiro errado.
+  const seed = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'gas-backend', 'seeds', 'call-script-seed.json'), 'utf8')
+  );
+
+  const ptBauInicio = seed.items
+    .filter(i => i.lang === 'PT' && i.key === 'BAU' && i.field === 'inicio')
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  if (ptBauInicio.length < 5) throw new Error('poucos passos em PT BAU/inicio');
+  if (!/Apresenta/i.test(ptBauInicio[0].value)) {
+    throw new Error('primeiro passo não é a apresentação: ' + ptBauInicio[0].value);
+  }
+});
+
+check('ES ainda não tem a seção de Tag Support (lacuna conhecida)', () => {
+  // Não é bug: é conteúdo que nunca chegou, e agora dá pra preencher pela
+  // Central sem tocar em código. O teste existe pra avisar quando mudar.
+  const seed = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'gas-backend', 'seeds', 'call-script-seed.json'), 'utf8')
+  );
+
+  const esMeio = seed.items.filter(i => i.lang === 'ES' && i.field === 'meio');
+  const ptMeio = seed.items.filter(i => i.lang === 'PT' && i.field === 'meio');
+
+  eq(esMeio.length, 0, 'ES segue sem passos de Tag Support:');
+  if (!ptMeio.length) throw new Error('PT deveria ter a seção de Tag Support');
+});
+
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);
 process.exit(fail ? 1 : 0);

--- a/src/modules/call-script/call-script-assistant.js
+++ b/src/modules/call-script/call-script-assistant.js
@@ -14,7 +14,7 @@ import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 import { getPageData } from "../shared/page-data.js";
 
-import { csaChecklistData } from "./call-script-data.js";
+import { csaChecklistData, hydrateCallScriptFromContentCentral } from "./call-script-data.js";
 import { getLanguage, onLanguageChange } from "../shared/i18n.js";
 
 const CSA_DICT = {
@@ -714,5 +714,11 @@ export function initCallScriptAssistant() {
   }
 
   csaBuildChecklist();
+
+  // Busca o roteiro publicado na Central de Conteúdo e repinta quando chegar.
+  // Não bloqueia: a tela já subiu com o roteiro embutido, então API fora do ar
+  // deixa tudo exatamente como era antes.
+  hydrateCallScriptFromContentCentral(() => csaBuildChecklist());
+
   return toggleVisibility;
 }

--- a/src/modules/call-script/call-script-data.js
+++ b/src/modules/call-script/call-script-data.js
@@ -1,5 +1,7 @@
 // src/modules/call-script/call-script-data.js
 
+import { DataService } from "../shared/data-service.js";
+
 // Seção "meio" (Implementação via Tag Support) é palavra-por-palavra igual entre
 // BAU e LT em PT — extraída pra uma constante única pra não divergir por acidente
 // se um dia precisar editar só uma cópia e esquecer da outra.
@@ -72,3 +74,54 @@ export const csaChecklistData = {
         fim: ["Ofrecer ayuda adicional.", "Dejar de compartir la pantalla.", "Pasos siguientes (Si se le hará seguimiento al caso).", "Encuesta de Satisfacción.", "Informar al cliente que el equipo de QA irá a realizar pruebas en los siguientes días."]
     }
 };
+
+// --- HIDRATAÇÃO PELA CENTRAL DE CONTEÚDO ---
+// O csaChecklistData acima deixa de ser a fonte da verdade e vira o fallback:
+// é o que aparece no primeiro load offline, quando não há resposta da API nem
+// cache local. Publicado o roteiro na Central, ele vence.
+//
+// Na planilha o roteiro é normalizado: cada passo é um item, com `lang` (PT/ES)
+// e `key` (BAU/LT) separados - aqui eles voltam a formar a chave combinada
+// ("PT BAU") que o resto do módulo já usa, então nada mais precisou mudar.
+const GROUP_ORDER = ['inicio', 'meio', 'fim'];
+
+export function applyCallScriptContent(items) {
+    if (!Array.isArray(items) || !items.length) return false;
+
+    const rebuilt = {};
+
+    // Ordena pelo sortOrder antes de agrupar: a ordem dos passos é o conteúdo
+    // aqui, um roteiro fora de ordem é um roteiro errado.
+    const sorted = items.slice().sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+
+    for (const item of sorted) {
+        const lang = (item.lang || '').toUpperCase();
+        const flow = item.key || '';
+        const group = item.field || '';
+        const text = item.value || '';
+
+        if (!lang || !flow || !GROUP_ORDER.includes(group) || !text) continue;
+
+        const combinedKey = `${lang} ${flow}`;
+        if (!rebuilt[combinedKey]) rebuilt[combinedKey] = {};
+        (rebuilt[combinedKey][group] = rebuilt[combinedKey][group] || []).push(text);
+    }
+
+    if (!Object.keys(rebuilt).length) return false;
+
+    for (const key of Object.keys(csaChecklistData)) delete csaChecklistData[key];
+    Object.assign(csaChecklistData, rebuilt);
+    return true;
+}
+
+export async function hydrateCallScriptFromContentCentral(onReady) {
+    const cached = DataService.getCachedContent('call_script');
+    if (applyCallScriptContent(cached)) onReady?.();
+
+    try {
+        const items = await DataService.fetchContentModule('call_script');
+        if (applyCallScriptContent(items)) onReady?.();
+    } catch (e) {
+        console.warn('Central de Conteúdo indisponível; usando roteiro embutido.', e);
+    }
+}


### PR DESCRIPTION
Segue o mesmo processo da Fase 1 (Links): gerador → wrapper sem argumentos → teste com planilha zerada → fallback embutido no front.

## Normalização na migração

Hoje a chave do roteiro é **combinada** (`"PT BAU"`, `"ES LT"`), misturando idioma e fluxo num campo só. Na planilha isso vira `lang` (PT/ES) + `key` (BAU/LT) — que é exatamente o que a coluna `lang` existe para carregar. O front remonta a chave combinada ao ler, então **nenhuma outra parte do módulo precisou mudar**.

Cada **passo** é um item próprio, e não a lista inteira num blob, pra dar pra editar, reordenar e traduzir um passo isolado pela tela.

## Semeadura

`npm run seed:call-script` gera `ContentSeed_CallScript.js` com o wrapper `seedCallScriptNow()` — sem argumentos, como exige o botão Executar do editor — e o JSON de inspeção. **71 passos em 4 roteiros.**

## Tela

Aba **Call Script** com seletor de idioma e fluxo, passos agrupados por seção (Início / Implementação / Encerramento) e numerados. Mesmo fluxo de proposta e aprovação dos links; papel sem permissão vê em modo leitura.

A **lacuna conhecida do ES** (sem a seção de Tag Support) aparece explicitamente como seção vazia com convite a preencher, em vez de sumir da tela — é conteúdo que nunca chegou, e agora dá pra preencher sem tocar em código. Era o primeiro caso de uso real previsto quando a Central foi desenhada.

## Testes

- **`test:content`** sobe pra **30 casos**: semeadura em planilha zerada, normalização lang/key, seções válidas e linhagem única por passo.
- **`test:call-script`** (novo): prova que a migração é **sem perda**. Semeia a partir do roteiro original, **embaralha os itens de propósito** (a ordem correta tem que vir do `sortOrder`, não da ordem em que as linhas voltaram) e reconstrói, exigindo os mesmos passos na ordem exata. Cobre também passos **multilinha** — que um pipeline descuidado achataria sem quebrar nada visivelmente, que é o pior tipo de falha num roteiro de ligação.

## Depois do merge

Rodar **`seedCallScriptNow`** no editor do Apps Script, como foi feito com os links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)