### PR TITLE
fix(motion): corrige "fecha e volta" dos módulos e reescreve o genie ancorado na pílula

### DIFF
--- a/src/modules/shared/animations.js
+++ b/src/modules/shared/animations.js
@@ -1,6 +1,22 @@
 // src/modules/shared/animations.js
 
 import { SoundManager } from "./sound-manager.js";
+
+// --- PARÂMETROS DA ANIMAÇÃO "GENIE" ---
+// Abrir é mais longo que fechar de propósito: entrar em cena merece ser
+// admirado, sair da frente do agente não. Os dois tempos são a fonte única
+// de verdade - o CSS lá embaixo e o teardown em JS leem daqui, então mudar
+// a duração num lugar só não deixa mais os dois fora de sincronia (foi
+// exatamente esse descompasso que causava o bug do "fechou e voltou").
+const OPEN_MS = 460;
+const CLOSE_MS = 280;
+// Margem de segurança do fallback: se a página estiver travada e o
+// transitionend não chegar, o teardown acontece assim mesmo.
+const TEARDOWN_GRACE_MS = 200;
+// Escala do estado fechado. Não é 0 porque um elemento com scale(0) é
+// descartado do compositor e a volta fica "pipocando".
+const CLOSED_SCALE = 0.06;
+
 // 1. INJEÇÃO DE ESTILOS (CSS do Módulo + Animações)
 if (!document.getElementById('cw-module-styles')) {
     const style = document.createElement('style');
@@ -8,17 +24,23 @@ if (!document.getElementById('cw-module-styles')) {
     style.innerHTML = `
         /* MÓDULO BASE */
         .cw-module-window {
-            /* Animação Apple Spring (Ida e Volta) */
-            transition: 
+            /* A transição real de abrir/fechar é aplicada inline por
+               toggleGenieAnimation(); esta aqui só cobre as mudanças de
+               estado visual (idle/foco) enquanto a janela está aberta. */
+            transition:
                 opacity 0.3s ease,
-                transform 0.45s var(--cw-ease-decelerate),
                 filter 0.3s ease,
+                border-color 0.3s ease,
                 box-shadow 0.3s ease;
-            
-            opacity: 0; 
+
+            opacity: 0;
             pointer-events: none;
-            transform: scale(0.05); /* Começa dentro do botão */
-            
+            /* Fora de cena de verdade: sem visibility a janela fechada
+               continuava no tab order e no leitor de tela, invisível só por
+               causa do opacity. */
+            visibility: hidden;
+            transform: scale(${CLOSED_SCALE});
+
             /* Visual Ceramic Light */
             background: #F8F9FA;
             backdrop-filter: blur(12px);
@@ -26,16 +48,16 @@ if (!document.getElementById('cw-module-styles')) {
             border: 1px solid rgba(0, 0, 0, 0.12);
             border-radius: 16px;
             overflow: hidden;
-            
+
             /* Fonte Base */
             font-family: 'Google Sans', Roboto, sans-serif;
         }
 
         /* ESTADO ABERTO (Ativo) */
         .cw-module-window.open {
-            opacity: 1; 
-            transform: scale(1); 
+            opacity: 1;
             pointer-events: auto;
+            visibility: visible;
             filter: brightness(1);
             /* Sombra alta */
             box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
@@ -43,17 +65,34 @@ if (!document.getElementById('cw-module-styles')) {
 
         /* ESTADO IDLE (Segundo Plano) */
         .cw-module-window.idle {
-            /* FIX DO DESLOCAMENTO: */
-            /* Scale muito sutil (0.99) para não "puxar" para o lado */
-            transform: scale(0.99); 
-            
-            /* O efeito vem daqui: */
+            /* Sem transform aqui: o transform da janela é sempre inline
+               (é ele que faz o voo até a pílula), então um scale nesta regra
+               nunca chegava a valer nada - e virava alvo fantasma quando o
+               inline era limpo no meio do fechamento. O efeito de "encostou
+               na mesa" vem todo de opacity/filter/sombra. */
             opacity: 0.9;
             filter: brightness(0.96) saturate(0.5);
             border-color: rgba(0, 0, 0, 0.2);
             box-shadow: 0 5px 15px rgba(0,0,0,0.1); /* Sombra cai (encostou na mesa) */
-            
+
             cursor: pointer; /* Indica clicável */
+        }
+
+        /* Pulso de "absorção" no ícone da pílula: um anel colapsa pra dentro
+           do botão no momento exato em que a janela é sugada (e quando ela
+           sai), dando a leitura de que os dois são o mesmo objeto.
+           É um anel de box-shadow, e não um scale, porque .cw-btn:hover já
+           usa transform com !important - o mouse quase sempre está em cima
+           do botão na hora do clique, e um pulso de scale simplesmente não
+           apareceria. */
+        @keyframes cw-btn-absorb {
+            0%   { box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.28); }
+            100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
+        }
+        .cw-btn.cw-absorbing { animation: cw-btn-absorb 0.34s var(--cw-ease-decelerate, ease-out); }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-btn.cw-absorbing { animation: none; }
         }
     `;
     document.head.appendChild(style);
@@ -81,144 +120,302 @@ if (!window._cwEscapeListenerActive) {
     });
 }
 
+function prefersReducedMotion() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+}
+
+/**
+ * Onde a janela nasce e para onde ela é sugada.
+ *
+ * O alvo natural é o ícone do próprio módulo na pílula. Mas quando a pílula
+ * está recolhida os ícones ficam com `visibility: hidden` e `scale(0.5)` -
+ * o getBoundingClientRect() deles devolve um retângulo que não corresponde a
+ * nada na tela (chegava a cair fora da viewport), e a janela voava pra um
+ * canto aleatório. Nesse caso o alvo correto é a bolinha recolhida, que é o
+ * que o agente de fato está vendo.
+ */
+function getAnchorPoint(buttonId) {
+    const pill = document.querySelector('.cw-pill');
+    const btn = buttonId ? document.getElementById(buttonId) : null;
+    const pillCollapsed = !!(pill && pill.classList.contains('collapsed'));
+
+    const usable = (el) => {
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        if (!r.width || !r.height) return null;
+        return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    };
+
+    if (!pillCollapsed) {
+        const fromBtn = usable(btn);
+        if (fromBtn) return fromBtn;
+    }
+    return usable(pill);
+}
+
+/**
+ * Retângulo da janela na posição de repouso (aberta), medido sem transform.
+ *
+ * Precisamos disso porque o transform-origin é expresso em coordenadas da
+ * caixa de layout, e a janela pode estar no meio de um voo quando alguém
+ * pede a medida.
+ */
+function measureRestBox(popup, isCustomPosition) {
+    const prevTransition = popup.style.transition;
+    const prevTransform = popup.style.transform;
+
+    popup.style.transition = 'none';
+    popup.style.transform = 'none';
+    const box = popup.getBoundingClientRect();
+
+    // O getBoundingClientRect() acima força um recálculo de estilo, então o
+    // navegador enxerga o transform zerado como um estado real. Devolver o
+    // valor original precisa de outro flush AINDA com transition: none -
+    // senão o próprio ato de medir dispararia uma transição fantasma de
+    // "none" de volta pro transform de repouso.
+    popup.style.transform = prevTransform;
+    void popup.offsetWidth;
+    popup.style.transition = prevTransition;
+
+    // Sem drag a janela é centralizada com translate(-50%, -50%), então a
+    // caixa de layout fica meia largura/altura deslocada do que se vê.
+    return {
+        left: isCustomPosition ? box.left : box.left - box.width / 2,
+        top: isCustomPosition ? box.top : box.top - box.height / 2,
+        width: box.width,
+        height: box.height,
+    };
+}
+
+/**
+ * Ancora o scale no ponto da pílula.
+ *
+ * Antes o voo era feito com translate(delta) + scale a partir do centro: a
+ * janela encolhia pro próprio miolo enquanto escorregava pro lado, o que lê
+ * como "sumiu e foi embora", não como "foi sugada". Colocando o
+ * transform-origin em cima do ícone, o scale sozinho já puxa a janela pra
+ * dentro dele - é a mesma física do genie do macOS e dispensa qualquer
+ * cálculo de delta (que era justamente de onde vinham os destinos errados).
+ */
+function applyGenieOrigin(popup, anchor, rest) {
+    if (!anchor) {
+        popup.style.transformOrigin = '50% 50%';
+        popup._cwOrigin = null;
+        return;
+    }
+    const origin = `${Math.round(anchor.x - rest.left)}px ${Math.round(anchor.y - rest.top)}px`;
+    popup.style.transformOrigin = origin;
+    popup._cwOrigin = origin;
+}
+
+function closedTransform(isCustomPosition) {
+    return isCustomPosition
+        ? `translate(0, 0) scale(${CLOSED_SCALE})`
+        : `translate(-50%, -50%) scale(${CLOSED_SCALE})`;
+}
+
+function restTransform(isCustomPosition) {
+    return isCustomPosition ? 'translate(0, 0) scale(1)' : 'translate(-50%, -50%) scale(1)';
+}
+
+function pulseButton(btn) {
+    if (!btn || prefersReducedMotion()) return;
+    btn.classList.remove('cw-absorbing');
+    void btn.offsetWidth; // reinicia a animação se dois toggles vierem colados
+    btn.classList.add('cw-absorbing');
+    setTimeout(() => btn.classList.remove('cw-absorbing'), 400);
+}
+
 /**
  * Gerencia a animação Genie e o Foco
  */
 export function toggleGenieAnimation(show, popup, buttonId) {
-    const btn = document.getElementById(buttonId);
+    const btn = buttonId ? document.getElementById(buttonId) : null;
     if (!popup) return;
+
+    // Cada chamada invalida a anterior. Sem isso, o teardown agendado por um
+    // fechamento continuava correndo mesmo depois de o módulo ser reaberto -
+    // e derrubava a janela recém-aberta na cara do agente.
+    const token = (popup._cwAnimToken || 0) + 1;
+    popup._cwAnimToken = token;
+    const stale = () => popup._cwAnimToken !== token;
+
+    // Limpa qualquer teardown pendente do ciclo anterior.
+    if (popup._cwTeardown) {
+        popup._cwTeardown();
+        popup._cwTeardown = null;
+    }
 
     // A animação mais disparada do app inteiro (9 módulos, várias aberturas
     // por turno) não tinha nenhuma proteção de reduced-motion - a física de
-    // voo (translate+scale) some, mas a posição final é aplicada do mesmo
-    // jeito, só sem o trajeto animado.
-    const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // voo (scale ancorado na pílula) some, mas o estado final é aplicado do
+    // mesmo jeito, só sem o trajeto animado.
+    const reduceMotion = prefersReducedMotion();
 
     // Verifica se é a primeira vez (Centro) ou se já foi movido (Customizado)
     const isCustomPosition = popup.getAttribute("data-moved") === "true";
-
-    // 1. ONDE ESTÁ O BOTÃO? (Origem)
-    let btnCenter = { x: 0, y: 0 };
-    if (btn) {
-        const btnRect = btn.getBoundingClientRect();
-        btnCenter.x = btnRect.left + (btnRect.width / 2);
-        btnCenter.y = btnRect.top + (btnRect.height / 2);
-    }
-
-    // 2. ONDE É O DESTINO?
-    let destX, destY;
-
-    if (!isCustomPosition) {
-        // CASO A: Primeira vez -> Centro da Tela
-        destX = window.innerWidth / 2;
-        destY = window.innerHeight / 2;
-    } else {
-        // CASO B: Já foi movido -> Posição Atual do DOM
-        // Pegamos o boundingBox atual (mesmo oculto, ele guarda a posição top/left setada pelo drag)
-        const rect = popup.getBoundingClientRect();
-        
-        // O centro do popup na posição onde ele foi deixado
-        destX = rect.left + (rect.width / 2);
-        destY = rect.top + (rect.height / 2);
-        
-        // Fallback de segurança: Se por algum motivo as coordenadas forem 0 (bug de display none)
-        // forçamos voltar ao centro para não quebrar.
-        if (destX === 0 && destY === 0) {
-            destX = window.innerWidth / 2;
-            destY = window.innerHeight / 2;
-        }
-    }
-
-    // 3. CALCULA O DELTA (Distância do voo)
-    const deltaX = btnCenter.x - destX;
-    const deltaY = btnCenter.y - destY;
 
     if (show) {
         // --- ABRIR ---
         SoundManager.playGenieOpen();
 
-        // A. RESET INSTANTÂNEO
+        // A. ANCORAGEM (de onde a janela nasce)
+        const rest = measureRestBox(popup, isCustomPosition);
+        applyGenieOrigin(popup, getAnchorPoint(buttonId), rest);
+
+        // B. RESET INSTANTÂNEO (colapsada em cima do ícone)
         popup.style.transition = 'none';
         popup.style.opacity = '0';
         popup.style.pointerEvents = 'auto';
-        // will-change só durante a animação em si (~500ms) - este popup é 1
-        // de ~9 janelas de módulo que existem no DOM o tempo todo, então
-        // deixar isso ligado sempre desperdiçaria memória de GPU nas 8 que
-        // estão fechadas e paradas.
+        popup.style.transform = closedTransform(isCustomPosition);
+        // will-change só durante a animação em si - este popup é 1 de ~9
+        // janelas de módulo que existem no DOM o tempo todo, então deixar
+        // isso ligado sempre desperdiçaria memória de GPU nas 8 que estão
+        // fechadas e paradas.
         popup.style.willChange = 'transform, opacity';
-        setTimeout(() => { popup.style.willChange = 'auto'; }, 550);
-
-        // B. POSIÇÃO DE PARTIDA (NO BOTÃO)
-        if (!isCustomPosition) {
-            // Se for centralizado, precisamos manter o offset de -50%
-            popup.style.transform = `translate(calc(-50% + ${deltaX}px), calc(-50% + ${deltaY}px)) scale(0.05)`;
-        } else {
-            // Se for posição fixa (drag), NÃO usamos translate -50%
-            popup.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(0.05)`;
-        }
 
         // C. REFLOW
         void popup.offsetWidth;
 
         // D. ANIMAÇÃO DE ENTRADA
         requestAnimationFrame(() => {
-            popup.classList.add('open'); // Suas classes de controle
-            if (btn) btn.classList.add('active');
+            if (stale()) return;
 
-            // Física Apple
+            popup.classList.add('open');
+            popup.classList.remove('idle');
+            if (btn) btn.classList.add('active');
+            pulseButton(btn);
+
+            // Física Apple: o transform desacelera devagar (a janela "chega"
+            // no lugar), o opacity termina antes pra janela já estar legível
+            // enquanto os últimos pixels de escala se acomodam.
             popup.style.transition = reduceMotion
                 ? "opacity 0.15s ease"
-                : "opacity 0.4s ease-out, transform 0.5s var(--cw-ease-decelerate)";
+                : `opacity ${Math.round(OPEN_MS * 0.6)}ms ease-out,`
+                  + ` transform ${OPEN_MS}ms var(--cw-ease-decelerate),`
+                  + ` filter 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease`;
             popup.style.opacity = '1';
+            popup.style.transform = restTransform(isCustomPosition);
 
-            // POSIÇÃO FINAL (DESTINO)
-            if (!isCustomPosition) {
-                // Volta para o centro perfeito
-                popup.style.transform = "translate(-50%, -50%) scale(1)";
-            } else {
-                // Fica onde o top/left mandam (sem offset de translate)
-                popup.style.transform = "translate(0, 0) scale(1)";
-            }
+            afterTransition(popup, token, reduceMotion ? 150 : OPEN_MS, () => {
+                popup.style.willChange = 'auto';
+                popup._cwSettled = true;
+            });
         });
-        
-        // Listeners (Idle, etc)
-        if (typeof setupIdleListener === 'function') setupIdleListener(popup, buttonId);
+
+        popup._cwSettled = false;
+        setupIdleListener(popup, buttonId);
 
     } else {
         // --- FECHAR ---
-SoundManager.playSwoosh();
-        // A. CONFIGURA SAÍDA
+        SoundManager.playSwoosh();
+
+        // A. ANCORAGEM (pra onde a janela é sugada)
+        // Recalculada agora, e não na abertura: entre abrir e fechar a
+        // pílula pode ter sido arrastada pro outro lado da tela ou recolhida.
+        // Se a janela ainda estiver voando (fechou logo depois de abrir),
+        // mantemos a origem do voo em curso pra não dar um salto no meio.
+        if (popup._cwSettled || !popup._cwOrigin) {
+            const rest = measureRestBox(popup, isCustomPosition);
+            applyGenieOrigin(popup, getAnchorPoint(buttonId), rest);
+        }
+
+        // B. CONFIGURA SAÍDA
         popup.style.transition = reduceMotion
             ? "opacity 0.15s ease"
-            : "opacity 0.25s ease, transform 0.3s var(--cw-ease-accelerate)";
+            : `opacity ${Math.round(CLOSE_MS * 0.8)}ms ease,`
+              + ` transform ${CLOSE_MS}ms var(--cw-ease-accelerate)`;
         popup.style.pointerEvents = 'none';
         popup.style.willChange = 'transform, opacity';
 
-        // B. ANIMAÇÃO DE SAÍDA (VOLTA PRO BOTÃO)
+        // Devolve o foco pra pílula se ele estava dentro da janela que está
+        // fechando - senão o foco fica órfão num elemento invisível e o
+        // próximo Tab reinicia do topo da página do CRM.
+        if (btn && popup.contains(document.activeElement)) {
+            try { btn.focus({ preventScroll: true }); } catch (e) { btn.focus(); }
+        }
+
+        // C. ANIMAÇÃO DE SAÍDA (SUGADA PRA DENTRO DO ÍCONE)
         requestAnimationFrame(() => {
+            if (stale()) return;
+
             popup.style.opacity = '0';
-            
-            if (!isCustomPosition) {
-                popup.style.transform = `translate(calc(-50% + ${deltaX}px), calc(-50% + ${deltaY}px)) scale(0.1)`;
-            } else {
-                popup.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(0.1)`;
-            }
+            popup.style.transform = closedTransform(isCustomPosition);
+
+            // D. LIMPEZA - só depois que a animação REALMENTE terminou.
+            //
+            // Este era o bug do "fechou e voltou": a limpeza era um
+            // setTimeout(300) disparado junto com uma transição de 300ms, ou
+            // seja, sempre chegava antes (o timer conta a partir do clique, a
+            // transição só começa no frame seguinte - e qualquer travadinha
+            // do CRM aumentava a diferença). Ela zerava transform/transition
+            // no meio do voo, e a janela, ainda visível, era re-animada de
+            // volta pro transform de repouso do CSS. Agora quem manda é o
+            // transitionend, com timeout só de rede de segurança.
+            afterTransition(popup, token, reduceMotion ? 150 : CLOSE_MS, () => {
+                popup.classList.remove('open');
+                // O idle nunca era removido: o módulo reabria acinzentado e
+                // dessaturado, e a regra .idle ainda disputava o estado de
+                // repouso com o transform inline.
+                popup.classList.remove('idle');
+                popup.style.zIndex = '';
+                if (btn) btn.classList.remove('active');
+                pulseButton(btn);
+
+                popup.style.willChange = 'auto';
+                popup.style.transition = '';
+                // transform e opacity ficam onde estão (colapsados sobre o
+                // ícone). Limpá-los devolveria a janela pro transform do CSS
+                // base, que é outro lugar - era daí que vinha o "puxão de
+                // volta" no fim do fechamento.
+                // IMPORTANTE: Não limpamos top/left aqui, para a memória persistir
+            });
         });
 
-        // C. LIMPEZA
-        setTimeout(() => {
-            popup.classList.remove('open');
-            if (btn) btn.classList.remove('active');
-            
-            // Limpa estilos
-            popup.style.transition = '';
-            popup.style.transform = '';
-            popup.style.willChange = 'auto';
-            // IMPORTANTE: Não limpamos top/left aqui, para a memória persistir
-        }, 300);
-
-        if (typeof removeIdleListener === 'function') removeIdleListener(popup);
+        removeIdleListener(popup);
     }
+}
+
+/**
+ * Executa `done` quando a transição de transform do popup terminar, com
+ * timeout de segurança. Ignora transitionend de elementos filhos (todo módulo
+ * tem dezenas deles animando dentro) e desiste em silêncio se outro toggle
+ * tiver assumido o controle no meio do caminho.
+ */
+function afterTransition(popup, token, durationMs, done) {
+    let finished = false;
+
+    const cleanup = () => {
+        popup.removeEventListener('transitionend', onEnd);
+        clearTimeout(timer);
+        if (popup._cwTeardown === cleanup) popup._cwTeardown = null;
+    };
+
+    const finish = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        if (popup._cwAnimToken !== token) return;
+        done();
+    };
+
+    const onEnd = (e) => {
+        if (e.target !== popup) return;
+        // Só o transform vale como "acabou": ele é sempre a propriedade mais
+        // longa do par (o opacity termina antes de propósito). Aceitar o
+        // opacity aqui recriaria em menor escala o mesmo corte que este
+        // teardown existe para evitar. Quando o transform não anima
+        // (reduced-motion, ou fechar uma janela que já estava colapsada) o
+        // transitionend simplesmente não vem e o timer abaixo assume.
+        if (e.propertyName !== 'transform') return;
+        finish();
+    };
+
+    popup.addEventListener('transitionend', onEnd);
+    const timer = setTimeout(finish, durationMs + TEARDOWN_GRACE_MS);
+
+    // Handle pro próximo toggle cancelar este teardown sem executá-lo.
+    popup._cwTeardown = cleanup;
 }
 
 // --- GERENCIAMENTO DE FOCO (IDLE SYSTEM) ---
@@ -241,7 +438,7 @@ function setupIdleListener(popup, buttonId) {
             popup.classList.remove('idle');
             popup.style.zIndex = '2147483648'; // Traz pra frente
         } else if (clickInPill) {
-            // Clicou na pílula: 
+            // Clicou na pílula:
             // NÃO faz nada aqui. O evento de click do botão vai cuidar de fechar.
             // Se colocarmos 'idle' aqui, ele briga com o toggle de fechar.
         } else {
@@ -250,7 +447,7 @@ function setupIdleListener(popup, buttonId) {
             popup.style.zIndex = '2147483646'; // Recua
         }
     };
-    
+
     popup._idleHandler = handler;
     document.addEventListener('mousedown', handler);
 }

--- a/src/modules/shared/command-center.js
+++ b/src/modules/shared/command-center.js
@@ -531,25 +531,29 @@ export function initCommandCenter(actions, splashDone) {
   syncStreakBadge();
 
   // 3. LISTENERS
-  const toggleModule = (btnClass, actionFn) => {
+  const toggleModule = (actionFn) => {
     SoundManager.playClick();
-    const btn = pill.querySelector(`.${btnClass}`);
-    btn.classList.toggle('active');
+    // O estado 'active' do ícone é responsabilidade exclusiva de
+    // toggleGenieAnimation(), que é por onde TODA abertura/fechamento de
+    // módulo passa (clique aqui, X do header, Esc, command palette).
+    // Alternar a classe aqui também criava uma segunda fonte de verdade: ao
+    // abrir pela palette e fechar pela pílula, os dois se cancelavam e o
+    // ícone ficava marcado como ativo com a janela fechada.
     actionFn();
   };
 
-  pill.querySelector(".notes").onclick = (e) => { e.stopPropagation(); toggleModule('notes', actions.toggleNotes); };
-  pill.querySelector(".bauform").onclick = (e) => { e.stopPropagation(); toggleModule('bauform', actions.toggleBAUForm); };
-  pill.querySelector(".email").onclick = (e) => { e.stopPropagation(); toggleModule('email', actions.toggleEmail); };
-  pill.querySelector(".script").onclick = (e) => { e.stopPropagation(); toggleModule('script', actions.toggleScript); };
-  pill.querySelector(".links").onclick = (e) => { e.stopPropagation(); toggleModule('links', actions.toggleLinks); };
-  pill.querySelector(".library").onclick = (e) => { e.stopPropagation(); toggleModule('library', actions.toggleLibrary); }; // [NOVO]
-  pill.querySelector(".timezone").onclick = (e) => { e.stopPropagation(); toggleModule('timezone', actions.toggleTimezone); };
-  pill.querySelector(".configs").onclick = (e) => { e.stopPropagation(); toggleModule('configs', actions.toggleConfigs); };
+  pill.querySelector(".notes").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleNotes); };
+  pill.querySelector(".bauform").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleBAUForm); };
+  pill.querySelector(".email").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleEmail); };
+  pill.querySelector(".script").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleScript); };
+  pill.querySelector(".links").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleLinks); };
+  pill.querySelector(".library").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleLibrary); }; // [NOVO]
+  pill.querySelector(".timezone").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleTimezone); };
+  pill.querySelector(".configs").onclick = (e) => { e.stopPropagation(); toggleModule(actions.toggleConfigs); };
 
   pill.querySelector(".broadcast").onclick = (e) => {
     e.stopPropagation();
-    toggleModule('broadcast', () => {
+    toggleModule(() => {
       const badge = e.currentTarget.querySelector('.cw-badge');
       if (badge) badge.remove();
       if (actions.broadcastControl) actions.broadcastControl.toggle();


### PR DESCRIPTION
## O bug

Fechar um módulo pelo X às vezes fazia a janela voltar rapidinho, obrigando a fechar de novo.

A limpeza do fechamento era um `setTimeout(300)` disparado junto com uma transição de saída de 300ms. O timer conta a partir do clique, mas a transição só começa no frame seguinte — então a limpeza **sempre** chegava antes do fim, e qualquer travadinha da página aumentava a diferença. Ela zerava `transform` e `transition` no meio do voo, e a janela, ainda visível, era re-animada de volta pro transform de repouso do CSS.

Reproduzido com 220ms de jank na main thread (o que um CRM pesado faz o tempo todo):

| | antes | depois |
|---|---|---|
| fim real da transição | 772ms | 746ms |
| limpeza rodou em | **301ms** | 762ms |
| opacidade nesse instante | **0.555** | 0 |
| escala nesse instante | **0.95** | colapsada |

Com o módulo em `idle` era pior: a regra `.idle` definia `transform: scale(0.99)`, então o alvo pós-limpeza era a janela em **tamanho cheio** — ela voltava inteira à cena (medido: opacidade 1.0 no momento da limpeza, rect final de 594px).

## Correções

- **Teardown dirigido pelo `transitionend`** do transform, com timeout só de rede de segurança (duração + 200ms). Nunca mais corta o voo.
- **Token por popup** invalida animações anteriores: reabrir durante o fechamento não deixa mais o teardown antigo derrubar a janela recém-aberta.
- **`.idle` nunca era removido no fechamento** — o módulo reabria acinzentado e dessaturado, e a regra ainda disputava o estado de repouso com o transform inline.
- **O transform final não é mais limpo**: a janela descansa colapsada sobre o ícone, em vez de ser puxada de volta pro transform do CSS base.
- **`toggleModule()` não alterna mais `active` por fora**: quem manda no estado do ícone é `toggleGenieAnimation()`, por onde passam pílula, X, Esc e command palette. Eram duas fontes de verdade que se cancelavam quando as origens se misturavam.

## Animação

- **Genie ancorado de verdade.** O voo era `translate(delta) + scale` a partir do centro — a janela encolhia pro próprio miolo enquanto escorregava pro lado, o que lê como "sumiu e foi embora", não como "foi sugada". Agora o `transform-origin` é o ícone do módulo na pílula e o scale sozinho puxa a janela pra dentro dele. Some o cálculo de delta, que era de onde vinham os destinos errados.
- **Pílula recolhida.** Os ícones ficam com `visibility: hidden` e `scale(0.5)`; o `getBoundingClientRect()` deles chegava a cair **fora da viewport** (medido: y=937 numa tela de 900px), e a janela voava pra um canto aleatório. A âncora agora é a bolinha recolhida, que é o que o agente está vendo.
- **Tempos assimétricos**: abrir 460ms (decelerate), fechar 280ms (accelerate), com o opacity terminando antes do transform nos dois sentidos.
- **Pulso de absorção** no ícone da pílula no instante do encontro — anel de `box-shadow`, não `scale`, porque `.cw-btn:hover` já usa `transform` com `!important` e o mouse quase sempre está em cima do botão na hora do clique.
- **Janela fechada é `visibility: hidden`**: sai do tab order e do leitor de tela. O foco volta pro ícone da pílula se estava dentro da janela que fechou.
- `prefers-reduced-motion` respeitado em todos os caminhos novos.

## Verificação

Playwright sobre `mock-crm.html`, com o onboarding pulado:

- 17 checagens automatizadas: trajetória de abertura ancorada no ícone, fechamento monotônico sem volta, corrida fechar→reabrir em 60ms, ciclo de idle, pílula recolhida, `prefers-reduced-motion`, estado do ícone abrindo pela palette e fechando pela pílula.
- Os 9 módulos (Notes, BAU Form, Email, Call Script, Links, Biblioteca, Timezone, Configs, Avisos) abrindo e fechando sem sobra.
- Janela arrastada: posição preservada entre fechar e reabrir, e âncora do genie batendo no ícone com erro < 2px.
- Teste de jank comparando bundle antigo e novo, com e sem `idle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)