### PR TITLE
feat(content-central): Fase 4 — modelos de e-mail com validação de placeholder

### DIFF
--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -283,6 +283,79 @@ function logContentEvent_(ldap, action, label, value) {
   }
 }
 
+// Tokens no formato [Alguma Coisa] - o mesmo que os modelos de e-mail já usam.
+const EMAIL_TOKEN_RE = /\[[^\][]{2,60}\]/g;
+
+/**
+ * Valida um modelo de e-mail antes de virar rascunho.
+ *
+ * As duas falhas que isso impede são silenciosas e caras, porque o e-mail vai
+ * para o anunciante:
+ *   - placeholder declarado que não existe no corpo: o agente preenche um campo
+ *     que não vai a lugar nenhum;
+ *   - token no corpo que ninguém declarou: o agente nem vê o campo, e o texto
+ *     sai LITERAL ("Olá, [Nome do Cliente],").
+ *
+ * Em ES só os rótulos são traduzidos - as chaves seguem as de PT, porque são
+ * elas que aparecem no corpo. Por isso a checagem de declaração vale para PT, e
+ * em ES o que se exige é que o corpo traduzido não tenha perdido nenhum token.
+ */
+function assertValidEmailTemplate_(rawValue, lang) {
+  let parsed;
+  try {
+    parsed = JSON.parse(rawValue || '{}');
+  } catch (e) {
+    throw new Error("Conteúdo do e-mail inválido (JSON malformado).");
+  }
+
+  const subject = String(parsed.subject || "").trim();
+  const body = String(parsed.template || "").trim();
+
+  if (!subject) throw new Error("O e-mail precisa de um assunto.");
+  if (!body) throw new Error("O e-mail precisa de um corpo.");
+
+  const full = subject + " " + body;
+  const noCorpo = (full.match(EMAIL_TOKEN_RE) || []).filter(function (v, i, a) {
+    return a.indexOf(v) === i;
+  });
+
+  if (String(lang).toUpperCase() === 'ES') {
+    // Sem `placeholders` próprio: a referência é a linha PT do mesmo template.
+    return { tokens: noCorpo };
+  }
+
+  const declarados = (parsed.placeholders || []).map(function (p) { return String(p.key || ""); });
+
+  const semUso = declarados.filter(function (k) { return k && full.indexOf(k) === -1; });
+  if (semUso.length) {
+    throw new Error(
+      "Estes campos estão declarados mas não aparecem no e-mail: " + semUso.join(", ") +
+      ". Use-os no texto ou remova a declaração."
+    );
+  }
+
+  const semDeclarar = noCorpo.filter(function (k) { return declarados.indexOf(k) === -1; });
+  if (semDeclarar.length) {
+    throw new Error(
+      "Estes trechos aparecem no e-mail mas não estão declarados como campo: " + semDeclarar.join(", ") +
+      ". Sem declarar, o texto sai literal para o anunciante."
+    );
+  }
+
+  return { tokens: noCorpo };
+}
+
+// Exposta para a tela conseguir avisar ANTES de salvar, em vez de o agente
+// descobrir o erro só ao tentar enviar.
+function checkEmailTemplate(rawValue, lang) {
+  try {
+    assertValidEmailTemplate_(rawValue, lang);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
 // =========================================================
 //  LEITURA
 // =========================================================
@@ -429,6 +502,9 @@ function saveContentDraft(payload) {
   }
   if (p.module === 'case_note_snippet') {
     assertValidNoteField_(String(p.field || ""));
+  }
+  if (p.module === 'email_template') {
+    assertValidEmailTemplate_(String(p.value || ""), String(p.lang || 'PT'));
   }
 
   const sheet = getContentSheet_(SHEET_CONTENT_DRAFTS);

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -663,6 +663,9 @@
                 <button class="tab-btn" role="tab" data-tab="notes" onclick="switchTab('notes')">
                     <span class="material-symbols-rounded" style="font-size:19px">edit_note</span> Case Notes
                 </button>
+                <button class="tab-btn" role="tab" data-tab="emails" onclick="switchTab('emails')">
+                    <span class="material-symbols-rounded" style="font-size:19px">mail</span> E-mails
+                </button>
                 <button class="tab-btn" role="tab" data-tab="approvals" onclick="switchTab('approvals')">
                     <span class="material-symbols-rounded" style="font-size:19px">rule</span> Aprovações
                     <span class="count-chip zero" id="pending-count">0</span>
@@ -670,9 +673,7 @@
                 <button class="tab-btn hidden" role="tab" data-tab="access" onclick="switchTab('access')" id="tab-access">
                     <span class="material-symbols-rounded" style="font-size:19px">manage_accounts</span> Acessos
                 </button>
-                <button class="tab-btn" role="tab" data-tab="soon" onclick="switchTab('soon')">
-                    <span class="material-symbols-rounded" style="font-size:19px">schedule</span> Próximos módulos
-                </button>
+
             </div>
 
             <!-- TAB: Links -->
@@ -753,6 +754,31 @@
                 </div>
             </section>
 
+            <!-- TAB: E-mails -->
+            <section id="pane-emails" class="hidden">
+                <div class="note" id="em-note">
+                    Modelos do assistente do agente. Não inclui os e-mails de CR nem os
+                    disparados pelo Dashboard de TL.
+                </div>
+                <div class="row-between" style="margin-bottom:14px">
+                    <div>
+                        <label class="fld" style="margin-top:0" for="em-lang">Idioma</label>
+                        <select id="em-lang" onchange="renderEmails()">
+                            <option value="PT">PT</option>
+                            <option value="ES">ES</option>
+                        </select>
+                    </div>
+                    <button class="btn btn-primary hidden" id="em-new-btn" disabled
+                        title="Criar modelo novo ainda não é suportado — por ora, edite os existentes.">
+                        Novo modelo
+                    </button>
+                </div>
+                <div class="card" id="em-list">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+            </section>
+
             <!-- TAB: Aprovações -->
             <section id="pane-approvals" class="hidden">
                 <div id="approvals-list">
@@ -795,22 +821,6 @@
             </section>
 
             <!-- TAB: Próximos módulos -->
-            <section id="pane-soon" class="hidden">
-                <div class="card">
-                    <div class="card-title">Ainda não migrado</div>
-                    <p class="card-sub" style="margin-bottom:16px">
-                        Links, Call Script e Case Notes já são editáveis nas abas acima. Falta o último módulo.
-                    </p>
-                    <div class="item-row">
-                        <div class="item-main">
-                            <div class="item-name">E-mails do assistente</div>
-                            <div class="item-meta">Editor ciente de placeholder e preview do HTML antes de publicar. Não
-                                inclui os e-mails de CR nem os enviados pelo Dashboard de TL.</div>
-                        </div>
-                        <span class="pill draft">Fase 4</span>
-                    </div>
-                </div>
-            </section>
         </main>
     </div>
 
@@ -863,6 +873,9 @@
             if (!document.getElementById('pane-notes').classList.contains('hidden')) {
                 loadNoteSnippets();
             }
+            if (!document.getElementById('pane-emails').classList.contains('hidden')) {
+                loadEmails();
+            }
         }
 
         // A UI é conveniência, não a fronteira: o servidor recusa a ação de
@@ -873,7 +886,7 @@
         }
 
         function switchTab(tab) {
-            ['links', 'callscript', 'notes', 'approvals', 'access', 'soon'].forEach(function (t) {
+            ['links', 'callscript', 'notes', 'emails', 'approvals', 'access'].forEach(function (t) {
                 var pane = document.getElementById('pane-' + t);
                 if (pane) pane.classList.toggle('hidden', t !== tab);
             });
@@ -882,6 +895,7 @@
             });
             if (tab === 'callscript') loadCallScript();
             if (tab === 'notes') loadNoteSnippets();
+            if (tab === 'emails') loadEmails();
             if (tab === 'approvals') loadApprovals();
             if (tab === 'access') loadAccess();
         }
@@ -915,6 +929,10 @@
                         document.getElementById('cs-new-btn').classList.add('hidden');
                         document.getElementById('cs-note').textContent =
                             'Seu papel (' + s.role + ') vê o roteiro, mas não propõe alterações neste módulo.';
+                    }
+                    if (!canPropose('email_template')) {
+                        document.getElementById('em-note').textContent =
+                            'Seu papel (' + s.role + ') vê os modelos, mas não propõe alterações neste módulo.';
                     }
                     if (!canPropose('case_note_snippet')) {
                         document.getElementById('nt-new-btn').classList.add('hidden');
@@ -1563,6 +1581,227 @@
                     label: title,
                     value: text
                 });
+        }
+
+        // --- E-mails ---
+        var EM_ITEMS = [];
+        var EM_DRAFTS = [];
+
+        function loadEmails() {
+            google.script.run
+                .withSuccessHandler(function (items) {
+                    EM_ITEMS = items || [];
+                    google.script.run
+                        .withSuccessHandler(function (d) { EM_DRAFTS = d || []; renderEmails(); })
+                        .withFailureHandler(function () { EM_DRAFTS = []; renderEmails(); })
+                        .listContentDrafts('email_template');
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('em-list').innerHTML =
+                        '<div class="state"><span class="material-symbols-rounded">error</span>' +
+                        '<h2>Não foi possível carregar os modelos</h2><p>' + esc(err.message) + '</p></div>';
+                })
+                .listContentItems('email_template');
+        }
+
+        function emDraftForItem(itemId) {
+            for (var i = 0; i < EM_DRAFTS.length; i++) {
+                if (EM_DRAFTS[i].itemId === itemId) return EM_DRAFTS[i];
+            }
+            return null;
+        }
+
+        function parseEmail(raw) {
+            try { return JSON.parse(raw || '{}'); } catch (e) { return {}; }
+        }
+
+        function renderEmails() {
+            var host = document.getElementById('em-list');
+            var lang = document.getElementById('em-lang').value;
+            var mine = EM_ITEMS.filter(function (i) { return i.lang === lang; });
+
+            if (!mine.length) {
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded">mail</span>' +
+                    '<h2>Nenhum modelo publicado em ' + esc(lang) + '</h2>' +
+                    '<p>Enquanto isso o assistente segue com os modelos embutidos no código. ' +
+                    'Rode a semeadura (seedEmailsNow) para trazer os atuais.</p></div>';
+                return;
+            }
+
+            var byCat = {};
+            mine.forEach(function (it) { (byCat[it.field || 'Sem categoria'] = byCat[it.field || 'Sem categoria'] || []).push(it); });
+
+            var html = '';
+            Object.keys(byCat).sort().forEach(function (cat) {
+                html += '<div class="cat-head">' + esc(cat) +
+                    ' <span class="pill draft">' + byCat[cat].length + '</span></div>';
+
+                byCat[cat].forEach(function (it) {
+                    var v = parseEmail(it.value);
+                    var d = emDraftForItem(it.id);
+                    var badge = d
+                        ? (d.status === 'pending'
+                            ? '<span class="pill pending">em revisão</span>'
+                            : '<span class="pill draft">rascunho</span>')
+                        : '';
+
+                    var nPh = (v.placeholders || []).length;
+                    var phInfo = lang === 'PT'
+                        ? nPh + ' campo' + (nPh === 1 ? '' : 's')
+                        : Object.keys(v.labels || {}).length + ' rótulos';
+
+                    var actions = canPropose('email_template')
+                        ? '<div style="display:flex;gap:8px">' +
+                        '<button class="btn btn-ghost btn-sm" onclick="openEmailEditor(\'' + it.id + '\')">Editar</button>' +
+                        '</div>'
+                        : '';
+
+                    html += '<div class="item-row">' +
+                        '<div class="item-main">' +
+                        '<div class="item-name">' + esc(it.label) + ' ' + badge + '</div>' +
+                        '<div class="item-meta">' + esc(v.subject || '') + ' · ' + esc(phInfo) + '</div>' +
+                        '</div>' + actions + '</div>';
+                });
+            });
+
+            host.innerHTML = html;
+        }
+
+        function openEmailEditor(itemId) {
+            var item = null;
+            for (var i = 0; i < EM_ITEMS.length; i++) {
+                if (EM_ITEMS[i].id === itemId) item = EM_ITEMS[i];
+            }
+            if (!item) return;
+
+            var existingDraft = emDraftForItem(itemId);
+            var src = existingDraft || item;
+            var v = parseEmail(src.value);
+            var lang = item.lang;
+
+            var phList = lang === 'PT'
+                ? (v.placeholders || []).map(function (p) {
+                    return '<code style="font-size:12px">' + esc(p.key) + '</code>';
+                }).join(' ')
+                : Object.keys(v.labels || {}).map(function (k) {
+                    return '<code style="font-size:12px">' + esc(k) + '</code>';
+                }).join(' ');
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:820px" role="dialog" aria-modal="true">' +
+                '<h2>Editar modelo — ' + esc(lang) + '</h2>' +
+                '<p class="card-sub">' + esc(item.label) + '</p>' +
+                (existingDraft && existingDraft.status === 'pending'
+                    ? '<div class="note warn" style="margin-top:14px">Este modelo já está em revisão.</div>'
+                    : '') +
+                '<div class="note" style="margin-top:14px">Campos deste modelo: ' +
+                (phList || '<em>nenhum</em>') +
+                '<br>Use-os no texto exatamente assim. Um campo não usado — ou um texto entre ' +
+                'colchetes que não seja campo — é recusado ao salvar.</div>' +
+                '<label class="fld" for="em-subject">Assunto</label>' +
+                '<input type="text" id="em-subject" value="' + esc(v.subject || '') + '">' +
+                '<label class="fld" for="em-body">Corpo (HTML)</label>' +
+                '<textarea id="em-body" style="min-height:200px;font-family:ui-monospace,monospace;font-size:12.5px">' +
+                esc(v.template || '') + '</textarea>' +
+                '<div class="row-between" style="margin-top:18px">' +
+                '<div class="card-title" style="margin:0">Prévia</div>' +
+                '<button class="btn btn-ghost btn-sm" onclick="refreshEmailPreview()">Atualizar prévia</button>' +
+                '</div>' +
+                '<div id="em-preview" style="border:1px solid var(--border-subtle);border-radius:var(--radius-sm);' +
+                'padding:16px;margin-top:8px;background:#fff;color:#202124;max-height:280px;overflow:auto"></div>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-primary" id="em-save">Salvar e enviar para revisão</button>' +
+                '</div></div></div>';
+
+            refreshEmailPreview();
+            document.getElementById('em-body').addEventListener('input', refreshEmailPreview);
+
+            document.getElementById('em-save').onclick = function () {
+                submitEmail(item, existingDraft ? existingDraft.draftId : null, v, this);
+            };
+        }
+
+        // A prévia renderiza o HTML como o anunciante vai receber. É o ponto da
+        // fase: sem ver, dá pra publicar um <p> não fechado e só descobrir no
+        // e-mail já enviado.
+        function refreshEmailPreview() {
+            var body = document.getElementById('em-body');
+            var host = document.getElementById('em-preview');
+            if (!body || !host) return;
+            host.innerHTML = body.value;
+        }
+
+        function submitEmail(item, draftId, original, btn) {
+            var subject = document.getElementById('em-subject').value.trim();
+            var template = document.getElementById('em-body').value.trim();
+
+            if (!subject) return toast('O e-mail precisa de um assunto.', true);
+            if (!template) return toast('O e-mail precisa de um corpo.', true);
+
+            // Só assunto e corpo são editáveis: a lista de campos (e, em ES, os
+            // rótulos) segue como está. Mexer nela pela tela exigiria casar as
+            // duas linguagens de uma vez, e é justamente onde um erro vaza
+            // placeholder literal para o anunciante.
+            var value = (item.lang === 'ES')
+                ? JSON.stringify({ subject: subject, template: template, labels: original.labels || {} })
+                : JSON.stringify({ subject: subject, template: template, placeholders: original.placeholders || [] });
+
+            btn.disabled = true;
+            btn.textContent = 'Validando…';
+
+            // Valida no servidor ANTES de gravar, pra mensagem de erro chegar
+            // enquanto o texto ainda está na tela.
+            google.script.run
+                .withSuccessHandler(function (res) {
+                    if (!res.ok) {
+                        btn.disabled = false;
+                        btn.textContent = 'Salvar e enviar para revisão';
+                        return toast(res.error, true);
+                    }
+
+                    btn.textContent = 'Enviando…';
+                    google.script.run
+                        .withSuccessHandler(function (saved) {
+                            google.script.run
+                                .withSuccessHandler(function () {
+                                    closeModal();
+                                    toast('Proposta enviada para revisão.');
+                                    loadEmails();
+                                    loadPendingCount();
+                                })
+                                .withFailureHandler(function (err) {
+                                    btn.disabled = false;
+                                    btn.textContent = 'Salvar e enviar para revisão';
+                                    toast(err.message, true);
+                                })
+                                .submitContentDraft(saved.draftId);
+                        })
+                        .withFailureHandler(function (err) {
+                            btn.disabled = false;
+                            btn.textContent = 'Salvar e enviar para revisão';
+                            toast(err.message, true);
+                        })
+                        .saveContentDraft({
+                            draftId: draftId || '',
+                            itemId: item.id,
+                            module: 'email_template',
+                            key: item.key,
+                            field: item.field,
+                            lang: item.lang,
+                            label: item.label,
+                            value: value,
+                            sortOrder: item.sortOrder
+                        });
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.textContent = 'Salvar e enviar para revisão';
+                    toast(err.message, true);
+                })
+                .checkEmailTemplate(value, item.lang);
         }
 
         // --- Aprovações ---

--- a/gas-backend/ContentSeed_Emails.js
+++ b/gas-backend/ContentSeed_Emails.js
@@ -1,0 +1,150 @@
+// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:emails (lê src/modules/email-assistant/email-data.js)
+//
+// Semeia o módulo "email_template" da Central de Conteúdo com os modelos do
+// assistente de e-mail. NÃO inclui os e-mails de CR nem os disparados pelo
+// Dashboard de TL - esses vivem em EmailEngine.gs e seguem fora da Central.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedEmailsNow" no seletor de
+// função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar.
+
+const CONTENT_SEED_EMAILS = {
+  "module": "email_template",
+  "items": [
+    {
+      "key": "attempt_10min",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Tentativa de Contato (Antes dos 10min)",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Tentativa de Contato\",\"template\":\"<p>Olá,</p><br><p>Aqui é o <strong>[Seu Nome]</strong> da equipe de Soluções Técnicas do Google. Tentei ligar no seguinte número: <strong>...</strong> sem sucesso, teria outro número para que eu pudesse entrar em contato?</p><br><p>Lembrando que vou auxiliar a implementar a seguinte tarefa:</p><p><strong>Ads Conversion Tracking</strong></p><br><p>Em seu site: <strong>[INSERIR URL]</strong></p><p>Tentarei ligar novamente dentro de 10 minutos, caso prefira, você pode acessar o link da nossa reunião: <strong>[LINK DO MEET]</strong></p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[Seu Nome]\",\"label\":\"Seu Nome\",\"type\":\"text\",\"auto\":\"agentName\"},{\"key\":\"[INSERIR URL]\",\"label\":\"URL do Site\",\"type\":\"text\"},{\"key\":\"[LINK DO MEET]\",\"label\":\"Link da Reunião\",\"type\":\"text\"}]}",
+      "sortOrder": 0
+    },
+    {
+      "key": "attempt_10min",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Intento de Contacto (Antes de los 10min)",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Intento de Contacto\",\"template\":\"<p>Hola,</p><br><p>Le habla <strong>[Seu Nome]</strong> del equipo de Soluciones Técnicas de Google. Intenté llamar al siguiente número: <strong>...</strong> sin éxito, ¿tendría otro número para que pueda ponerme en contacto?</p><br><p>Le recuerdo que voy a ayudarle a implementar la siguiente tarea:</p><p><strong>Ads Conversion Tracking</strong></p><br><p>En su sitio: <strong>[INSERIR URL]</strong></p><p>Intentaré llamar nuevamente en 10 minutos; si lo prefiere, puede acceder al enlace de nuestra reunión: <strong>[LINK DO MEET]</strong></p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[Seu Nome]\":\"Tu Nombre\",\"[INSERIR URL]\":\"URL del Sitio\",\"[LINK DO MEET]\":\"Enlace de la Reunión\"}}",
+      "sortOrder": 1
+    },
+    {
+      "key": "reschedule2",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Proposta de Reagendamento",
+      "value": "{\"subject\":\"Reagendamento de Consultoria\",\"template\":\"<p>Olá, tudo bem?</p><br><p>Seguem as próximas datas disponíveis:</p><ul><li><strong>[DATA 1] às [HORA 1]</strong></li><li><strong>[DATA 2] às [HORA 2]</strong></li><li><strong>[DATA 3] às [HORA 3]</strong></li></ul><br><p>Também informo que se não houver resposta a este email nas próximas 48 horas o caso será encerrado.</p><p>Reforço que minha agenda é dinâmica, sendo assim, a qualquer momento um atendimento pode ser marcado para os dias disponíveis. Logo, quanto mais rápido conseguir me responder, mais garantido será o agendamento de data e horário.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[DATA 1]\",\"label\":\"Data 1\",\"type\":\"text\"},{\"key\":\"[HORA 1]\",\"label\":\"Hora 1\",\"type\":\"text\"},{\"key\":\"[DATA 2]\",\"label\":\"Data 2\",\"type\":\"text\"},{\"key\":\"[HORA 2]\",\"label\":\"Hora 2\",\"type\":\"text\"},{\"key\":\"[DATA 3]\",\"label\":\"Data 3\",\"type\":\"text\"},{\"key\":\"[HORA 3]\",\"label\":\"Hora 3\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 2
+    },
+    {
+      "key": "reschedule2",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Propuesta de Reprogramación",
+      "value": "{\"subject\":\"Reprogramación de Consultoría\",\"template\":\"<p>Hola, ¿cómo está?</p><br><p>Estas son las próximas fechas disponibles:</p><ul><li><strong>[DATA 1] a las [HORA 1]</strong></li><li><strong>[DATA 2] a las [HORA 2]</strong></li><li><strong>[DATA 3] a las [HORA 3]</strong></li></ul><br><p>También le informo que si no hay respuesta a este correo en las próximas 48 horas el caso será cerrado.</p><p>Le recuerdo que mi agenda es dinámica, por lo que en cualquier momento se puede agendar una consultoría para los días disponibles. Por lo tanto, cuanto más rápido pueda responderme, más garantizada será la programación de la fecha y el horario.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[DATA 1]\":\"Fecha 1\",\"[HORA 1]\":\"Hora 1\",\"[DATA 2]\":\"Fecha 2\",\"[HORA 2]\":\"Hora 2\",\"[DATA 3]\":\"Fecha 3\",\"[HORA 3]\":\"Hora 3\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 3
+    },
+    {
+      "key": "max_reschedules",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Limite de Reagendamentos Excedido",
+      "value": "{\"subject\":\"Status do Agendamento - Time de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Espero que este e-mail o encontre bem.</p><p>Escrevo em nome do time do Google Ads para informar sobre o seu pedido de reagendamento para a implementação das tags.</p><br><p>Infelizmente, <strong>não podemos mais reagendar este caso específico</strong>, pois excedemos o limite máximo de agendamentos permitido.</p><br><p>Se você deseja prosseguir com a implementação das tags, será necessário abrir um <strong>novo caso</strong> diretamente com a <a href=\\\"https://support.google.com/google-ads\\\">Ajuda do Google Ads</a>. Isso garantirá que você receba o acompanhamento e o suporte necessário para dar continuidade à sua solicitação.</p><br><p>Agradecemos o seu envolvimento neste processo e a oportunidade de ajudar. Esperamos continuar a nossa colaboração.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 4
+    },
+    {
+      "key": "max_reschedules",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Límite de Reprogramaciones Excedido",
+      "value": "{\"subject\":\"Estado de la Programación - Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Espero que este correo le encuentre bien.</p><p>Le escribo en nombre del equipo de Google Ads para informarle sobre su solicitud de reprogramación para la implementación de las etiquetas.</p><br><p>Lamentablemente, <strong>ya no podemos reprogramar este caso específico</strong>, pues hemos excedido el límite máximo de programaciones permitido.</p><br><p>Si desea continuar con la implementación de las etiquetas, será necesario abrir un <strong>nuevo caso</strong> directamente con la <a href=\\\"https://support.google.com/google-ads\\\">Ayuda de Google Ads</a>. Esto garantizará que reciba el seguimiento y el soporte necesarios para dar continuidad a su solicitud.</p><br><p>Agradecemos su participación en este proceso y la oportunidad de ayudar. Esperamos continuar nuestra colaboración.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 5
+    },
+    {
+      "key": "2_6_day3",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Dia 3 (Acompanhamento)",
+      "value": "{\"subject\":\"Consultoria com a Equipe de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong></p><br><p>Espero que você esteja bem!</p><p>Tentamos contato através do Número de Telefone, porém sem sucesso. Gostaria de saber se você já conseguiu <strong>[INFORMAR QUAL AÇÃO FICOU PENDENTE]</strong>, ou se você já possui uma previsão de quando essa ação será concluída.</p><br><p>Continuarei monitorando o status da implementação no seu site, e no dia <strong>[MM/DD/YYYY]</strong> farei um novo acompanhamento para verificar o andamento da implementação.</p><p>Se você tiver algum problema ou dúvidas que impossibilite de realizar a implementação, fique à vontade para compartilhá-lo conosco.</p><br><p>Fico à disposição.</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[INFORMAR QUAL AÇÃO FICOU PENDENTE]\",\"label\":\"Ação Pendente\",\"type\":\"text\"},{\"key\":\"[MM/DD/YYYY]\",\"label\":\"Data do Próximo Contato\",\"type\":\"date\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 6
+    },
+    {
+      "key": "2_6_day3",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Día 3 (Seguimiento)",
+      "value": "{\"subject\":\"Consultoría con el Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong></p><br><p>¡Espero que se encuentre bien!</p><p>Intentamos contactarle por teléfono, pero sin éxito. Me gustaría saber si ya pudo <strong>[INFORMAR QUAL AÇÃO FICOU PENDENTE]</strong>, o si ya tiene una previsión de cuándo se concluirá esa acción.</p><br><p>Continuaré monitoreando el estado de la implementación en su sitio, y el día <strong>[MM/DD/YYYY]</strong> haré un nuevo seguimiento para verificar el avance de la implementación.</p><p>Si tiene algún problema o duda que le impida realizar la implementación, no dude en compartirlo con nosotros.</p><br><p>Quedo a disposición.</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[INFORMAR QUAL AÇÃO FICOU PENDENTE]\":\"Acción Pendiente\",\"[MM/DD/YYYY]\":\"Fecha del Próximo Contacto\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 7
+    },
+    {
+      "key": "2_6_day6",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Dia 6 (Acompanhamento Final)",
+      "value": "{\"subject\":\"Consultoria com a Equipe de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong></p><br><p>Espero que você esteja bem!</p><p>Após análise e revisão do status de implementação da tag no seu site, <strong>[URL]</strong>, verificamos que a tag ainda está com a implementação pendente. Tentamos contato através do email, porém sem sucesso.</p><br><p>É essencial que seja implementado, pois ele oferece uma ampla gama de benefícios, como:</p><ul><li>Ajuda a rastrear conversões em tempo real</li><li>Melhora a geração de receita, em termos de cliques</li><li>Serve para vincular o Google Analytics e os anúncios e acompanhar conversões</li><li>Fornece informações sobre a experiência do usuário</li></ul><br><p>Se você tiver algum problema ou dúvidas que o impossibilite de realizar a implementação, fique à vontade para compartilhá-lo conosco. Teremos o maior prazer em ajudar.</p><p>Caso não tenhamos nenhuma resposta nos próximos 3 dias, infelizmente o caso será encerrado.</p><br><p>Fico à disposição.</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[URL]\",\"label\":\"URL do Site\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 8
+    },
+    {
+      "key": "2_6_day6",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Día 6 (Seguimiento Final)",
+      "value": "{\"subject\":\"Consultoría con el Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong></p><br><p>¡Espero que se encuentre bien!</p><p>Tras analizar y revisar el estado de implementación de la etiqueta en su sitio, <strong>[URL]</strong>, verificamos que la etiqueta aún está pendiente de implementación. Intentamos contactarle por correo, pero sin éxito.</p><br><p>Es esencial que sea implementada, pues ofrece una amplia gama de beneficios, como:</p><ul><li>Ayuda a rastrear conversiones en tiempo real</li><li>Mejora la generación de ingresos, en términos de clics</li><li>Sirve para vincular Google Analytics con los anuncios y hacer seguimiento de las conversiones</li><li>Proporciona información sobre la experiencia del usuario</li></ul><br><p>Si tiene algún problema o duda que le impida realizar la implementación, no dude en compartirlo con nosotros. Estaremos encantados de ayudar.</p><p>Si no recibimos ninguna respuesta en los próximos 3 días, lamentablemente el caso será cerrado.</p><br><p>Quedo a disposición.</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[URL]\":\"URL del Sitio\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 9
+    },
+    {
+      "key": "2_6_completed_reschedule",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Ações Concluídas (Solicitar Reagendamento)",
+      "value": "{\"subject\":\"Continuidade da Implementação - Soluções Técnicas do Google\",\"template\":\"<p>Olá, tudo bem?</p><br><p>Maravilha! Muito bom saber que conseguiu concluir as ações pendentes. Sendo assim, agora podemos continuar com a implementação das configurações em sua conta.</p><br><p>Para isso, peço, por favor, que me envie algumas das próximas datas e horários em que está disponível a partir do dia <strong>[Disponibilidade em BAU]</strong>.</p><p>Assim que me enviar essa informação, irei criar um reagendamento para que um de nossos agentes continue te ajudando.</p><br><p>Também informo que se não houver resposta a este email, realizarei um acompanhamento neste caso durante 6 dias, onde entrarei em contato a cada 3 dias para tentarmos reagendar seu caso o mais breve possível.</p><p>Reforço que minha agenda é dinâmica, sendo assim, a qualquer momento um atendimento pode ser marcado para os dias disponíveis. Logo, quanto mais rápido conseguir me responder, mais garantido será o agendamento de data e horário.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[Disponibilidade em BAU]\",\"label\":\"Próxima Disponibilidade\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 10
+    },
+    {
+      "key": "2_6_completed_reschedule",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Acciones Concluidas (Solicitar Reprogramación)",
+      "value": "{\"subject\":\"Continuidad de la Implementación - Soluciones Técnicas de Google\",\"template\":\"<p>Hola, ¿cómo está?</p><br><p>¡Excelente! Muy bueno saber que logró concluir las acciones pendientes. Siendo así, ahora podemos continuar con la implementación de las configuraciones en su cuenta.</p><br><p>Para eso, le pido, por favor, que me envíe algunas de las próximas fechas y horarios en los que esté disponible a partir del día <strong>[Disponibilidade em BAU]</strong>.</p><p>En cuanto me envíe esa información, crearé una reprogramación para que uno de nuestros agentes continúe ayudándole.</p><br><p>También le informo que si no hay respuesta a este correo, realizaré un seguimiento de este caso durante 6 días, en el que me pondré en contacto cada 3 días para intentar reprogramar su caso lo antes posible.</p><p>Le recuerdo que mi agenda es dinámica, por lo que en cualquier momento se puede agendar una consultoría para los días disponibles. Por lo tanto, cuanto más rápido pueda responderme, más garantizada será la programación de la fecha y el horario.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[Disponibilidade em BAU]\":\"Próxima Disponibilidad\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 11
+    },
+    {
+      "key": "nrp_standard",
+      "field": "NRP / Encerramento",
+      "lang": "PT",
+      "label": "NRP - Padrão (3ª Tentativa)",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Encerramento\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Tentamos ligar para você hoje sobre o caso de Implementação da tag referente à solicitação para <strong>[Task pedida pelo AM]</strong>. Outra tentativa foi feita após 10 minutos, mas também não conseguimos contato com você.</p><p>Devido à grande demanda, não podemos reagendar um horário. Por isso, vamos encerrar este caso. No entanto, se você ainda quiser continuar com a implementação, basta você acessar este link e escolher a melhor data e horário para falar com o nosso time, ou se preferir, entre em contato com seu gerente de contas do Google para agendar uma nova reunião.</p><p>Lamentamos o inconveniente e esperamos trabalhar com você novamente no futuro.</p><br><p>Se você quiser saber mais, confira abaixo alguns links úteis de recursos valiosos relacionados à implementação de tags e suporte do Shopping.</p><p><strong>Em relação às tags</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Suporte à implementação de tags</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>Em relação ao Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Como configurar a conta e o feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Otimização do feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Task pedida pelo AM]\",\"label\":\"Task Solicitada\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 12
+    },
+    {
+      "key": "nrp_standard",
+      "field": "NRP / Cierre",
+      "lang": "ES",
+      "label": "NRP - Estándar (3.º Intento)",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Cierre\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Intentamos llamarle hoy sobre el caso de Implementación de la etiqueta referente a la solicitud de <strong>[Task pedida pelo AM]</strong>. Se hizo otro intento después de 10 minutos, pero tampoco logramos contactarle.</p><p>Debido a la alta demanda, no podemos reprogramar un horario. Por eso, vamos a cerrar este caso. Sin embargo, si aún desea continuar con la implementación, basta con acceder a este enlace y elegir la mejor fecha y horario para hablar con nuestro equipo, o si lo prefiere, póngase en contacto con su gerente de cuentas de Google para agendar una nueva reunión.</p><p>Lamentamos el inconveniente y esperamos trabajar con usted nuevamente en el futuro.</p><br><p>Si desea saber más, consulte a continuación algunos enlaces útiles con recursos valiosos relacionados con la implementación de etiquetas y el soporte de Shopping.</p><p><strong>En relación con las etiquetas</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Soporte para la implementación de etiquetas</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>En relación con Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Cómo configurar la cuenta y el feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Optimización del feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Task pedida pelo AM]\":\"Tarea Solicitada\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 13
+    },
+    {
+      "key": "nrp_dfa",
+      "field": "NRP / Encerramento",
+      "lang": "PT",
+      "label": "NRP - DFA",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Encerramento\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Tentamos ligar para você hoje sobre o caso de Implementação da tag referente à solicitação. Outra tentativa foi feita após 10 minutos, mas também não conseguimos contato com você.</p><p>Devido à grande demanda, não podemos reagendar um horário. Por isso, vamos encerrar este caso. No entanto, se você ainda quiser continuar com a implementação, basta você acessar este link e escolher a melhor data e horário para falar com o nosso time.</p><p>Lamentamos o inconveniente e esperamos trabalhar com você novamente no futuro.</p><br><p>Se você quiser saber mais, confira abaixo alguns links úteis de recursos valiosos relacionados à implementação de tags e suporte do Shopping.</p><p><strong>Em relação às tags</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Suporte à implementação de tags</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>Em relação ao Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Como configurar a conta e o feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Otimização do feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 14
+    },
+    {
+      "key": "nrp_dfa",
+      "field": "NRP / Cierre",
+      "lang": "ES",
+      "label": "NRP - DFA",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Cierre\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Intentamos llamarle hoy sobre el caso de Implementación de la etiqueta referente a la solicitud. Se hizo otro intento después de 10 minutos, pero tampoco logramos contactarle.</p><p>Debido a la alta demanda, no podemos reprogramar un horario. Por eso, vamos a cerrar este caso. Sin embargo, si aún desea continuar con la implementación, basta con acceder a este enlace y elegir la mejor fecha y horario para hablar con nuestro equipo.</p><p>Lamentamos el inconveniente y esperamos trabajar con usted nuevamente en el futuro.</p><br><p>Si desea saber más, consulte a continuación algunos enlaces útiles con recursos valiosos relacionados con la implementación de etiquetas y el soporte de Shopping.</p><p><strong>En relación con las etiquetas</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Soporte para la implementación de etiquetas</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>En relación con Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Cómo configurar la cuenta y el feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Optimización del feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 15
+    }
+  ]
+};
+
+function seedEmailsNow() {
+  const result = seedContentModule(CONTENT_SEED_EMAILS);
+  Logger.log(result);
+  return result;
+}

--- a/gas-backend/seeds/email-seed.json
+++ b/gas-backend/seeds/email-seed.json
@@ -1,0 +1,133 @@
+{
+  "module": "email_template",
+  "items": [
+    {
+      "key": "attempt_10min",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Tentativa de Contato (Antes dos 10min)",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Tentativa de Contato\",\"template\":\"<p>Olá,</p><br><p>Aqui é o <strong>[Seu Nome]</strong> da equipe de Soluções Técnicas do Google. Tentei ligar no seguinte número: <strong>...</strong> sem sucesso, teria outro número para que eu pudesse entrar em contato?</p><br><p>Lembrando que vou auxiliar a implementar a seguinte tarefa:</p><p><strong>Ads Conversion Tracking</strong></p><br><p>Em seu site: <strong>[INSERIR URL]</strong></p><p>Tentarei ligar novamente dentro de 10 minutos, caso prefira, você pode acessar o link da nossa reunião: <strong>[LINK DO MEET]</strong></p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[Seu Nome]\",\"label\":\"Seu Nome\",\"type\":\"text\",\"auto\":\"agentName\"},{\"key\":\"[INSERIR URL]\",\"label\":\"URL do Site\",\"type\":\"text\"},{\"key\":\"[LINK DO MEET]\",\"label\":\"Link da Reunião\",\"type\":\"text\"}]}",
+      "sortOrder": 0
+    },
+    {
+      "key": "attempt_10min",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Intento de Contacto (Antes de los 10min)",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Intento de Contacto\",\"template\":\"<p>Hola,</p><br><p>Le habla <strong>[Seu Nome]</strong> del equipo de Soluciones Técnicas de Google. Intenté llamar al siguiente número: <strong>...</strong> sin éxito, ¿tendría otro número para que pueda ponerme en contacto?</p><br><p>Le recuerdo que voy a ayudarle a implementar la siguiente tarea:</p><p><strong>Ads Conversion Tracking</strong></p><br><p>En su sitio: <strong>[INSERIR URL]</strong></p><p>Intentaré llamar nuevamente en 10 minutos; si lo prefiere, puede acceder al enlace de nuestra reunión: <strong>[LINK DO MEET]</strong></p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[Seu Nome]\":\"Tu Nombre\",\"[INSERIR URL]\":\"URL del Sitio\",\"[LINK DO MEET]\":\"Enlace de la Reunión\"}}",
+      "sortOrder": 1
+    },
+    {
+      "key": "reschedule2",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Proposta de Reagendamento",
+      "value": "{\"subject\":\"Reagendamento de Consultoria\",\"template\":\"<p>Olá, tudo bem?</p><br><p>Seguem as próximas datas disponíveis:</p><ul><li><strong>[DATA 1] às [HORA 1]</strong></li><li><strong>[DATA 2] às [HORA 2]</strong></li><li><strong>[DATA 3] às [HORA 3]</strong></li></ul><br><p>Também informo que se não houver resposta a este email nas próximas 48 horas o caso será encerrado.</p><p>Reforço que minha agenda é dinâmica, sendo assim, a qualquer momento um atendimento pode ser marcado para os dias disponíveis. Logo, quanto mais rápido conseguir me responder, mais garantido será o agendamento de data e horário.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[DATA 1]\",\"label\":\"Data 1\",\"type\":\"text\"},{\"key\":\"[HORA 1]\",\"label\":\"Hora 1\",\"type\":\"text\"},{\"key\":\"[DATA 2]\",\"label\":\"Data 2\",\"type\":\"text\"},{\"key\":\"[HORA 2]\",\"label\":\"Hora 2\",\"type\":\"text\"},{\"key\":\"[DATA 3]\",\"label\":\"Data 3\",\"type\":\"text\"},{\"key\":\"[HORA 3]\",\"label\":\"Hora 3\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 2
+    },
+    {
+      "key": "reschedule2",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Propuesta de Reprogramación",
+      "value": "{\"subject\":\"Reprogramación de Consultoría\",\"template\":\"<p>Hola, ¿cómo está?</p><br><p>Estas son las próximas fechas disponibles:</p><ul><li><strong>[DATA 1] a las [HORA 1]</strong></li><li><strong>[DATA 2] a las [HORA 2]</strong></li><li><strong>[DATA 3] a las [HORA 3]</strong></li></ul><br><p>También le informo que si no hay respuesta a este correo en las próximas 48 horas el caso será cerrado.</p><p>Le recuerdo que mi agenda es dinámica, por lo que en cualquier momento se puede agendar una consultoría para los días disponibles. Por lo tanto, cuanto más rápido pueda responderme, más garantizada será la programación de la fecha y el horario.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[DATA 1]\":\"Fecha 1\",\"[HORA 1]\":\"Hora 1\",\"[DATA 2]\":\"Fecha 2\",\"[HORA 2]\":\"Hora 2\",\"[DATA 3]\":\"Fecha 3\",\"[HORA 3]\":\"Hora 3\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 3
+    },
+    {
+      "key": "max_reschedules",
+      "field": "Tentativas & Agendamento",
+      "lang": "PT",
+      "label": "Limite de Reagendamentos Excedido",
+      "value": "{\"subject\":\"Status do Agendamento - Time de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Espero que este e-mail o encontre bem.</p><p>Escrevo em nome do time do Google Ads para informar sobre o seu pedido de reagendamento para a implementação das tags.</p><br><p>Infelizmente, <strong>não podemos mais reagendar este caso específico</strong>, pois excedemos o limite máximo de agendamentos permitido.</p><br><p>Se você deseja prosseguir com a implementação das tags, será necessário abrir um <strong>novo caso</strong> diretamente com a <a href=\\\"https://support.google.com/google-ads\\\">Ajuda do Google Ads</a>. Isso garantirá que você receba o acompanhamento e o suporte necessário para dar continuidade à sua solicitação.</p><br><p>Agradecemos o seu envolvimento neste processo e a oportunidade de ajudar. Esperamos continuar a nossa colaboração.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 4
+    },
+    {
+      "key": "max_reschedules",
+      "field": "Intentos y Programación",
+      "lang": "ES",
+      "label": "Límite de Reprogramaciones Excedido",
+      "value": "{\"subject\":\"Estado de la Programación - Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Espero que este correo le encuentre bien.</p><p>Le escribo en nombre del equipo de Google Ads para informarle sobre su solicitud de reprogramación para la implementación de las etiquetas.</p><br><p>Lamentablemente, <strong>ya no podemos reprogramar este caso específico</strong>, pues hemos excedido el límite máximo de programaciones permitido.</p><br><p>Si desea continuar con la implementación de las etiquetas, será necesario abrir un <strong>nuevo caso</strong> directamente con la <a href=\\\"https://support.google.com/google-ads\\\">Ayuda de Google Ads</a>. Esto garantizará que reciba el seguimiento y el soporte necesarios para dar continuidad a su solicitud.</p><br><p>Agradecemos su participación en este proceso y la oportunidad de ayudar. Esperamos continuar nuestra colaboración.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 5
+    },
+    {
+      "key": "2_6_day3",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Dia 3 (Acompanhamento)",
+      "value": "{\"subject\":\"Consultoria com a Equipe de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong></p><br><p>Espero que você esteja bem!</p><p>Tentamos contato através do Número de Telefone, porém sem sucesso. Gostaria de saber se você já conseguiu <strong>[INFORMAR QUAL AÇÃO FICOU PENDENTE]</strong>, ou se você já possui uma previsão de quando essa ação será concluída.</p><br><p>Continuarei monitorando o status da implementação no seu site, e no dia <strong>[MM/DD/YYYY]</strong> farei um novo acompanhamento para verificar o andamento da implementação.</p><p>Se você tiver algum problema ou dúvidas que impossibilite de realizar a implementação, fique à vontade para compartilhá-lo conosco.</p><br><p>Fico à disposição.</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[INFORMAR QUAL AÇÃO FICOU PENDENTE]\",\"label\":\"Ação Pendente\",\"type\":\"text\"},{\"key\":\"[MM/DD/YYYY]\",\"label\":\"Data do Próximo Contato\",\"type\":\"date\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 6
+    },
+    {
+      "key": "2_6_day3",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Día 3 (Seguimiento)",
+      "value": "{\"subject\":\"Consultoría con el Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong></p><br><p>¡Espero que se encuentre bien!</p><p>Intentamos contactarle por teléfono, pero sin éxito. Me gustaría saber si ya pudo <strong>[INFORMAR QUAL AÇÃO FICOU PENDENTE]</strong>, o si ya tiene una previsión de cuándo se concluirá esa acción.</p><br><p>Continuaré monitoreando el estado de la implementación en su sitio, y el día <strong>[MM/DD/YYYY]</strong> haré un nuevo seguimiento para verificar el avance de la implementación.</p><p>Si tiene algún problema o duda que le impida realizar la implementación, no dude en compartirlo con nosotros.</p><br><p>Quedo a disposición.</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[INFORMAR QUAL AÇÃO FICOU PENDENTE]\":\"Acción Pendiente\",\"[MM/DD/YYYY]\":\"Fecha del Próximo Contacto\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 7
+    },
+    {
+      "key": "2_6_day6",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Dia 6 (Acompanhamento Final)",
+      "value": "{\"subject\":\"Consultoria com a Equipe de Soluções Técnicas do Google\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong></p><br><p>Espero que você esteja bem!</p><p>Após análise e revisão do status de implementação da tag no seu site, <strong>[URL]</strong>, verificamos que a tag ainda está com a implementação pendente. Tentamos contato através do email, porém sem sucesso.</p><br><p>É essencial que seja implementado, pois ele oferece uma ampla gama de benefícios, como:</p><ul><li>Ajuda a rastrear conversões em tempo real</li><li>Melhora a geração de receita, em termos de cliques</li><li>Serve para vincular o Google Analytics e os anúncios e acompanhar conversões</li><li>Fornece informações sobre a experiência do usuário</li></ul><br><p>Se você tiver algum problema ou dúvidas que o impossibilite de realizar a implementação, fique à vontade para compartilhá-lo conosco. Teremos o maior prazer em ajudar.</p><p>Caso não tenhamos nenhuma resposta nos próximos 3 dias, infelizmente o caso será encerrado.</p><br><p>Fico à disposição.</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[URL]\",\"label\":\"URL do Site\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 8
+    },
+    {
+      "key": "2_6_day6",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Día 6 (Seguimiento Final)",
+      "value": "{\"subject\":\"Consultoría con el Equipo de Soluciones Técnicas de Google\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong></p><br><p>¡Espero que se encuentre bien!</p><p>Tras analizar y revisar el estado de implementación de la etiqueta en su sitio, <strong>[URL]</strong>, verificamos que la etiqueta aún está pendiente de implementación. Intentamos contactarle por correo, pero sin éxito.</p><br><p>Es esencial que sea implementada, pues ofrece una amplia gama de beneficios, como:</p><ul><li>Ayuda a rastrear conversiones en tiempo real</li><li>Mejora la generación de ingresos, en términos de clics</li><li>Sirve para vincular Google Analytics con los anuncios y hacer seguimiento de las conversiones</li><li>Proporciona información sobre la experiencia del usuario</li></ul><br><p>Si tiene algún problema o duda que le impida realizar la implementación, no dude en compartirlo con nosotros. Estaremos encantados de ayudar.</p><p>Si no recibimos ninguna respuesta en los próximos 3 días, lamentablemente el caso será cerrado.</p><br><p>Quedo a disposición.</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[URL]\":\"URL del Sitio\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 9
+    },
+    {
+      "key": "2_6_completed_reschedule",
+      "field": "Follow Up",
+      "lang": "PT",
+      "label": "Ações Concluídas (Solicitar Reagendamento)",
+      "value": "{\"subject\":\"Continuidade da Implementação - Soluções Técnicas do Google\",\"template\":\"<p>Olá, tudo bem?</p><br><p>Maravilha! Muito bom saber que conseguiu concluir as ações pendentes. Sendo assim, agora podemos continuar com a implementação das configurações em sua conta.</p><br><p>Para isso, peço, por favor, que me envie algumas das próximas datas e horários em que está disponível a partir do dia <strong>[Disponibilidade em BAU]</strong>.</p><p>Assim que me enviar essa informação, irei criar um reagendamento para que um de nossos agentes continue te ajudando.</p><br><p>Também informo que se não houver resposta a este email, realizarei um acompanhamento neste caso durante 6 dias, onde entrarei em contato a cada 3 dias para tentarmos reagendar seu caso o mais breve possível.</p><p>Reforço que minha agenda é dinâmica, sendo assim, a qualquer momento um atendimento pode ser marcado para os dias disponíveis. Logo, quanto mais rápido conseguir me responder, mais garantido será o agendamento de data e horário.</p><br><p>Atenciosamente,</p><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google.</p>\",\"placeholders\":[{\"key\":\"[Disponibilidade em BAU]\",\"label\":\"Próxima Disponibilidade\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 10
+    },
+    {
+      "key": "2_6_completed_reschedule",
+      "field": "Follow Up",
+      "lang": "ES",
+      "label": "Acciones Concluidas (Solicitar Reprogramación)",
+      "value": "{\"subject\":\"Continuidad de la Implementación - Soluciones Técnicas de Google\",\"template\":\"<p>Hola, ¿cómo está?</p><br><p>¡Excelente! Muy bueno saber que logró concluir las acciones pendientes. Siendo así, ahora podemos continuar con la implementación de las configuraciones en su cuenta.</p><br><p>Para eso, le pido, por favor, que me envíe algunas de las próximas fechas y horarios en los que esté disponible a partir del día <strong>[Disponibilidade em BAU]</strong>.</p><p>En cuanto me envíe esa información, crearé una reprogramación para que uno de nuestros agentes continúe ayudándole.</p><br><p>También le informo que si no hay respuesta a este correo, realizaré un seguimiento de este caso durante 6 días, en el que me pondré en contacto cada 3 días para intentar reprogramar su caso lo antes posible.</p><p>Le recuerdo que mi agenda es dinámica, por lo que en cualquier momento se puede agendar una consultoría para los días disponibles. Por lo tanto, cuanto más rápido pueda responderme, más garantizada será la programación de la fecha y el horario.</p><br><p>Atentamente,</p><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google.</p>\",\"labels\":{\"[Disponibilidade em BAU]\":\"Próxima Disponibilidad\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 11
+    },
+    {
+      "key": "nrp_standard",
+      "field": "NRP / Encerramento",
+      "lang": "PT",
+      "label": "NRP - Padrão (3ª Tentativa)",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Encerramento\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Tentamos ligar para você hoje sobre o caso de Implementação da tag referente à solicitação para <strong>[Task pedida pelo AM]</strong>. Outra tentativa foi feita após 10 minutos, mas também não conseguimos contato com você.</p><p>Devido à grande demanda, não podemos reagendar um horário. Por isso, vamos encerrar este caso. No entanto, se você ainda quiser continuar com a implementação, basta você acessar este link e escolher a melhor data e horário para falar com o nosso time, ou se preferir, entre em contato com seu gerente de contas do Google para agendar uma nova reunião.</p><p>Lamentamos o inconveniente e esperamos trabalhar com você novamente no futuro.</p><br><p>Se você quiser saber mais, confira abaixo alguns links úteis de recursos valiosos relacionados à implementação de tags e suporte do Shopping.</p><p><strong>Em relação às tags</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Suporte à implementação de tags</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>Em relação ao Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Como configurar a conta e o feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Otimização do feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Task pedida pelo AM]\",\"label\":\"Task Solicitada\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 12
+    },
+    {
+      "key": "nrp_standard",
+      "field": "NRP / Cierre",
+      "lang": "ES",
+      "label": "NRP - Estándar (3.º Intento)",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Cierre\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Intentamos llamarle hoy sobre el caso de Implementación de la etiqueta referente a la solicitud de <strong>[Task pedida pelo AM]</strong>. Se hizo otro intento después de 10 minutos, pero tampoco logramos contactarle.</p><p>Debido a la alta demanda, no podemos reprogramar un horario. Por eso, vamos a cerrar este caso. Sin embargo, si aún desea continuar con la implementación, basta con acceder a este enlace y elegir la mejor fecha y horario para hablar con nuestro equipo, o si lo prefiere, póngase en contacto con su gerente de cuentas de Google para agendar una nueva reunión.</p><p>Lamentamos el inconveniente y esperamos trabajar con usted nuevamente en el futuro.</p><br><p>Si desea saber más, consulte a continuación algunos enlaces útiles con recursos valiosos relacionados con la implementación de etiquetas y el soporte de Shopping.</p><p><strong>En relación con las etiquetas</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Soporte para la implementación de etiquetas</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>En relación con Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Cómo configurar la cuenta y el feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Optimización del feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Task pedida pelo AM]\":\"Tarea Solicitada\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 13
+    },
+    {
+      "key": "nrp_dfa",
+      "field": "NRP / Encerramento",
+      "lang": "PT",
+      "label": "NRP - DFA",
+      "value": "{\"subject\":\"Implementação com o Time de Soluções Técnicas do Google - Encerramento\",\"template\":\"<p>Olá, <strong>[Nome do Cliente]</strong>,</p><br><p>Tentamos ligar para você hoje sobre o caso de Implementação da tag referente à solicitação. Outra tentativa foi feita após 10 minutos, mas também não conseguimos contato com você.</p><p>Devido à grande demanda, não podemos reagendar um horário. Por isso, vamos encerrar este caso. No entanto, se você ainda quiser continuar com a implementação, basta você acessar este link e escolher a melhor data e horário para falar com o nosso time.</p><p>Lamentamos o inconveniente e esperamos trabalhar com você novamente no futuro.</p><br><p>Se você quiser saber mais, confira abaixo alguns links úteis de recursos valiosos relacionados à implementação de tags e suporte do Shopping.</p><p><strong>Em relação às tags</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Suporte à implementação de tags</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>Em relação ao Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Como configurar a conta e o feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Otimização do feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Time de Soluções Técnicas Cognizant, em nome do Google</p>\",\"placeholders\":[{\"key\":\"[Nome do Cliente]\",\"label\":\"Nome do Cliente\",\"type\":\"text\"},{\"key\":\"[Seu Nome]\",\"label\":\"Assinatura\",\"type\":\"text\",\"auto\":\"agentName\"}]}",
+      "sortOrder": 14
+    },
+    {
+      "key": "nrp_dfa",
+      "field": "NRP / Cierre",
+      "lang": "ES",
+      "label": "NRP - DFA",
+      "value": "{\"subject\":\"Implementación con el Equipo de Soluciones Técnicas de Google - Cierre\",\"template\":\"<p>Hola, <strong>[Nome do Cliente]</strong>,</p><br><p>Intentamos llamarle hoy sobre el caso de Implementación de la etiqueta referente a la solicitud. Se hizo otro intento después de 10 minutos, pero tampoco logramos contactarle.</p><p>Debido a la alta demanda, no podemos reprogramar un horario. Por eso, vamos a cerrar este caso. Sin embargo, si aún desea continuar con la implementación, basta con acceder a este enlace y elegir la mejor fecha y horario para hablar con nuestro equipo.</p><p>Lamentamos el inconveniente y esperamos trabajar con usted nuevamente en el futuro.</p><br><p>Si desea saber más, consulte a continuación algunos enlaces útiles con recursos valiosos relacionados con la implementación de etiquetas y el soporte de Shopping.</p><p><strong>En relación con las etiquetas</strong></p><ul><li><a href=\\\"https://developers.google.com/gtagjs\\\">Soporte para la implementación de etiquetas</a></li><li><a href=\\\"https://www.youtube.com/user/learnwithgoogle/playlists\\\">Google Ads</a></li><li><a href=\\\"https://www.youtube.com/user/googleanalytics\\\">Google Analytics</a></li></ul><p><strong>En relación con Shopping</strong></p><ul><li><a href=\\\"https://www.google.com/retail/\\\">Google for Retail</a></li><li><a href=\\\"https://www.google.com/retail/solutions/merchant-center/\\\">Google Merchant Center</a></li><li><a href=\\\"https://support.google.com/merchants/answer/188924\\\">Cómo configurar la cuenta y el feed</a></li><li><a href=\\\"https://support.google.com/merchants/topic/7294606\\\">Optimización del feed</a></li><li><a href=\\\"https://support.google.com/merchants/answer/9199328\\\">Google plataformas</a></li></ul><br><p><strong>[Seu Nome]</strong><br>Equipo de Soluciones Técnicas Cognizant, en nombre de Google</p>\",\"labels\":{\"[Nome do Cliente]\":\"Nombre del Cliente\",\"[Seu Nome]\":\"Firma\"}}",
+      "sortOrder": 15
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "seed:links": "node scripts/generate-links-seed.mjs",
     "seed:call-script": "node scripts/generate-call-script-seed.mjs",
     "test:note-snippets": "node scripts/test-note-snippets.mjs",
-    "seed:note-fields": "node scripts/generate-note-fields.mjs"
+    "seed:note-fields": "node scripts/generate-note-fields.mjs",
+    "test:emails": "node scripts/test-email-roundtrip.mjs",
+    "seed:emails": "node scripts/generate-email-seed.mjs"
   },
   "dependencies": {
     "esbuild": "^0.27.4",

--- a/scripts/generate-email-seed.mjs
+++ b/scripts/generate-email-seed.mjs
@@ -1,0 +1,183 @@
+// scripts/generate-email-seed.mjs
+//
+// Gera a semeadura do módulo "email_template" a partir de
+// src/modules/email-assistant/email-data.js.
+//
+// Escopo: só os modelos do ASSISTENTE DE E-MAIL do agente. Ficam de fora, por
+// decisão do produto, os e-mails de CR e os disparados pelo Dashboard de TL -
+// esses vivem em gas-backend/EmailEngine.js, são enviados pelo próprio Apps
+// Script e não passam por aqui.
+//
+// Escreve:
+//   - gas-backend/seeds/email-seed.json      (para inspeção)
+//   - gas-backend/ContentSeed_Emails.js      (o que roda: seedEmailsNow())
+//
+// Uso: npm run seed:emails
+//
+// --- Como o par PT/ES é modelado ---
+// Hoje há uma lista PT e um overlay EMAIL_TEMPLATES_ES chaveado por id, onde as
+// CHAVES dos placeholders continuam em português ("[Nome do Cliente]") e só os
+// rótulos mudam. Isso é proposital: a chave é o que o corpo do e-mail contém.
+// Na planilha cada idioma vira uma linha (lang = PT | ES) do mesmo template
+// (key = id), e a hidratação remonta as duas estruturas originais - por isso
+// getEmailTemplate() não precisou mudar.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+    resolve(here, '../src/modules/email-assistant/email-data.js'),
+    'utf8'
+);
+
+// Recorta pelo texto EXATO da declaração. Casar só pelo nome já mordeu uma vez:
+// EMAIL_TEMPLATES_ES é `const`, não `export const`, e um prefixo errado faz o
+// indexOf falhar e a busca cair no primeiro `{` do arquivo - extraindo o objeto
+// errado sem erro nenhum.
+function extractLiteral(decl, open, close) {
+    const start = source.indexOf(decl);
+    if (start === -1) throw new Error(`Não encontrei a declaração: ${decl}`);
+
+    const from = source.indexOf(open, start);
+    let depth = 0;
+    let inString = null;
+
+    for (let i = from; i < source.length; i++) {
+        const ch = source[i];
+        const prev = source[i - 1];
+
+        if (inString) {
+            if (ch === inString && prev !== '\\') inString = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'" || ch === '`') { inString = ch; continue; }
+        if (ch === open) depth++;
+        else if (ch === close) {
+            depth--;
+            if (depth === 0) return source.slice(from, i + 1);
+        }
+    }
+    throw new Error(`Literal de ${decl} não fecha`);
+}
+
+const evalLiteral = (t) => new Function(`return (${t});`)();
+
+const EMAIL_TEMPLATES = evalLiteral(
+    extractLiteral('export const EMAIL_TEMPLATES = [', '[', ']')
+);
+const EMAIL_TEMPLATES_ES = evalLiteral(
+    extractLiteral('const EMAIL_TEMPLATES_ES = {', '{', '}')
+);
+
+const TOKEN = /\[[^\][]{2,60}\]/g;
+
+// Um placeholder declarado que não aparece no corpo nunca é preenchido; um
+// token no corpo que ninguém declarou vai embora LITERALMENTE para o anunciante
+// ("Olá, [Nome do Cliente]"). Semear com qualquer um dos dois seria publicar o
+// defeito - então o gerador falha em vez de gerar.
+const problemas = [];
+
+for (const tpl of EMAIL_TEMPLATES) {
+    const corpo = `${tpl.subject || ''} ${tpl.template || ''}`;
+    const declarados = (tpl.placeholders || []).map(p => p.key);
+
+    const semUso = declarados.filter(k => !corpo.includes(k));
+    const semDeclarar = [...new Set(corpo.match(TOKEN) || [])].filter(k => !declarados.includes(k));
+
+    if (semUso.length) problemas.push(`PT[${tpl.id}] declarado mas ausente do corpo: ${semUso.join(', ')}`);
+    if (semDeclarar.length) problemas.push(`PT[${tpl.id}] no corpo mas não declarado: ${semDeclarar.join(', ')}`);
+}
+
+for (const [id, es] of Object.entries(EMAIL_TEMPLATES_ES)) {
+    const pt = EMAIL_TEMPLATES.find(t => t.id === id);
+    if (!pt) { problemas.push(`ES[${id}] não tem correspondente em PT`); continue; }
+
+    const corpo = `${es.subject || ''} ${es.template || ''}`;
+    const faltando = (pt.placeholders || []).map(p => p.key).filter(k => !corpo.includes(k));
+    if (faltando.length) problemas.push(`ES[${id}] placeholder ausente no corpo: ${faltando.join(', ')}`);
+}
+
+if (problemas.length) {
+    process.stderr.write('Placeholders inconsistentes — nada gerado:\n  ' + problemas.join('\n  ') + '\n');
+    process.exit(1);
+}
+
+const items = [];
+let order = 0;
+
+for (const tpl of EMAIL_TEMPLATES) {
+    items.push({
+        key: tpl.id,
+        field: tpl.category || '',
+        lang: 'PT',
+        label: tpl.name || tpl.id,
+        value: JSON.stringify({
+            subject: tpl.subject || '',
+            template: tpl.template || '',
+            placeholders: (tpl.placeholders || []).map(p => ({
+                key: p.key,
+                label: p.label || '',
+                type: p.type || 'text',
+                ...(p.auto ? { auto: p.auto } : {}),
+            })),
+        }),
+        sortOrder: order++,
+    });
+
+    const es = EMAIL_TEMPLATES_ES[tpl.id];
+    if (!es) continue;
+
+    items.push({
+        key: tpl.id,
+        field: es.category || tpl.category || '',
+        lang: 'ES',
+        label: es.name || tpl.name || tpl.id,
+        value: JSON.stringify({
+            subject: es.subject || '',
+            template: es.template || '',
+            // Em ES só os RÓTULOS mudam; as chaves seguem as de PT, porque são
+            // elas que aparecem no corpo do e-mail.
+            labels: es.labels || {},
+        }),
+        sortOrder: order++,
+    });
+}
+
+const payload = { module: 'email_template', items };
+
+writeFileSync(
+    resolve(here, '../gas-backend/seeds/email-seed.json'),
+    JSON.stringify(payload, null, 2) + '\n'
+);
+
+const gasFile = `// ARQUIVO GERADO - não edite à mão.
+// Origem: npm run seed:emails (lê src/modules/email-assistant/email-data.js)
+//
+// Semeia o módulo "email_template" da Central de Conteúdo com os modelos do
+// assistente de e-mail. NÃO inclui os e-mails de CR nem os disparados pelo
+// Dashboard de TL - esses vivem em EmailEngine.gs e seguem fora da Central.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedEmailsNow" no seletor de
+// função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar.
+
+const CONTENT_SEED_EMAILS = ${JSON.stringify(payload, null, 2)};
+
+function seedEmailsNow() {
+  const result = seedContentModule(CONTENT_SEED_EMAILS);
+  Logger.log(result);
+  return result;
+}
+`;
+
+writeFileSync(resolve(here, '../gas-backend/ContentSeed_Emails.js'), gasFile);
+
+const pt = items.filter(i => i.lang === 'PT').length;
+const es = items.filter(i => i.lang === 'ES').length;
+
+process.stdout.write(
+    `${items.length} itens (${pt} PT + ${es} ES) — placeholders conferidos, nenhum inconsistente\n` +
+    'Gerados: gas-backend/seeds/email-seed.json e gas-backend/ContentSeed_Emails.js\n'
+);

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -421,6 +421,131 @@ check('a ordem dos passos sobrevive à semeadura', () => {
   }
 });
 
+console.log('\n--- E-mails (validação de placeholder) ---');
+
+const emailValue = (subject, body, placeholders) => JSON.stringify({
+  subject: subject, template: body, placeholders: placeholders || []
+});
+
+check('modelo consistente é aceito', () => {
+  const r = api.saveContentDraft({
+    module: 'email_template', key: 'attempt_10min', field: 'Tentativas', lang: 'PT',
+    label: 'Tentativa',
+    value: emailValue('Olá [Nome do Cliente]', '<p>Oi [Nome do Cliente], sou [Seu Nome].</p>',
+      [{ key: '[Nome do Cliente]', label: 'Cliente', type: 'text' },
+      { key: '[Seu Nome]', label: 'Assinatura', type: 'text', auto: 'agentName' }])
+  });
+  if (!r.draftId) throw new Error('rascunho não criado');
+});
+
+check('campo declarado que não aparece no corpo é recusado', () => {
+  // O agente preencheria um campo que não vai a lugar nenhum.
+  throws(() => api.saveContentDraft({
+    module: 'email_template', key: 'x', field: 'c', lang: 'PT', label: 'X',
+    value: emailValue('Assunto', '<p>Sem token nenhum.</p>',
+      [{ key: '[Nome do Cliente]', label: 'Cliente', type: 'text' }])
+  }), /declarados mas não aparecem/);
+});
+
+check('token no corpo sem declaração é recusado', () => {
+  // Esse é o caro: sai literal "Olá, [Nome do Cliente]," para o anunciante.
+  throws(() => api.saveContentDraft({
+    module: 'email_template', key: 'x', field: 'c', lang: 'PT', label: 'X',
+    value: emailValue('Assunto', '<p>Olá, [Nome do Cliente], tudo bem?</p>', [])
+  }), /não estão declarados/);
+});
+
+check('assunto e corpo são obrigatórios', () => {
+  throws(() => api.saveContentDraft({
+    module: 'email_template', key: 'x', field: 'c', lang: 'PT', label: 'X',
+    value: emailValue('', '<p>corpo</p>', [])
+  }), /precisa de um assunto/);
+
+  throws(() => api.saveContentDraft({
+    module: 'email_template', key: 'x', field: 'c', lang: 'PT', label: 'X',
+    value: emailValue('Assunto', '', [])
+  }), /precisa de um corpo/);
+});
+
+check('o token pode estar só no assunto', () => {
+  const r = api.saveContentDraft({
+    module: 'email_template', key: 'y', field: 'c', lang: 'PT', label: 'Y',
+    value: emailValue('Caso de [Nome do Cliente]', '<p>Texto sem token.</p>',
+      [{ key: '[Nome do Cliente]', label: 'Cliente', type: 'text' }])
+  });
+  if (!r.draftId) throw new Error('recusou token válido no assunto');
+});
+
+check('ES não exige declaração própria (as chaves são as de PT)', () => {
+  const r = api.saveContentDraft({
+    module: 'email_template', key: 'attempt_10min', field: 'Intentos', lang: 'ES',
+    label: 'Intento',
+    value: JSON.stringify({
+      subject: 'Hola [Nome do Cliente]',
+      template: '<p>Hola [Nome do Cliente], soy [Seu Nome].</p>',
+      labels: { '[Nome do Cliente]': 'Nombre del Cliente', '[Seu Nome]': 'Firma' }
+    })
+  });
+  if (!r.draftId) throw new Error('recusou overlay ES válido');
+});
+
+check('checkEmailTemplate devolve o erro em vez de lançar', () => {
+  // A tela chama isso antes de gravar, pra avisar com o texto ainda na tela.
+  const bad = api.checkEmailTemplate(emailValue('A', '<p>[Fantasma]</p>', []), 'PT');
+  eq(bad.ok, false);
+  if (!/não estão declarados/.test(bad.error)) throw new Error('erro inesperado: ' + bad.error);
+
+  const good = api.checkEmailTemplate(emailValue('A', '<p>ok</p>', []), 'PT');
+  eq(good.ok, true);
+});
+
+check('JSON malformado não passa', () => {
+  throws(() => api.saveContentDraft({
+    module: 'email_template', key: 'x', field: 'c', lang: 'PT', label: 'X',
+    value: '{isso não é json'
+  }), /JSON malformado/);
+});
+
+check('seedEmailsNow() popula os modelos numa planilha zerada', () => {
+  const freshSS = new FakeSpreadsheet();
+  const freshCtx = vm.createContext({
+    SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    MailApp: { sendEmail: () => { } },
+    Logger: { log: () => { } },
+    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    handleLog: () => { },
+    console,
+  });
+
+  vm.runInContext(fs.readFileSync(SRC, 'utf8'), freshCtx);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, '..', 'gas-backend', 'ContentSeed_Emails.js'), 'utf8'),
+    freshCtx
+  );
+
+  const res = freshCtx.seedEmailsNow();
+  eq(res.status, 'success');
+
+  const live = freshCtx.listContentItems('email_template');
+  eq(live.length, res.seeded);
+
+  const pt = live.filter(i => i.lang === 'PT');
+  const es = live.filter(i => i.lang === 'ES');
+  if (!pt.length || !es.length) throw new Error('faltou algum idioma');
+
+  // Cada template tem exatamente uma linha por idioma - duplicata aqui viraria
+  // modelo repetido na lista do agente.
+  const ptKeys = pt.map(i => i.key);
+  eq(new Set(ptKeys).size, ptKeys.length, 'uma linha PT por template:');
+
+  // E todo modelo semeado tem que passar na própria validação.
+  pt.forEach(i => {
+    const r = freshCtx.checkEmailTemplate(i.value, 'PT');
+    if (!r.ok) throw new Error('modelo semeado inválido [' + i.key + ']: ' + r.error);
+  });
+});
+
 console.log('\n--- Case Notes (trechos por campo) ---');
 
 check('QA propõe trecho de nota (está no escopo do papel)', () => {

--- a/scripts/test-email-roundtrip.mjs
+++ b/scripts/test-email-roundtrip.mjs
@@ -1,0 +1,168 @@
+// scripts/test-email-roundtrip.mjs
+//
+// Prova que a migração dos modelos de e-mail é SEM PERDA: semear a partir do
+// email-data.js e reconstruir a partir do que foi semeado tem que devolver
+// exatamente os mesmos modelos - assunto, corpo HTML, placeholders (chave,
+// rótulo, tipo e `auto`) e o overlay ES inteiro.
+//
+// É o risco central desta fase, e o mais caro do projeto: o resultado vai por
+// e-mail para o anunciante. Uma tag HTML perdida, um placeholder que muda de
+// chave ou um `auto` que some não quebram nada visivelmente aqui - aparecem
+// como e-mail torto na caixa de entrada de terceiro.
+//
+// Uso: npm run test:emails
+
+import { build } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const store = {};
+globalThis.window = { location: { hostname: 'localhost' } };
+globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+};
+globalThis.document = { createElement: () => ({}), body: { appendChild() { }, contains: () => false } };
+
+const bundled = await build({
+    entryPoints: [resolve(here, '../src/modules/email-assistant/email-data.js')],
+    bundle: true,
+    write: false,
+    format: 'cjs',
+    platform: 'node',
+    logLevel: 'silent',
+});
+
+const mod = { exports: {} };
+// eslint-disable-next-line no-new-func
+new Function('module', 'exports', 'require', bundled.outputFiles[0].text)(mod, mod.exports, require);
+
+const { EMAIL_TEMPLATES, applyEmailContent, getEmailTemplate } = mod.exports;
+
+// Snapshot ANTES de qualquer hidratação, incluindo a visão em ES que o módulo
+// entrega hoje (é ela que o agente vê, não o overlay cru).
+const originalPt = JSON.parse(JSON.stringify(EMAIL_TEMPLATES));
+const originalEsView = originalPt.map(t => JSON.parse(JSON.stringify(getEmailTemplate(t, 'es'))));
+
+const seed = JSON.parse(readFileSync(resolve(here, '../gas-backend/seeds/email-seed.json'), 'utf8'));
+
+const asServed = seed.items.map((it, idx) => ({
+    key: it.key, field: it.field, lang: it.lang,
+    label: it.label, value: it.value, sortOrder: it.sortOrder ?? idx,
+}));
+
+// Embaralha: a ordem tem que vir do sortOrder, não de como a planilha devolveu.
+for (let i = asServed.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [asServed[i], asServed[j]] = [asServed[j], asServed[i]];
+}
+
+const applied = applyEmailContent(asServed);
+
+let fail = 0;
+function check(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+
+console.log('\n--- Round-trip dos modelos de e-mail ---');
+
+check('a hidratação foi aplicada', () => {
+    if (!applied) throw new Error('applyEmailContent devolveu false');
+});
+
+check('mesmos modelos, na mesma ordem', () => {
+    const a = originalPt.map(t => t.id).join('|');
+    const b = EMAIL_TEMPLATES.map(t => t.id).join('|');
+    if (a !== b) throw new Error(`esperado ${a}\n      veio     ${b}`);
+});
+
+check('assunto e corpo HTML idênticos, byte a byte', () => {
+    for (const orig of originalPt) {
+        const novo = EMAIL_TEMPLATES.find(t => t.id === orig.id);
+        if (!novo) throw new Error('sumiu o modelo ' + orig.id);
+        if (novo.subject !== orig.subject) {
+            throw new Error(`${orig.id}: assunto divergiu\n      antes: ${orig.subject}\n      agora: ${novo.subject}`);
+        }
+        if (novo.template !== orig.template) {
+            throw new Error(`${orig.id}: corpo HTML divergiu (${orig.template.length} -> ${novo.template.length} chars)`);
+        }
+    }
+});
+
+check('placeholders preservam chave, rótulo, tipo e preenchimento automático', () => {
+    for (const orig of originalPt) {
+        const novo = EMAIL_TEMPLATES.find(t => t.id === orig.id);
+        const a = orig.placeholders || [];
+        const b = novo.placeholders || [];
+
+        if (a.length !== b.length) {
+            throw new Error(`${orig.id}: ${a.length} campos viraram ${b.length}`);
+        }
+        for (let i = 0; i < a.length; i++) {
+            // `auto` é o que faz o campo se preencher sozinho (ex.: agentName).
+            // Perder isso não quebra o envio, só devolve trabalho manual ao
+            // agente em silêncio - o tipo de regressão que ninguém reporta.
+            for (const prop of ['key', 'label', 'type', 'auto']) {
+                if (a[i][prop] !== b[i][prop]) {
+                    throw new Error(
+                        `${orig.id}.placeholders[${i}].${prop}: ${JSON.stringify(a[i][prop])} -> ${JSON.stringify(b[i][prop])}`
+                    );
+                }
+            }
+        }
+    }
+});
+
+check('a visão em espanhol continua idêntica', () => {
+    for (const orig of originalEsView) {
+        const base = EMAIL_TEMPLATES.find(t => t.id === orig.id);
+        if (!base) throw new Error('sumiu o modelo ' + orig.id);
+        const novo = getEmailTemplate(base, 'es');
+
+        for (const prop of ['name', 'category', 'subject', 'template']) {
+            if (novo[prop] !== orig[prop]) {
+                throw new Error(`${orig.id}.${prop} divergiu em ES`);
+            }
+        }
+        const a = orig.placeholders || [];
+        const b = novo.placeholders || [];
+        for (let i = 0; i < a.length; i++) {
+            if (a[i].key !== b[i].key) throw new Error(`${orig.id}: chave mudou em ES (${a[i].key} -> ${b[i].key})`);
+            if (a[i].label !== b[i].label) throw new Error(`${orig.id}: rótulo ES divergiu em ${a[i].key}`);
+        }
+    }
+});
+
+check('as chaves dos placeholders continuam em português no corpo em ES', () => {
+    // Traduzir a chave quebraria o preenchimento: é ela que o corpo contém e
+    // que o assistente procura para substituir.
+    for (const base of EMAIL_TEMPLATES) {
+        const es = getEmailTemplate(base, 'es');
+        for (const ph of base.placeholders || []) {
+            const corpo = (es.subject || '') + ' ' + (es.template || '');
+            if (!corpo.includes(ph.key)) {
+                throw new Error(`${base.id}: chave ${ph.key} não está no corpo em ES`);
+            }
+        }
+    }
+});
+
+check('nenhum modelo publicado ficaria com placeholder inconsistente', () => {
+    const TOKEN = /\[[^\][]{2,60}\]/g;
+    for (const t of EMAIL_TEMPLATES) {
+        const corpo = (t.subject || '') + ' ' + (t.template || '');
+        const declarados = (t.placeholders || []).map(p => p.key);
+        const soltos = [...new Set(corpo.match(TOKEN) || [])].filter(k => !declarados.includes(k));
+        if (soltos.length) throw new Error(`${t.id}: token sem declaração: ${soltos.join(', ')}`);
+    }
+});
+
+console.log('\n' + (fail ? '✗' : '✓') + ` round-trip de ${EMAIL_TEMPLATES.length} modelos (PT + ES), ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/src/modules/email-assistant/email-data-service.js
+++ b/src/modules/email-assistant/email-data-service.js
@@ -1,13 +1,24 @@
 // src/modules/email-assistant/email-data-service.js
-import { EMAIL_TEMPLATES } from './email-data.js';
+import { EMAIL_TEMPLATES, hydrateEmailsFromContentCentral } from './email-data.js';
 
 export const EmailDataService = {
     _templates: null,
+    _hydrated: false,
 
     async getTemplates() {
         if (this._templates) return this._templates;
 
-        // Agora, em vez de buscar o JSON, usamos o objeto importado diretamente.
+        // Busca o que está publicado na Central antes de devolver. A hidratação
+        // reescreve EMAIL_TEMPLATES no lugar, então a referência abaixo continua
+        // válida - e se a API falhar, o array segue com os modelos embutidos.
+        //
+        // Ao contrário dos outros módulos, aqui vale esperar: um e-mail montado
+        // com o modelo velho e enviado antes da resposta chegar não tem desfazer.
+        if (!this._hydrated) {
+            this._hydrated = true;
+            await hydrateEmailsFromContentCentral();
+        }
+
         this._templates = EMAIL_TEMPLATES;
         return this._templates;
     }

--- a/src/modules/email-assistant/email-data.js
+++ b/src/modules/email-assistant/email-data.js
@@ -1,3 +1,5 @@
+import { DataService } from "../shared/data-service.js";
+
 // ==================================================================
 //                    TEMPLATES DE E-MAIL (PT)
 // ==================================================================
@@ -195,4 +197,77 @@ export function getEmailTemplate(tpl, lang) {
             label: es.labels?.[ph.key] ?? ph.label
         }))
     };
+}
+
+// --- HIDRATAÇÃO PELA CENTRAL DE CONTEÚDO ---
+// Os modelos acima viram fallback: é o que vale no primeiro load offline, sem
+// resposta da API nem cache. Publicado na Central, o publicado vence.
+//
+// Na planilha cada idioma é uma linha do mesmo template (key = id, lang =
+// PT|ES), e aqui as duas estruturas originais são remontadas - a lista PT e o
+// overlay ES. É por isso que getEmailTemplate() acima não precisou mudar.
+export function applyEmailContent(items) {
+    if (!Array.isArray(items) || !items.length) return false;
+
+    const sorted = items.slice().sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    const pt = [];
+    const es = {};
+
+    for (const item of sorted) {
+        const id = item.key;
+        if (!id) continue;
+
+        let v;
+        try {
+            v = JSON.parse(item.value || '{}');
+        } catch (e) {
+            continue; // Um modelo corrompido não pode derrubar os outros.
+        }
+        if (!v.subject || !v.template) continue;
+
+        if (String(item.lang).toUpperCase() === 'ES') {
+            es[id] = {
+                name: item.label || '',
+                category: item.field || '',
+                subject: v.subject,
+                template: v.template,
+                labels: v.labels || {},
+            };
+        } else {
+            pt.push({
+                id,
+                name: item.label || id,
+                category: item.field || '',
+                subject: v.subject,
+                template: v.template,
+                placeholders: v.placeholders || [],
+            });
+        }
+    }
+
+    // Sem nenhum modelo PT não há o que exibir: melhor manter o embutido do que
+    // deixar o assistente sem template nenhum.
+    if (!pt.length) return false;
+
+    EMAIL_TEMPLATES.length = 0;
+    EMAIL_TEMPLATES.push(...pt);
+
+    for (const key of Object.keys(EMAIL_TEMPLATES_ES)) delete EMAIL_TEMPLATES_ES[key];
+    Object.assign(EMAIL_TEMPLATES_ES, es);
+
+    return true;
+}
+
+export async function hydrateEmailsFromContentCentral() {
+    const cached = DataService.getCachedContent('email_template');
+    let applied = applyEmailContent(cached);
+
+    try {
+        const items = await DataService.fetchContentModule('email_template');
+        applied = applyEmailContent(items) || applied;
+    } catch (e) {
+        console.warn('Central de Conteúdo indisponível; usando modelos embutidos.', e);
+    }
+
+    return applied;
 }


### PR DESCRIPTION
Última fase. Escopo conforme definido: **só os modelos do assistente do agente**. Os e-mails de CR e os disparados pelo Dashboard de TL seguem fora da Central — vivem em `EmailEngine.gs` e são enviados pelo próprio Apps Script.

## Modelo de dados

Cada idioma é uma linha do mesmo template (`key` = id, `lang` = PT|ES). A hidratação remonta as duas estruturas originais (a lista PT e o overlay `EMAIL_TEMPLATES_ES`), por isso **`getEmailTemplate()` não precisou mudar**.

As chaves dos placeholders continuam **em português também no corpo em ES** — é o que o próprio arquivo já documentava, e traduzi-las quebraria o preenchimento.

## Validação de placeholder — o ponto da fase

`assertValidEmailTemplate_()` recusa as duas falhas silenciosas e caras, porque o resultado vai para o anunciante:

1. **Campo declarado que não aparece no corpo** — o agente preenche algo que não vai a lugar nenhum.
2. **Token no corpo sem declaração** — sai **literal**: `Olá, [Nome do Cliente],`.

A tela chama `checkEmailTemplate()` **antes de gravar**, pra o erro chegar enquanto o texto ainda está na tela. O gerador aplica a mesma regra e se **recusa a gerar** se o dado de origem estiver inconsistente.

Auditei os dados atuais antes de tornar a regra rígida: **8 modelos PT, 8 overlays ES, zero inconsistências**.

## Tela

Aba **E-mails** com seletor de idioma, editor de assunto/corpo e **prévia do HTML renderizado ao vivo** — sem ver, dá pra publicar um `<p>` não fechado e só descobrir no e-mail já enviado.

A lista de campos **não** é editável pela tela: mexer nela exigiria casar PT e ES de uma vez, e é exatamente onde um erro vaza placeholder literal.

## No agente

`EmailDataService.getTemplates()` passa a hidratar antes de devolver. Aqui vale **esperar** a resposta, ao contrário dos outros módulos — um e-mail montado com o modelo velho e já enviado não tem desfazer.

## Testes

- **`test:content`** sobe para **45 casos**: as duas regras de placeholder, token só no assunto, ES sem declaração própria, JSON malformado, e a semeadura em planilha zerada exigindo que **todo modelo semeado passe na própria validação**.
- **`test:emails`** (novo): round-trip **sem perda** — assunto e corpo HTML **byte a byte**, placeholders com chave/rótulo/tipo/`auto`, e a visão em ES idêntica. `auto` é o que preenche o campo sozinho: perdê-lo não quebra o envio, só devolve trabalho manual ao agente **em silêncio**.

## Depois do merge

Rodar **`seedEmailsNow`** no Apps Script. Com isso os **quatro módulos** ficam migrados e a aba "Próximos módulos" sai da tela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)