### PR TITLE
feat(content-central): migra as Dicas (Tips) para a Central

### DIFF
--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -16,7 +16,7 @@ const SHEET_CONTENT_ACCESS = "Content_Access";
 // Módulos gerenciáveis. Adicionar um módulo novo é acrescentar uma string
 // aqui - não uma aba nova, que é justamente a dívida que Tips/Broadcast/
 // Database_Snippets acumularam ao ganhar cada um seu próprio schema.
-const CONTENT_MODULES = ['links', 'call_script', 'email_template', 'case_note_snippet'];
+const CONTENT_MODULES = ['links', 'call_script', 'email_template', 'case_note_snippet', 'tips'];
 
 // Idiomas aceitos na coluna `lang`. 'ALL' = vale para todos (caso dos links,
 // cujo par PT/ES mora no próprio valor do item).

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -666,6 +666,9 @@
                 <button class="tab-btn" role="tab" data-tab="emails" onclick="switchTab('emails')">
                     <span class="material-symbols-rounded" style="font-size:19px">mail</span> E-mails
                 </button>
+                <button class="tab-btn" role="tab" data-tab="tips" onclick="switchTab('tips')">
+                    <span class="material-symbols-rounded" style="font-size:19px">lightbulb</span> Dicas
+                </button>
                 <button class="tab-btn" role="tab" data-tab="approvals" onclick="switchTab('approvals')">
                     <span class="material-symbols-rounded" style="font-size:19px">rule</span> Aprovações
                     <span class="count-chip zero" id="pending-count">0</span>
@@ -779,6 +782,26 @@
                 </div>
             </section>
 
+            <!-- TAB: Dicas -->
+            <section id="pane-tips" class="hidden">
+                <div class="note" id="tp-note">
+                    Frases curtas exibidas durante os carregamentos do app.
+                </div>
+                <div class="row-between" style="margin-bottom:14px">
+                    <div>
+                        <div class="card-title">Dicas no ar</div>
+                        <p class="card-sub" id="tp-summary">Carregando…</p>
+                    </div>
+                    <button class="btn btn-primary" id="tp-new-btn" onclick="openTipEditor(null)">
+                        <span class="material-symbols-rounded" style="font-size:19px">add</span> Nova dica
+                    </button>
+                </div>
+                <div class="card" id="tp-list">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+            </section>
+
             <!-- TAB: Aprovações -->
             <section id="pane-approvals" class="hidden">
                 <div id="approvals-list">
@@ -876,6 +899,9 @@
             if (!document.getElementById('pane-emails').classList.contains('hidden')) {
                 loadEmails();
             }
+            if (!document.getElementById('pane-tips').classList.contains('hidden')) {
+                loadTips();
+            }
         }
 
         // A UI é conveniência, não a fronteira: o servidor recusa a ação de
@@ -886,7 +912,7 @@
         }
 
         function switchTab(tab) {
-            ['links', 'callscript', 'notes', 'emails', 'approvals', 'access'].forEach(function (t) {
+            ['links', 'callscript', 'notes', 'emails', 'tips', 'approvals', 'access'].forEach(function (t) {
                 var pane = document.getElementById('pane-' + t);
                 if (pane) pane.classList.toggle('hidden', t !== tab);
             });
@@ -896,6 +922,7 @@
             if (tab === 'callscript') loadCallScript();
             if (tab === 'notes') loadNoteSnippets();
             if (tab === 'emails') loadEmails();
+            if (tab === 'tips') loadTips();
             if (tab === 'approvals') loadApprovals();
             if (tab === 'access') loadAccess();
         }
@@ -929,6 +956,11 @@
                         document.getElementById('cs-new-btn').classList.add('hidden');
                         document.getElementById('cs-note').textContent =
                             'Seu papel (' + s.role + ') vê o roteiro, mas não propõe alterações neste módulo.';
+                    }
+                    if (!canPropose('tips')) {
+                        document.getElementById('tp-new-btn').classList.add('hidden');
+                        document.getElementById('tp-note').textContent =
+                            'Seu papel (' + s.role + ') vê as dicas, mas não propõe alterações neste módulo.';
                     }
                     if (!canPropose('email_template')) {
                         document.getElementById('em-note').textContent =
@@ -1802,6 +1834,149 @@
                     toast(err.message, true);
                 })
                 .checkEmailTemplate(value, item.lang);
+        }
+
+        // --- Dicas ---
+        var TP_ITEMS = [];
+        var TP_DRAFTS = [];
+
+        function loadTips() {
+            google.script.run
+                .withSuccessHandler(function (items) {
+                    TP_ITEMS = items || [];
+                    google.script.run
+                        .withSuccessHandler(function (d) { TP_DRAFTS = d || []; renderTips(); })
+                        .withFailureHandler(function () { TP_DRAFTS = []; renderTips(); })
+                        .listContentDrafts('tips');
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('tp-list').innerHTML =
+                        '<div class="state"><span class="material-symbols-rounded">error</span>' +
+                        '<h2>Não foi possível carregar as dicas</h2><p>' + esc(err.message) + '</p></div>';
+                })
+                .listContentItems('tips');
+        }
+
+        function tpDraftForItem(itemId) {
+            for (var i = 0; i < TP_DRAFTS.length; i++) {
+                if (TP_DRAFTS[i].itemId === itemId) return TP_DRAFTS[i];
+            }
+            return null;
+        }
+
+        function renderTips() {
+            var host = document.getElementById('tp-list');
+            var summary = document.getElementById('tp-summary');
+
+            if (!TP_ITEMS.length) {
+                summary.textContent = 'Nenhuma dica publicada ainda.';
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded">lightbulb</span>' +
+                    '<h2>Nenhuma dica na Central ainda</h2>' +
+                    '<p>Enquanto isso o app segue lendo a aba Tips, como sempre leu. ' +
+                    'Rode a semeadura (seedTipsNow) para trazer as atuais.</p></div>';
+                return;
+            }
+
+            summary.textContent = TP_ITEMS.length + ' dicas publicadas' +
+                (TP_DRAFTS.length ? ' · ' + TP_DRAFTS.length + ' com alteração em andamento' : '');
+
+            host.innerHTML = TP_ITEMS.map(function (it) {
+                var d = tpDraftForItem(it.id);
+                var badge = d
+                    ? (d.status === 'pending'
+                        ? '<span class="pill pending">em revisão</span>'
+                        : '<span class="pill draft">rascunho</span>')
+                    : '';
+
+                var actions = canPropose('tips')
+                    ? '<div style="display:flex;gap:8px">' +
+                    '<button class="btn btn-ghost btn-sm" onclick="openTipEditor(\'' + it.id + '\')">Editar</button>' +
+                    '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
+                    '</div>'
+                    : '';
+
+                return '<div class="item-row">' +
+                    '<div class="item-main">' +
+                    '<div class="item-meta" style="font-size:14px;color:var(--text-primary)">' +
+                    esc(it.value) + ' ' + badge + '</div>' +
+                    '</div>' + actions + '</div>';
+            }).join('');
+        }
+
+        function openTipEditor(itemId) {
+            var item = null;
+            for (var i = 0; i < TP_ITEMS.length; i++) {
+                if (TP_ITEMS[i].id === itemId) item = TP_ITEMS[i];
+            }
+
+            var existingDraft = itemId ? tpDraftForItem(itemId) : null;
+            var src = existingDraft || item;
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" role="dialog" aria-modal="true">' +
+                '<h2>' + (item ? 'Editar dica' : 'Nova dica') + '</h2>' +
+                '<p class="card-sub">Aparece durante os carregamentos. Frases curtas funcionam melhor.</p>' +
+                (existingDraft && existingDraft.status === 'pending'
+                    ? '<div class="note warn" style="margin-top:14px">Esta dica já está em revisão.</div>'
+                    : '') +
+                '<label class="fld" for="tp-text">Texto</label>' +
+                '<textarea id="tp-text" style="min-height:70px">' + esc(src ? src.value : '') + '</textarea>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-primary" id="tp-save">Salvar e enviar para revisão</button>' +
+                '</div></div></div>';
+
+            document.getElementById('tp-save').onclick = function () {
+                submitTip(itemId, existingDraft ? existingDraft.draftId : null, src, this);
+            };
+            document.getElementById('tp-text').focus();
+        }
+
+        function submitTip(itemId, draftId, src, btn) {
+            var text = document.getElementById('tp-text').value.trim();
+            if (!text) return toast('Escreva o texto da dica.', true);
+
+            var sortOrder = src ? src.sortOrder : TP_ITEMS.reduce(function (max, i) {
+                return Math.max(max, i.sortOrder);
+            }, 0) + 1;
+
+            btn.disabled = true;
+            btn.textContent = 'Enviando…';
+
+            google.script.run
+                .withSuccessHandler(function (res) {
+                    google.script.run
+                        .withSuccessHandler(function () {
+                            closeModal();
+                            toast('Proposta enviada para revisão.');
+                            loadTips();
+                            loadPendingCount();
+                        })
+                        .withFailureHandler(function (err) {
+                            btn.disabled = false;
+                            btn.textContent = 'Salvar e enviar para revisão';
+                            toast(err.message, true);
+                        })
+                        .submitContentDraft(res.draftId);
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.textContent = 'Salvar e enviar para revisão';
+                    toast(err.message, true);
+                })
+                .saveContentDraft({
+                    draftId: draftId || '',
+                    itemId: itemId || '',
+                    module: 'tips',
+                    key: 'geral',
+                    lang: 'ALL',
+                    // A dica é o próprio conteúdo: não há título separado.
+                    label: text,
+                    value: text,
+                    sortOrder: sortOrder
+                });
         }
 
         // --- Aprovações ---

--- a/gas-backend/ContentSeed_Tips.js
+++ b/gas-backend/ContentSeed_Tips.js
@@ -1,0 +1,87 @@
+// =========================================================
+// ARQUIVO: ContentSeed_Tips.gs
+//
+// Semeia o módulo "tips" da Central de Conteúdo a partir da aba Tips que já
+// existe.
+//
+// Este é escrito à mão, e não gerado por script como os outros seeds: as dicas
+// nunca moraram no código, moram numa planilha desde sempre. Não há literal em
+// src/ para ler - a migração é de aba para aba, dentro do próprio Apps Script.
+//
+// COMO RODAR: no editor do Apps Script, escolha "seedTipsNow" no seletor de
+// função e clique em Executar. Roda uma vez só; chamadas seguintes são
+// ignoradas se o módulo já tiver itens no ar.
+//
+// A aba Tips NÃO é apagada. Fica como está, intocada: se algo der errado, o
+// caminho de volta é reverter o código, não restaurar dado.
+// =========================================================
+
+function seedTipsNow() {
+  const result = seedContentModule(buildTipsSeedPayload_());
+  Logger.log(result);
+  return result;
+}
+
+// Lê a aba Tips (coluna A, uma dica por linha, pulando o cabeçalho) e monta o
+// payload no formato que seedContentModule espera.
+function buildTipsSeedPayload_() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(SHEET_TIPS);
+  const items = [];
+
+  if (!sheet) return { module: 'tips', items: items };
+
+  const raw = sheet.getDataRange().getValues();
+
+  for (let i = 1; i < raw.length; i++) {
+    const texto = String(raw[i][0] || "").trim();
+    if (!texto) continue;
+
+    items.push({
+      key: 'geral',
+      // As dicas de hoje não são marcadas por idioma - são frases curtas de
+      // carregamento, escritas em PT. 'ALL' evita inventar uma classificação
+      // que ninguém fez; quem quiser separar por idioma depois é só editar.
+      lang: 'ALL',
+      // Uma dica é o próprio conteúdo: não existe título separado. O label
+      // serve pra listagem na tela, então recebe o mesmo texto.
+      label: texto,
+      value: texto,
+      sortOrder: items.length
+    });
+  }
+
+  return { module: 'tips', items: items };
+}
+
+// Serve a rota legada `op=tips`. Prioriza a Central; enquanto o módulo não for
+// semeado, devolve a aba Tips como sempre devolveu.
+//
+// É isso que permite migrar sem coordenar deploy com a base instalada: quem
+// ainda roda um bundle antigo continua funcionando, e passa a ver o conteúdo
+// gerenciado assim que a semeadura roda.
+function getTipsForLegacyEndpoint(ss) {
+  try {
+    const doCentral = readContentRows_(SHEET_CONTENT_ITEMS)
+      .filter(function (r) {
+        return String(r.Module).trim() === 'tips' && String(r.Status).trim() === CONTENT_STATUS.LIVE;
+      })
+      .sort(function (a, b) { return (Number(a.Sort_Order) || 0) - (Number(b.Sort_Order) || 0); })
+      .map(function (r) { return String(r.Value || "").trim(); })
+      .filter(function (t) { return t; });
+
+    if (doCentral.length) return doCentral;
+  } catch (e) {
+    // Central indisponível por qualquer motivo: cai pro comportamento antigo.
+  }
+
+  const sheet = (ss || SpreadsheetApp.getActiveSpreadsheet()).getSheetByName(SHEET_TIPS);
+  if (!sheet) return [];
+
+  const raw = sheet.getDataRange().getValues();
+  const tips = [];
+  for (let i = 1; i < raw.length; i++) {
+    if (raw[i][0]) tips.push(raw[i][0]);
+  }
+  return tips;
+}

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -157,11 +157,11 @@ function doGet(e) {
       result = { broadcast: data };
     }
     else if (op === 'tips') {
-      const sheet = ss.getSheetByName(SHEET_TIPS);
-      const raw = sheet.getDataRange().getValues();
-      const tips = [];
-      for(let i=1; i<raw.length; i++) if(raw[i][0]) tips.push(raw[i][0]);
-      result = { tips: tips };
+      // Rota legada, mantida viva porque bundles antigos em cache ainda a
+      // chamam. Depois da migração ela serve o conteúdo da Central, e não mais
+      // a aba Tips - assim as duas versões do app leem a MESMA fonte, e editar
+      // pela Central vale para todo mundo durante a transição.
+      result = { tips: getTipsForLegacyEndpoint(ss) };
     }
 
     // 5. MÓDULO: Escrita (Broadcast Admin)

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -421,6 +421,111 @@ check('a ordem dos passos sobrevive à semeadura', () => {
   }
 });
 
+console.log('\n--- Dicas (migração da aba Tips) ---');
+
+// Ambiente próprio com a aba Tips já povoada, como está hoje em produção.
+function makeTipsEnv(linhas) {
+  const ss = new FakeSpreadsheet();
+  const tips = ss.insertSheet('Tips');
+  tips.appendRow(['Dica']);
+  linhas.forEach(t => tips.appendRow([t]));
+
+  const ctx2 = vm.createContext({
+    SpreadsheetApp: { getActiveSpreadsheet: () => ss },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    MailApp: { sendEmail: () => { } },
+    Logger: { log: () => { } },
+    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    handleLog: () => { },
+    SHEET_TIPS: 'Tips',
+    console,
+  });
+
+  vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx2);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, '..', 'gas-backend', 'ContentSeed_Tips.js'), 'utf8'),
+    ctx2
+  );
+  return ctx2;
+}
+
+const TIPS_ATUAIS = ['Mantenha o foco!', 'Respire fundo.', 'Quase lá…'];
+
+check('a rota legada serve a aba Tips enquanto não há migração', () => {
+  // Compatibilidade é o ponto: bundles antigos em cache seguem chamando op=tips.
+  const env = makeTipsEnv(TIPS_ATUAIS);
+  eq(env.getTipsForLegacyEndpoint(), TIPS_ATUAIS);
+});
+
+check('seedTipsNow() traz as dicas da aba para a Central', () => {
+  const env = makeTipsEnv(TIPS_ATUAIS);
+  const res = env.seedTipsNow();
+
+  eq(res.status, 'success');
+  eq(res.seeded, TIPS_ATUAIS.length);
+
+  const live = env.listContentItems('tips');
+  eq(live.map(i => i.value), TIPS_ATUAIS, 'mesmas dicas, mesma ordem:');
+});
+
+check('depois da migração a rota legada serve a Central, não mais a aba', () => {
+  // Sem isso a aba viraria uma fonte fantasma: editar pela Central não afetaria
+  // quem ainda roda o bundle antigo, e ninguém entenderia por quê.
+  const env = makeTipsEnv(TIPS_ATUAIS);
+  env.seedTipsNow();
+
+  const item = env.listContentItems('tips').find(i => i.value === 'Respire fundo.');
+  const d = env.saveContentDraft({
+    module: 'tips', itemId: item.id, key: 'geral', lang: 'ALL',
+    label: 'Respire fundo, deu tudo certo.', value: 'Respire fundo, deu tudo certo.',
+    sortOrder: item.sortOrder
+  });
+  env.submitContentDraft(d.draftId);
+  env.approveContentDraft(d.draftId, '');
+
+  const servidas = env.getTipsForLegacyEndpoint();
+  if (!servidas.includes('Respire fundo, deu tudo certo.')) {
+    throw new Error('rota legada não pegou a edição: ' + servidas.join(' | '));
+  }
+  if (servidas.includes('Respire fundo.')) {
+    throw new Error('rota legada ainda serve o texto antigo da aba');
+  }
+});
+
+check('a aba Tips não é apagada pela migração', () => {
+  // O caminho de volta é reverter código, não restaurar dado.
+  const env = makeTipsEnv(TIPS_ATUAIS);
+  env.seedTipsNow();
+
+  const aba = env.SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Tips');
+  const linhas = aba.getDataRange().getValues().slice(1).map(r => r[0]);
+  eq(linhas, TIPS_ATUAIS, 'aba original intacta:');
+});
+
+check('aba Tips vazia não quebra a semeadura', () => {
+  const env = makeTipsEnv([]);
+  const res = env.seedTipsNow();
+  eq(res.seeded, 0);
+  eq(env.getTipsForLegacyEndpoint(), []);
+});
+
+check('dica só entra no ar depois de aprovada', () => {
+  const env = makeTipsEnv(TIPS_ATUAIS);
+  env.seedTipsNow();
+  const antes = env.getTipsForLegacyEndpoint().length;
+
+  const d = env.saveContentDraft({
+    module: 'tips', key: 'geral', lang: 'ALL',
+    label: 'Dica nova', value: 'Dica nova'
+  });
+  env.submitContentDraft(d.draftId);
+
+  eq(env.getTipsForLegacyEndpoint().length, antes, 'pendente não vaza pra rota pública:');
+
+  env.approveContentDraft(d.draftId, '');
+  eq(env.getTipsForLegacyEndpoint().length, antes + 1);
+});
+
 console.log('\n--- E-mails (validação de placeholder) ---');
 
 const emailValue = (subject, body, placeholders) => JSON.stringify({

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -65,10 +65,12 @@ export const DataService = {
     // ==========================================
     // 1. SISTEMA CORE (Dicas e Inicialização)
     // ==========================================
+    // As dicas passaram a ser gerenciadas pela Central de Conteúdo (módulo
+    // 'tips'). O contrato público daqui não mudou: quem chama segue usando
+    // fetchTips() e getRandomTip() sem saber de onde vem.
     fetchTips: async () => {
         try {
-            const data = await jsonpFetch('tips');
-            if (data?.tips) localStorage.setItem(CACHE_KEY_TIPS, JSON.stringify(data.tips));
+            await DataService.fetchContentModule('tips');
         } catch (err) { console.warn("Tips offline", err); }
     },
 
@@ -118,9 +120,25 @@ export const DataService = {
     },
     
     getRandomTip: () => {
-        let tips = FALLBACK_TIPS;
-        const cached = localStorage.getItem(CACHE_KEY_TIPS);
-        if (cached) try { tips = JSON.parse(cached); } catch(e){}
+        let tips = null;
+
+        // 1. Central de Conteúdo (fonte atual).
+        const items = DataService.getCachedContent('tips');
+        if (Array.isArray(items) && items.length) {
+            tips = items.map(i => i.value).filter(Boolean);
+        }
+
+        // 2. Cache da rota antiga. Só importa no primeiro load depois do
+        // deploy, e só se o usuário estiver offline: sem isso ele veria as três
+        // frases genéricas do fallback em vez das dicas que já tinha em cache.
+        if (!tips || !tips.length) {
+            const legado = localStorage.getItem(CACHE_KEY_TIPS);
+            if (legado) try { tips = JSON.parse(legado); } catch (e) { }
+        }
+
+        // 3. Fallback embutido.
+        if (!Array.isArray(tips) || !tips.length) tips = FALLBACK_TIPS;
+
         return tips[Math.floor(Math.random() * tips.length)];
     },
 


### PR DESCRIPTION
Broadcast fica de fora por ora, por decisão — segue exatamente como está.

## Por que este seed é diferente

Diferente das quatro fases anteriores, **não há literal em `src/` para ler**: as dicas nunca moraram no código, moram na aba `Tips` desde sempre. Por isso o seed é escrito à mão e roda dentro do Apps Script, migrando **de aba para aba**, em vez de ser gerado por um script node.

## Compatibilidade com bundles antigos

A rota legada `op=tips` continua existindo, mas passa a servir o conteúdo da Central assim que o módulo é semeado — caindo na aba `Tips` enquanto não for.

Sem isso a aba viraria **fonte fantasma**: editar pela Central não afetaria quem ainda roda um bundle em cache, e ninguém entenderia por quê. Assim as duas versões do app leem a mesma fonte durante a transição, e migrar não exige coordenar deploy com a base instalada.

**A aba `Tips` não é apagada** — fica intocada, para o caminho de volta ser reverter código e não restaurar dado.

## No front

O contrato público não mudou: `fetchTips()` e `getRandomTip()` seguem iguais para quem chama (`app.js` e `command-center.js`).

`getRandomTip()` agora lê a Central, com o **cache da rota antiga como segundo fallback** — só importa no primeiro load pós-deploy e só se o usuário estiver offline, mas sem isso ele veria as três frases genéricas do fallback embutido em vez das dicas que já tinha em cache.

## Testes

**51 casos** (era 45). Cobrem a rota legada antes e depois da migração, a ordem preservada, a aba original intacta, aba vazia, e que **dica pendente não vaza para a rota pública**.

## Depois do merge

Rodar **`seedTipsNow`** no Apps Script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)