### PR TITLE
feat(shortcuts): atalhos do Ctrl+K configuráveis por agente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Atalhos do Ctrl+K configuráveis por agente.** Cada pessoa escolhe os
+  comandos que quer no Ctrl+K: status + substatus + os cenários que quiser (ou
+  nenhum), com nome e apelido de busca próprios. Dois caminhos para criar — o
+  botão "Salvar como atalho" no Case Notes, que captura a combinação já montada
+  na tela, e o construtor em Configurações → **Meus Atalhos**, onde também se
+  renomeia, reordena (arrastando ou pelas setas) e exclui. O palette passa a
+  agrupar "Meus atalhos" acima de "Módulos" e, por padrão, ordena os atalhos por
+  frequência de uso (desligável). Limite de 8 atalhos. Quem nunca configurou
+  nada continua recebendo os dois de sempre, agora editáveis.
+  Ver `docs/decisions/0002-atalhos-ctrl-k-por-agente.md`.
+- **Aba `User_Prefs`** e ops `get_user_prefs`/`save_user_prefs`: preferência de
+  agente na nuvem (cache-first, mesmo padrão da Biblioteca Pessoal), para que a
+  configuração siga a pessoa ao trocar de máquina ou de perfil do Chrome.
+- Suítes `npm run test:shortcuts` (16 casos), `npm run test:prefs` (12) e
+  `npm run smoke:shortcuts` (10, Playwright sobre o `mock-crm.html`).
 - Project adopted into groundrules on 2026-08-18
 - **Suporte a espanhol (PT/ES) em todo o produto.** O idioma da interface é
   herdado do perfil da pessoa na planilha People (`profile.defaultLanguage`) e
@@ -25,6 +40,17 @@ versions follow [Semantic Versioning](https://semver.org/).
   módulos agora seguem o idioma único da sessão, trocado em Configurações.
 
 ### Fixed
+- **Os atalhos de nota do Ctrl+K sumiriam sem aviso quando a Central de Conteúdo
+  publicasse os modelos de nota.** `applyNoteTemplateContent()` reescreve
+  `scenarioSnippets` inteiro com ids derivados e sem o campo `quickLaunch`, do
+  qual os atalhos dependiam — o filtro do palette passaria a devolver zero, sem
+  erro nenhum. Os atalhos agora vivem fora do catálogo de cenários e referenciam
+  o cenário com resolução tolerante (id exato → slug no mesmo substatus).
+- Um atalho apontando para um cenário que não existe mais abria a nota pela
+  metade em silêncio; agora avisa o agente e aparece marcado em Configurações.
+- Cenários publicados pela Central apareciam nos chips com o id cru
+  (`cw in_not_reachable in no show bau`); passam pelo mesmo `scenarioLabel()`
+  que o construtor de atalhos usa.
 - Botões "Não/Sim" do seletor "Caso de Portugal?" (Notes) não retraduziam ao
   trocar de idioma.
 - Botão padrão de confirmação destrutiva (`confirmDialog`) ficava em português

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ TechSol Operations Assistant — a productivity and automation suite for a corpo
 
 - Install deps: `npm install`
 - Run dev: `npm run dev` — builds `dist/bundle-dev.js`; there is no localhost target, load it into the real CRM via the Dev bookmarklet (see `README.md`)
-- Test: no automated test suite exists today — verify manually via the Dev bookmarklet on the CRM and the Apps Script execution log (see `README.md` → Testing)
+- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts` drives the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
 - Lint: none configured
 - Build: `npm run build` — builds `dist/bundle.js` (minified, production)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -33,6 +33,15 @@ Raw ideas, captured before they're lost (e.g. via `/groundrules:idea`). Not yet 
 
 ## Recently done
 
+- [~] **Atalhos do Ctrl+K por agente** — captura no Case Notes + construtor em
+      Configurações, persistência em `User_Prefs` (nuvem, cache-first), grupos e
+      ranking por uso no palette. ADR em
+      `docs/decisions/0002-atalhos-ctrl-k-por-agente.md`. Testes: `test:shortcuts`,
+      `test:prefs`, `smoke:shortcuts`. O merge em `refactor-structure` já leva o
+      backend novo ao deployment de **dev** pela CI (a aba `User_Prefs` nasce
+      sozinha no primeiro uso). Para **produção**, falta o `clasp deploy` manual
+      de sempre (`RELEASE.md`) — até lá, em produção os atalhos funcionam mas
+      ficam só no navegador de cada pessoa, que é o fallback previsto. (2026-08-20)
 - [x] Project adopted into groundrules (2026-08-18)
 - [x] Suporte PT/ES completo — interface, conteúdo (notas, e-mails, links) e
       Apps Script (e-mails automáticos + TL Dashboard). Idioma herdado da

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A productivity and automation suite for a corporate CRM, delivered as a JavaScri
 - **Broadcast System** — global announcements sourced from the backend, with `localStorage`-based read tracking and a custom emoji-shortcode parser.
 - **Links Hub** — curated shortcuts to internal tools and pages, grouped by task.
 - **Command Center & Command Palette** — a floating pill that surfaces every module, plus a `Ctrl/Cmd+K` quick-search that calls the same toggle functions as clicking an icon.
+- **Per-agent Ctrl+K shortcuts** — each agent configures their own quick commands (status + substatus + scenarios), created either by capturing a Case Notes screen they already built or from a builder in Settings. Stored per person in the backend so they follow the agent across machines.
 - **Onboarding & Changelog wizards** — first-run tutorial slides and a "what's new" popup shown automatically when the app version changes.
 - **Sound UX & Material Look** — audio feedback for success/error/notification events, a cinematic startup sound, and CSS-in-JS components styled to blend into Google's native UI.
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -19,7 +19,9 @@ Keep definitions short and precise. The goal: a new developer (or Claude) quickl
 
 **Command Center** — The floating pill UI (`src/modules/shared/command-center.js`) that is the app's main entry point, surfacing every module and drag-repositionable on screen.
 
-**Command Palette** — The `Ctrl/Cmd+K` quick-search overlay (`command-palette.js`) that calls the same toggle functions as clicking a Command Center icon, without duplicating open/close logic.
+**Command Palette** — The `Ctrl/Cmd+K` quick-search overlay (`command-palette.js`) that calls the same toggle functions as clicking a Command Center icon, without duplicating open/close logic. It lists two groups: the agent's own **Shortcuts** first, then the modules.
+
+**Shortcut (Ctrl+K)** — An agent-owned command in the palette (`shared/shortcut-service.js`): a case type + status + substatus + zero or more scenarios, with a name and a search alias. It stores *references* to scenarios, never their text, so published content corrections reach it for free. Created from Case Notes ("Salvar como atalho") or from Configurações → Meus Atalhos; capped at 8. Not to be confused with a **Scenario**, which is content, or a **Draft**, which is one unfinished note.
 
 ## D
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -12,6 +12,30 @@ Include the minimal code snippet / command when it is the fix.
 
 ---
 
+## Não pendure dado novo dentro de uma estrutura que a Central de Conteúdo reescreve
+
+**Why**: os atalhos do Ctrl+K nasceram como um campo `quickLaunch` dentro de dois
+cenários de `notes-data.js`. Parecia o lugar óbvio — o atalho *é sobre* aquele
+cenário. Mas `applyNoteTemplateContent()` (note-templates-service.js) **apaga
+`scenarioSnippets` inteiro** e o repovoa com o que veio da Central, cujos ids são
+derivados (`cw-<substatus>-<slug>`) e cujo payload carrega apenas `type`,
+`substatus` e os campos de texto. No dia em que o módulo `note_template` fosse
+publicado, o `filter(([, d]) => d.quickLaunch)` do palette passaria a devolver
+zero e os dois atalhos sumiriam da tela do agente **sem erro nenhum, sem log,
+sem nada**. Ninguém teria ligado o desaparecimento à publicação do conteúdo.
+
+A mesma armadilha vale para qualquer campo extra pendurado ali: `linkedTask` e
+`activeTasks` só sobrevivem porque o serviço os copia explicitamente.
+
+**When to apply**: antes de adicionar um campo a `scenarioSnippets`,
+`EMAIL_TEMPLATES`, `LINKS_DB`, `callScriptData` ou qualquer outra estrutura que
+um serviço da Central reescreva — pergunte "quem reconstrói isto, e vai copiar
+meu campo?". Se o dado é do **agente** (preferência, configuração), ele não
+pertence ao catálogo de conteúdo de jeito nenhum: guarde numa entidade própria e
+referencie o item do catálogo por id, com resolução tolerante para o caso de o
+id mudar de forma. Se é conteúdo mesmo, o serviço e o gerador de seed precisam
+carregá-lo explicitamente — e um teste tem que provar o round-trip.
+
 ## Ao traduzir, separe "texto que a pessoa lê" de "texto que atravessa fronteira de sistema"
 
 **Why**: na tradução PT→ES (2026-08-19), três textos pareciam iguais aos outros mas

--- a/docs/decisions/0002-atalhos-ctrl-k-por-agente.md
+++ b/docs/decisions/0002-atalhos-ctrl-k-por-agente.md
@@ -1,0 +1,100 @@
+# 0002 — Atalhos do Ctrl+K por agente e preferências de usuário na nuvem
+
+**Date**: 2026-08-19
+**Status**: Accepted
+
+## Context
+
+O Ctrl+K (`command-palette.js`) lista os 9 módulos e, desde a Fase de Quick
+Launch, dois **atalhos de nota**: combinações status + substatus + cenário que
+abrem o Case Notes já preenchido. Esses dois atalhos são iguais para todo mundo
+e nascem de um campo `quickLaunch` embutido em dois cenários de
+`notes-data.js` — o agente não escolhe quais são os seus.
+
+Três restrições moldaram a decisão:
+
+1. **O `quickLaunch` embutido não sobrevive à Central de Conteúdo.**
+   `applyNoteTemplateContent()` (note-templates-service.js) apaga
+   `scenarioSnippets` inteiro e o repovoa com os modelos publicados, cujos ids
+   são derivados (`cw-<substatus>-<slug>`) e cujo payload só carrega
+   `type`, `substatus` e os campos de texto. No instante em que o módulo
+   `note_template` for publicado, os dois atalhos de hoje **desaparecem do
+   Ctrl+K sem erro nenhum** — a busca `filter(([, d]) => d.quickLaunch)`
+   simplesmente devolve zero. Ou seja: o mecanismo atual já estava condenado,
+   independentemente desta feature.
+
+2. **Preferência de agente não podia morar só no navegador.** O produto é um
+   bookmarklet injetado no CRM: o agente troca de máquina e de perfil do Chrome
+   com frequência. `localStorage` sozinho perde a configuração exatamente quando
+   ela mais custa (primeiro dia numa máquina nova). Já existia o precedente certo
+   — a Biblioteca Pessoal (`snippet-service.js`), com leitura cache-first e
+   escrita otimista contra o Apps Script.
+
+3. **O transporte é JSONP (GET).** Tudo que for salvo viaja na query string, o
+   que impõe um teto prático de tamanho ao que pode ser guardado.
+
+## Decision
+
+Os atalhos do Ctrl+K passam a ser **dados do agente**, não do catálogo de
+cenários: vivem numa entidade própria (`shortcut-service.js`), referenciam os
+cenários por id **com resolução tolerante**, e são persistidos numa aba nova
+`User_Prefs` — uma linha por agente, um blob JSON de preferências — através de
+um serviço genérico (`user-prefs-service.js`) e de duas ops novas do Apps
+Script (`get_user_prefs` / `save_user_prefs`).
+
+O campo `quickLaunch` de `notes-data.js` é removido; os dois atalhos que ele
+definia viram a **semeadura padrão** de quem ainda não configurou nenhum — agora
+editáveis e apagáveis como qualquer outro.
+
+## Alternatives considered
+
+- **Manter o `quickLaunch` e só torná-lo editável**: rejeitado porque a
+  estrutura morre junto com a publicação dos modelos de nota (restrição 1) e
+  porque um preset *é uma propriedade do cenário* nesse desenho — o que impede
+  dois atalhos sobre o mesmo cenário, e impede um atalho **sem** cenário
+  (abrir só no status/substatus certo), que é um dos casos pedidos.
+- **Guardar os atalhos na aba `Database_Snippets` com `type: 'quicklaunch'`**:
+  seria zero mudança de backend (as ops já existem, com checagem de dono), mas
+  mistura duas entidades sem relação numa aba só, e qualquer tela que leia
+  snippets sem filtrar por `type` passaria a mostrar atalhos como se fossem
+  respostas salvas. A aba própria custou ~60 linhas de Apps Script e deixa a
+  porta aberta para som, idioma e ordem da pílula migrarem para o mesmo lugar.
+- **Guardar o texto da nota dentro do atalho** (em vez de referenciar o
+  cenário): tornaria o atalho imune a mudanças de id, mas congelaria o conteúdo
+  — o agente deixaria de receber as correções publicadas na Central, que é
+  justamente o que aquela máquina existe para entregar. Referenciar e resolver
+  na hora mantém o atalho vivo.
+
+## Consequences
+
+### Positive
+- Os atalhos deixam de depender do formato interno do catálogo de cenários e
+  passam a sobreviver à publicação dos modelos na Central.
+- Um atalho pode combinar **vários** cenários ou nenhum, e dois atalhos podem
+  apontar para o mesmo cenário com nomes diferentes.
+- Existe, pela primeira vez, um lugar canônico para preferência de agente
+  (`User_Prefs`), reaproveitável por som/idioma/ordem sem novo backend.
+- O atalho é criado capturando a tela do Case Notes que o agente já montou, sem
+  reimplementar o cascade status → substatus → cenários numa segunda tela.
+
+### Negative / Tradeoffs
+- O blob de preferências trafega por JSONP (GET). Por isso o atalho guarda
+  **referências** (ids, rótulo, alias), nunca o texto dos campos: com 8 atalhos
+  o blob fica na casa de 1 KB, longe do limite prático de URL.
+- Um atalho pode ficar órfão se o cenário que ele referencia for removido da
+  Central. Mitigado com resolução tolerante (id exato → slug dentro do mesmo
+  substatus) e, quando nem assim resolve, o atalho aparece **marcado como
+  quebrado** em Configurações em vez de sumir ou falhar em silêncio.
+- Mais uma aba na planilha para manter e fazer backup.
+
+### Neutral
+- A contagem de uso (usada para ordenar por frequência) fica **só no
+  navegador**: é um sinal de conveniência, não um dado do agente, e sincronizá-la
+  significaria uma escrita na nuvem a cada Ctrl+K.
+
+## Notes
+
+- Substitui o mecanismo introduzido em `feat(notes): quick-launch note presets
+  via Ctrl+K`.
+- Contrato das ops novas: `specs/data-models/api-payloads.md`.
+  Esquema da aba: `specs/data-models/db-schema.md`.

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -7,8 +7,14 @@ const SHEET_BROADCAST = "Broadcast";
 const SHEET_LOGS = "Logs";
 const SHEET_TIPS = "Tips";
 const SHEET_SNIPPETS = "Database_Snippets";
-const SHEET_BAU_FORM = "BAU_form_data"; 
+const SHEET_BAU_FORM = "BAU_form_data";
 const SHEET_PEOPLE = "People";
+const SHEET_USER_PREFS = "User_Prefs";
+
+// Teto de segurança para o blob de preferências. O transporte é JSONP (GET), e
+// uma linha de planilha aceita bem mais do que uma URL — o limite real está no
+// caminho, não na célula. Com 8 atalhos o blob fica na casa de 1 KB.
+const USER_PREFS_MAX_BYTES = 8000;
 
 function doGet(e) {
   // Fallback para testes manuais
@@ -197,6 +203,17 @@ function doGet(e) {
       result = handleContentPublicRead(p);
     }
 
+    // 8. MÓDULO: Preferências do agente (blob JSON, uma linha por pessoa)
+    // Hoje guarda os atalhos do Ctrl+K; nasceu genérico de propósito para que
+    // som, idioma e ordem da pílula possam migrar pra cá sem novo backend.
+    // Ver docs/decisions/0002-atalhos-ctrl-k-por-agente.md.
+    else if (op === 'get_user_prefs') {
+      result = handleGetUserPrefs(ss, p);
+    }
+    else if (op === 'save_user_prefs') {
+      result = handleSaveUserPrefs(ss, p);
+    }
+
     // 6. MÓDULO: Perfil de Usuário e Permissões (LDAP)
     else if (op === 'get_user_profile') {
       const userEmail = p.user || "";
@@ -224,6 +241,78 @@ function doGet(e) {
 // =========================================================
 //  FUNÇÕES AUXILIARES (HELPERS)
 // =========================================================
+
+// ---------------------------------------------------------
+//  PREFERÊNCIAS DO AGENTE (aba User_Prefs)
+// ---------------------------------------------------------
+// Uma linha por pessoa, um blob JSON. Diferente de Database_Snippets, que é
+// uma lista de itens, aqui o registro inteiro é substituído a cada escrita -
+// o cliente sempre manda o estado completo das preferências dele.
+
+function handleGetUserPrefs(ss, p) {
+  const userEmail = String(p.user || "").toLowerCase().trim();
+  if (!userEmail) throw new Error("User email required");
+
+  const sheet = getOrCreateSheet(ss, SHEET_USER_PREFS);
+  const rowIndex = findUserPrefsRow(sheet, userEmail);
+  if (rowIndex < 0) return { status: 'success', prefs: {} };
+
+  const raw = sheet.getRange(rowIndex, 2).getValue();
+  let prefs = {};
+  try {
+    prefs = raw ? JSON.parse(raw) : {};
+  } catch (e) {
+    // Blob corrompido não pode travar o agente fora das próprias preferências:
+    // devolve vazio (o cliente segue com o cache local) e registra o caso.
+    Logger.log("User_Prefs ilegível para " + userEmail + ": " + e);
+    prefs = {};
+  }
+  return { status: 'success', prefs: prefs };
+}
+
+function handleSaveUserPrefs(ss, p) {
+  const userEmail = String(p.user || "").toLowerCase().trim();
+  if (!userEmail) throw new Error("User email required");
+
+  const raw = String(p.prefs || "");
+  if (raw.length > USER_PREFS_MAX_BYTES) throw new Error("Preferences payload too large");
+
+  // Valida antes de gravar: um blob inválido só apareceria como erro na
+  // PRÓXIMA sessão do agente, longe da causa.
+  let parsed;
+  try {
+    parsed = JSON.parse(raw || "{}");
+  } catch (e) {
+    throw new Error("Preferences payload is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error("Preferences payload must be an object");
+  }
+
+  const sheet = getOrCreateSheet(ss, SHEET_USER_PREFS);
+  const timestamp = new Date().toISOString();
+  const rowIndex = findUserPrefsRow(sheet, userEmail);
+
+  if (rowIndex > 0) {
+    sheet.getRange(rowIndex, 2).setValue(raw);
+    sheet.getRange(rowIndex, 3).setValue(timestamp);
+    return { status: 'success', action: 'update' };
+  }
+
+  sheet.appendRow([userEmail, raw, timestamp]);
+  return { status: 'success', action: 'create' };
+}
+
+// A chave aqui é o e-mail (coluna 1), não um ID gerado - por isso não dá pra
+// reusar findRowIndexById().
+function findUserPrefsRow(sheet, userEmail) {
+  if (!sheet) return -1;
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][0]).toLowerCase().trim() === userEmail) return i + 1;
+  }
+  return -1;
+}
 
 // Regra de permissão (Overhead) compartilhada entre getUserProfileByLdap() e
 // getActiveTLs() - qualquer roleCategory que não seja Agent/Apprentice é
@@ -345,6 +434,8 @@ function getOrCreateSheet(ss, name) {
         "Adv_Name", "Adv_Email", "Website", "Timezone", "Language", "AM_Name",
         "Sales_Program", "Reason", "Task_Type", "Description", "Availability"
       ]);
+    } else if (name === SHEET_USER_PREFS) {
+      sheet.appendRow(["User_Email", "Prefs_JSON", "LastUpdated"]);
     }
   }
   return sheet;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:emails": "node scripts/test-email-roundtrip.mjs",
     "seed:emails": "node scripts/generate-email-seed.mjs",
     "test:note-templates": "node scripts/test-note-templates.mjs",
+    "test:shortcuts": "node scripts/test-shortcuts.mjs",
+    "test:prefs": "node scripts/test-user-prefs.js",
+    "smoke:shortcuts": "node scripts/smoke-shortcuts.mjs",
     "seed:note-templates": "node scripts/generate-note-templates-seed.mjs"
   },
   "dependencies": {

--- a/scripts/smoke-shortcuts.mjs
+++ b/scripts/smoke-shortcuts.mjs
@@ -1,0 +1,229 @@
+// scripts/smoke-shortcuts.mjs
+//
+// Smoke end-to-end dos atalhos do Ctrl+K, no navegador de verdade, sobre o
+// mock-crm.html. É o único teste que exercita o que o agente realmente faz:
+// abrir o palette, disparar o atalho e ver a nota montada.
+//
+// Existe porque a parte cara desta feature é temporal - openWithPreset()
+// encadeia animação do genie, troca de <select>, rebuild do formulário e clique
+// nos chips, tudo com esperas. Nada disso aparece num teste de unidade: se a
+// ordem quebrar, o teste de serviço continua verde e a nota abre vazia.
+//
+// Uso: npm run smoke:shortcuts
+
+import { chromium } from 'playwright';
+import { build } from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const raiz = resolve(here, '..');
+
+const bundle = await build({
+    entryPoints: [resolve(raiz, 'src/app.js')],
+    bundle: true,
+    write: false,
+    logLevel: 'silent',
+});
+const script = bundle.outputFiles[0].text;
+
+let fail = 0;
+async function check(name, fn) {
+    try { await fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+
+// A API real (Apps Script) não responde daqui: qualquer JSONP fica pendurado
+// até o watchdog de 15s. Cortar as chamadas na origem deixa o app no caminho
+// "sem nuvem", que é justamente o que precisa continuar funcionando.
+await page.route('**script.google.com/**', (route) => route.abort());
+
+page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
+
+await page.goto('file://' + resolve(raiz, 'mock-crm.html'));
+await page.evaluate(() => {
+    localStorage.setItem('cw_onboarding_seen_v1', 'true');
+    localStorage.setItem('cw_changelog_seen_version', '99.9');
+});
+await page.addScriptTag({ content: script });
+
+// A pílula só termina de aparecer depois da animação de abertura (~11s). O
+// Ctrl+K, porém, é registrado no document já na inicialização - e é por ele que
+// este teste entra em tudo, justamente como o agente que usa atalhos faria.
+await page.waitForSelector('#cw-btn-notes', { state: 'attached', timeout: 30000 });
+await page.waitForTimeout(12000);
+
+const dialogCancel = page.locator('#cw-conf-cancel');
+if (await dialogCancel.isVisible().catch(() => false)) await dialogCancel.click();
+
+console.log('\n--- Smoke: atalhos do Ctrl+K no navegador ---');
+
+// Cada verificação abre o palette do zero. A seleção do Ctrl+K é estado
+// (selectedIndex) e vaza entre passos: a primeira versão deste teste passou a
+// falhar porque um ArrowDown de um passo anterior deslocava o Enter do
+// seguinte, e o que abria era o módulo errado.
+async function abrirPalette(busca = '') {
+    const jaAberto = await page.locator('.cw-palette-overlay.active').isVisible().catch(() => false);
+    if (jaAberto) {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(400);
+    }
+    await page.keyboard.press('Control+k');
+    await page.waitForSelector('.cw-palette-overlay.active', { timeout: 5000 });
+    if (busca) {
+        await page.fill('.cw-palette-input', busca);
+        await page.waitForTimeout(200);
+    }
+}
+
+await check('Ctrl+K abre o palette com o grupo "Meus atalhos" antes dos módulos', async () => {
+    await abrirPalette();
+
+    const grupos = await page.locator('.cw-palette-group').allTextContents();
+    if (grupos[0] !== 'Meus atalhos') throw new Error('primeiro grupo: ' + JSON.stringify(grupos));
+    if (!grupos.includes('Módulos')) throw new Error('faltou o grupo de módulos: ' + JSON.stringify(grupos));
+});
+
+await check('os dois atalhos semeados aparecem no topo', async () => {
+    const itens = await page.locator('.cw-palette-item .cw-palette-item-label').allTextContents();
+    if (!itens[0].includes('NI Attempted')) throw new Error('primeiro item: ' + itens[0]);
+    if (!itens[1].includes('IN Not Reachable')) throw new Error('segundo item: ' + itens[1]);
+});
+
+await check('a busca pelo apelido ("2day") encontra os atalhos', async () => {
+    await abrirPalette('2day');
+    const itens = await page.locator('.cw-palette-item .cw-palette-item-label').allTextContents();
+    if (!itens.length) throw new Error('o apelido não encontrou nada');
+    if (itens.some((i) => i === 'Case Notes')) throw new Error('a busca não filtrou os módulos');
+});
+
+await check('a seta para baixo navega sem travar no cabeçalho de grupo', async () => {
+    await abrirPalette();
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    const selecionado = await page.locator('.cw-palette-item.selected .cw-palette-item-label').textContent();
+    if (!selecionado.includes('IN Not Reachable')) throw new Error('selecionado: ' + selecionado);
+
+    // Terceiro item: o cabeçalho "Módulos" fica entre ele e o anterior no DOM,
+    // mas não pode consumir um passo da navegação.
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    const terceiro = await page.locator('.cw-palette-item.selected .cw-palette-item-label').textContent();
+    if (terceiro !== 'Case Notes') throw new Error('o cabeçalho engoliu um passo: ' + terceiro);
+});
+
+await check('Enter no atalho abre o Case Notes já no substatus certo, com o cenário aplicado', async () => {
+    await abrirPalette('Not Reachable');
+    await page.keyboard.press('Enter');
+
+    await page.waitForSelector('#sub-status-select', { timeout: 10000 });
+    await page.waitForFunction(
+        () => document.querySelector('#sub-status-select')?.value === 'IN_Not_Reachable',
+        { timeout: 10000 }
+    );
+
+    const status = await page.inputValue('#main-status-select');
+    if (status !== 'IN') throw new Error('status principal: ' + status);
+
+    // O cenário do atalho preenche o motivo - é a prova de que o chip foi
+    // clicado de verdade, não só que o substatus mudou.
+    await page.waitForFunction(
+        () => (document.querySelector('#field-REASON_COMMENTS')?.value || '').includes('2 Day Rule'),
+        { timeout: 10000 }
+    );
+});
+
+await check('o cursor já fica no campo que falta preencher', async () => {
+    // O foco chega DEPOIS do texto dos cenários (fim do openWithPreset), então
+    // precisa de espera própria - ler logo após o texto pegava o body.
+    await page.waitForFunction(
+        () => document.activeElement && document.activeElement.id === 'field-SPEAKEASY_ID',
+        { timeout: 10000 }
+    );
+    // O realce âmbar (cw-quicklaunch-pending) dura 2,4s e some sozinho; o foco
+    // é o efeito que permanece - e é o que faz o agente sair do atalho já
+    // digitando o SE ID em vez de procurar onde clicar.
+    const realce = await page.locator('#field-SPEAKEASY_ID.cw-quicklaunch-pending').count();
+    if (!realce) throw new Error('o campo pendente não foi realçado');
+});
+
+await check('"Salvar como atalho" cria um terceiro atalho a partir da tela montada', async () => {
+    const btn = page.locator('.cw-save-shortcut-btn');
+    await btn.scrollIntoViewIfNeeded();
+    await btn.click();
+
+    await page.waitForSelector('#cw-prompt-input', { timeout: 5000 });
+    await page.fill('#cw-prompt-input', 'Meu atalho de teste');
+    await page.click('#cw-prompt-ok');
+    await page.waitForTimeout(600);
+
+    const salvos = await page.evaluate(() => {
+        const prefs = JSON.parse(localStorage.getItem('cw_user_prefs_v1') || '{}');
+        return (prefs.shortcuts || []).map((s) => s.label);
+    });
+    if (!salvos.includes('Meu atalho de teste')) throw new Error('salvos: ' + JSON.stringify(salvos));
+    if (salvos.length !== 3) throw new Error(`esperava 2 padrões + 1 novo, veio ${salvos.length}`);
+});
+
+await check('o atalho novo aparece no Ctrl+K na abertura seguinte', async () => {
+    await abrirPalette();
+    const itens = await page.locator('.cw-palette-item .cw-palette-item-label').allTextContents();
+    if (!itens.includes('Meu atalho de teste')) throw new Error('itens: ' + JSON.stringify(itens));
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(400);
+});
+
+await check('Configurações lista os atalhos e permite excluir um', async () => {
+    // Fecha o Case Notes antes: os popups se sobrepõem, e o de Notes ficaria
+    // por cima interceptando os cliques de Configurações. O próprio Ctrl+K é o
+    // jeito de alternar.
+    await abrirPalette('Case Notes');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(900);
+
+    await abrirPalette('configuracoes');
+    await page.keyboard.press('Enter');
+
+    await page.waitForSelector('.cw-sc-item', { timeout: 10000 });
+    // Espera o voo do genie terminar: clicar durante a animação é instável.
+    await page.waitForTimeout(1000);
+
+    const antes = await page.locator('.cw-sc-item').count();
+    if (antes !== 3) throw new Error(`esperava 3 atalhos na lista, veio ${antes}`);
+
+    const alvo = page.locator('.cw-sc-item', { hasText: 'Meu atalho de teste' }).locator('.js-sc-del');
+    await alvo.scrollIntoViewIfNeeded();
+    await alvo.click();
+    await page.waitForSelector('#cw-conf-ok', { timeout: 5000 });
+    await page.click('#cw-conf-ok');
+    await page.waitForTimeout(600);
+
+    const depois = await page.locator('.cw-sc-item').count();
+    if (depois !== 2) throw new Error(`esperava 2 depois de excluir, veio ${depois}`);
+});
+
+await check('o construtor de Configurações só oferece cenários do substatus escolhido', async () => {
+    // O popup ainda está terminando o voo do genie; clicar no meio da animação
+    // é instável (o alvo se move debaixo do ponteiro).
+    await page.waitForTimeout(1000);
+    await page.locator('.cw-sc-add').scrollIntoViewIfNeeded();
+    await page.click('.cw-sc-add');
+    await page.waitForSelector('#cw-sc-status', { timeout: 5000 });
+
+    await page.selectOption('#cw-sc-status', 'IN');
+    await page.selectOption('#cw-sc-sub', 'IN_Not_Reachable');
+    await page.waitForTimeout(300);
+
+    const chips = await page.locator('.cw-sc-chip').allTextContents();
+    if (!chips.length) throw new Error('nenhum cenário oferecido');
+    if (chips.some((c) => c.startsWith('cw ') || c.includes('quickfill'))) {
+        throw new Error('nome de cenário cru na tela: ' + JSON.stringify(chips));
+    }
+});
+
+await browser.close();
+console.log('\n' + (fail ? '✗' : '✓') + ` smoke: ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/scripts/test-shortcuts.mjs
+++ b/scripts/test-shortcuts.mjs
@@ -1,0 +1,262 @@
+// scripts/test-shortcuts.mjs
+//
+// Prova as regras dos atalhos do Ctrl+K - as que quebram em silêncio.
+//
+// O risco central é este: o atalho guarda a REFERÊNCIA de um cenário, e o
+// catálogo de cenários é reescrito inteiro quando a Central de Conteúdo publica
+// os modelos de nota (note-templates-service.js), trocando ids embutidos
+// (`quickfill-in-no-show-bau`) por ids derivados (`cw-in_not_reachable-in-no-
+// show-bau`). Se a resolução falhar, o atalho abre a nota sem o texto e o
+// agente só descobre lendo a nota - por isso o teste exercita os dois mundos.
+//
+// Uso: npm run test:shortcuts
+
+import { build } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// ---- Ambiente de navegador mínimo ----
+const store = {};
+globalThis.window = { location: { hostname: 'localhost' } };
+globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+};
+globalThis.document = { createElement: () => ({}), body: { appendChild() { }, contains: () => false } };
+
+// Sem e-mail do agente capturado, o serviço de preferências fica só no cache
+// local - que é exatamente o caminho que queremos exercitar aqui, sem JSONP.
+async function carregar() {
+    const bundle = await build({
+        entryPoints: [resolve(here, '../src/modules/shared/shortcut-service.js')],
+        bundle: true,
+        write: false,
+        format: 'cjs',
+        platform: 'node',
+        logLevel: 'silent',
+        footer: { js: 'module.exports.__scenarios = scenarioSnippets;' },
+    });
+    const mod = { exports: {} };
+    // eslint-disable-next-line no-new-func
+    new Function('module', 'exports', 'require', bundle.outputFiles[0].text)(mod, mod.exports, require);
+    return mod.exports;
+}
+
+const sc = await carregar();
+const { ShortcutService, resolveScenarioId, shortcutIssues, MAX_SHORTCUTS } = sc;
+
+let fail = 0;
+function check(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+async function checkAsync(name, fn) {
+    try { await fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+function limparPrefs() {
+    delete store['cw_user_prefs_v1'];
+    delete store['cw_shortcut_usage_v1'];
+}
+
+console.log('\n--- Atalhos do Ctrl+K ---');
+
+// ----------------------------------------------------------------
+//  Semeadura
+// ----------------------------------------------------------------
+limparPrefs();
+
+check('quem nunca configurou nada recebe os dois atalhos de sempre', () => {
+    const lista = ShortcutService.list();
+    if (lista.length !== 2) throw new Error(`esperava 2 atalhos padrão, veio ${lista.length}`);
+    const subs = lista.map((s) => s.payload.subStatus).sort();
+    const esperado = ['IN_Not_Reachable', 'NI_Attempted_Contact'];
+    if (JSON.stringify(subs) !== JSON.stringify(esperado)) {
+        throw new Error(`substatus inesperados: ${subs.join(', ')}`);
+    }
+});
+
+check('os atalhos padrão têm id estável entre leituras', () => {
+    // Id gerado a cada chamada faria a contagem de uso e a seleção do Ctrl+K
+    // apontarem para o vazio, sem erro nenhum.
+    const a = ShortcutService.list().map((s) => s.id);
+    const b = ShortcutService.list().map((s) => s.id);
+    if (JSON.stringify(a) !== JSON.stringify(b)) throw new Error(`ids mudaram: ${a} -> ${b}`);
+});
+
+check('os cenários dos atalhos padrão existem no catálogo embutido', () => {
+    for (const atalho of ShortcutService.list()) {
+        const problemas = shortcutIssues(atalho);
+        if (problemas.length) throw new Error(`${atalho.label}: ${problemas.join(', ')}`);
+    }
+});
+
+// ----------------------------------------------------------------
+//  Resolução tolerante de cenário (o coração do risco)
+// ----------------------------------------------------------------
+console.log('\n--- Resolução do cenário nos dois mundos ---');
+
+check('id embutido resolve para ele mesmo', () => {
+    const id = 'quickfill-in-no-show-bau';
+    const r = resolveScenarioId({ id, substatus: 'IN_Not_Reachable' });
+    if (r !== id) throw new Error(`esperava ${id}, veio ${r}`);
+});
+
+check('id publicado pela Central resolve para o embutido equivalente', () => {
+    // É o caso real do rollback: o agente salvou o atalho com a Central no ar,
+    // a Central sai do ar, e o catálogo volta a ser o embutido.
+    const publicado = 'cw-in_not_reachable-in-no-show-bau';
+    const r = resolveScenarioId({ id: publicado, substatus: 'IN_Not_Reachable' });
+    if (r !== 'quickfill-in-no-show-bau') throw new Error(`esperava o embutido, veio ${r}`);
+});
+
+check('id embutido resolve para o publicado quando a Central reescreve o catálogo', () => {
+    // Simula exatamente o que applyNoteTemplateContent() faz: apaga tudo e
+    // repovoa com ids derivados. É este caminho que fazia os atalhos antigos
+    // sumirem do Ctrl+K sem erro nenhum.
+    const catalogo = sc.__scenarios;
+    const original = JSON.parse(JSON.stringify(catalogo));
+    try {
+        for (const k of Object.keys(catalogo)) delete catalogo[k];
+        catalogo['cw-in_not_reachable-in-no-show-bau'] = {
+            type: 'bau',
+            substatus: ['IN_Not_Reachable'],
+            'field-REASON_COMMENTS': 'Sem resposta ao 2 Day Rule.',
+        };
+
+        const r = resolveScenarioId({ id: 'quickfill-in-no-show-bau', substatus: 'IN_Not_Reachable' });
+        if (r !== 'cw-in_not_reachable-in-no-show-bau') {
+            throw new Error(`o atalho não se reencontrou no catálogo publicado (veio ${r})`);
+        }
+    } finally {
+        for (const k of Object.keys(catalogo)) delete catalogo[k];
+        Object.assign(catalogo, original);
+    }
+});
+
+check('cenário que não existe mais devolve null em vez de lançar', () => {
+    const r = resolveScenarioId({ id: 'quickfill-nao-existe-mais', substatus: 'IN_Not_Reachable' });
+    if (r !== null) throw new Error(`esperava null, veio ${r}`);
+});
+
+check('atalho órfão é reportado como quebrado, não silenciosamente vazio', () => {
+    const orfao = {
+        id: 'sc_x', kind: 'note', label: 'Órfão', alias: '', order: 0,
+        payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [{ id: 'quickfill-sumiu', substatus: 'IN_Not_Reachable' }] },
+    };
+    const problemas = shortcutIssues(orfao);
+    if (problemas.length !== 1) throw new Error(`esperava 1 problema, veio ${problemas.length}`);
+});
+
+check('atalho sem cenário nenhum é válido (abre só no substatus certo)', () => {
+    const semCenario = {
+        id: 'sc_y', kind: 'note', label: 'Só o substatus', alias: '', order: 0,
+        payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [] },
+    };
+    if (shortcutIssues(semCenario).length) throw new Error('atalho sem cenário foi marcado como quebrado');
+});
+
+// ----------------------------------------------------------------
+//  CRUD e limites
+// ----------------------------------------------------------------
+console.log('\n--- Criação, limite e ordem ---');
+
+function novoAtalho(label) {
+    return {
+        kind: 'note',
+        label,
+        alias: '',
+        payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [] },
+    };
+}
+
+await checkAsync('salvar um atalho materializa a lista (os padrões param de ser virtuais)', async () => {
+    limparPrefs();
+    await ShortcutService.save(novoAtalho('Meu primeiro'));
+    const lista = ShortcutService.listRaw();
+    if (lista.length !== 3) throw new Error(`esperava 2 padrões + 1 novo, veio ${lista.length}`);
+    if (!lista.some((s) => s.label === 'Meu primeiro')) throw new Error('o atalho novo não entrou');
+});
+
+await checkAsync('apagar um atalho padrão não o ressuscita na leitura seguinte', async () => {
+    limparPrefs();
+    const alvo = ShortcutService.listRaw()[0];
+    await ShortcutService.remove(alvo.id);
+    const depois = ShortcutService.listRaw();
+    if (depois.some((s) => s.id === alvo.id)) throw new Error('o atalho apagado voltou');
+    if (depois.length !== 1) throw new Error(`esperava 1 restante, veio ${depois.length}`);
+});
+
+await checkAsync(`o limite de ${MAX_SHORTCUTS} atalhos é recusado com motivo`, async () => {
+    limparPrefs();
+    for (let i = ShortcutService.listRaw().length; i < MAX_SHORTCUTS; i++) {
+        const r = await ShortcutService.save(novoAtalho('Atalho ' + i));
+        if (!r.ok) throw new Error(`recusou cedo demais, no ${i}`);
+    }
+    const excedente = await ShortcutService.save(novoAtalho('Um a mais'));
+    if (excedente.ok) throw new Error('aceitou passar do limite');
+    if (excedente.reason !== 'limit') throw new Error(`motivo inesperado: ${excedente.reason}`);
+});
+
+await checkAsync('editar um atalho existente não cria outro nem muda a posição', async () => {
+    limparPrefs();
+    const lista = ShortcutService.listRaw();
+    const alvo = lista[1];
+    await ShortcutService.save({ ...alvo, label: 'Renomeado' });
+    const depois = ShortcutService.listRaw();
+    if (depois.length !== lista.length) throw new Error('a edição duplicou o atalho');
+    if (depois[1].label !== 'Renomeado') throw new Error('a edição mudou a posição');
+});
+
+await checkAsync('reordenar reescreve a ordem inteira, sem buracos', async () => {
+    limparPrefs();
+    await ShortcutService.save(novoAtalho('Terceiro'));
+    const antes = ShortcutService.listRaw();
+    const ultimo = antes[antes.length - 1];
+
+    await ShortcutService.reorder(ultimo.id, 0);
+    const depois = ShortcutService.listRaw();
+
+    if (depois[0].id !== ultimo.id) throw new Error('o item não foi para o topo');
+    const ordens = depois.map((s) => s.order);
+    if (JSON.stringify(ordens) !== JSON.stringify(depois.map((_, i) => i))) {
+        throw new Error(`ordem com buraco: ${ordens.join(',')}`);
+    }
+});
+
+await checkAsync('ordenar por uso põe o mais usado na frente sem perder ninguém', async () => {
+    limparPrefs();
+    const lista = ShortcutService.listRaw();
+    const segundo = lista[1];
+
+    await ShortcutService.setSortedByUsage(true);
+    ShortcutService.registerUse(segundo.id);
+    ShortcutService.registerUse(segundo.id);
+
+    const ordenada = ShortcutService.list();
+    if (ordenada[0].id !== segundo.id) throw new Error('o mais usado não ficou em primeiro');
+    if (ordenada.length !== lista.length) throw new Error('a ordenação perdeu um atalho');
+
+    await ShortcutService.setSortedByUsage(false);
+    const manual = ShortcutService.list();
+    if (manual[0].id !== lista[0].id) throw new Error('desligar a ordenação por uso não voltou à ordem manual');
+});
+
+check('dado corrompido nas preferências não derruba a lista', () => {
+    // Um blob inválido é plausível: vem da nuvem, de outra versão do app.
+    store['cw_user_prefs_v1'] = JSON.stringify({ shortcuts: [null, { id: 'x' }, 'lixo'] });
+    const lista = ShortcutService.list();
+    if (!Array.isArray(lista)) throw new Error('a lista não é um array');
+    if (lista.length !== 0) throw new Error(`esperava descartar tudo que é inválido, sobrou ${lista.length}`);
+});
+
+limparPrefs();
+
+console.log('\n' + (fail ? '✗' : '✓') + ` atalhos: ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/scripts/test-user-prefs.js
+++ b/scripts/test-user-prefs.js
@@ -1,0 +1,189 @@
+// scripts/test-user-prefs.js
+//
+// Harness local para as ops de preferências do agente (get_user_prefs /
+// save_user_prefs) do Código.js, que não rodam no Apps Script sem uma planilha
+// de verdade. Mesmo desenho do test-content-api.js: stub mínimo de
+// SpreadsheetApp/ContentService/Logger e chamadas via doGet(), que é como o
+// front realmente as invoca (JSONP).
+//
+// O que precisa estar provado antes de subir:
+//   - a aba nasce com cabeçalho e uma linha por agente (nunca duplica);
+//   - salvar de novo SUBSTITUI a linha da pessoa, não empilha;
+//   - o blob de um agente nunca vaza para outro;
+//   - payload inválido é recusado na escrita, e não descoberto na leitura;
+//   - linha corrompida devolve {} em vez de derrubar o agente.
+//
+// Uso: npm run test:prefs
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('node:vm');
+
+const SRC = path.join(__dirname, '..', 'gas-backend', 'Código.js');
+
+// ---- Stub de planilha ----
+class FakeRange {
+  constructor(sheet, row, col) { this.sheet = sheet; this.row = row; this.col = col; }
+  setValue(v) {
+    while (this.sheet._data.length < this.row) this.sheet._data.push([]);
+    this.sheet._data[this.row - 1][this.col - 1] = v;
+    return this;
+  }
+  getValue() {
+    const linha = this.sheet._data[this.row - 1] || [];
+    return linha[this.col - 1];
+  }
+  getValues() { return this.sheet._data.map((r) => r.slice()); }
+}
+
+class FakeSheet {
+  constructor(name) { this.name = name; this._data = []; }
+  appendRow(row) { this._data.push(row.slice()); }
+  getDataRange() { return new FakeRange(this, 1, 1); }
+  getRange(row, col) { return new FakeRange(this, row, col); }
+  getLastRow() { return this._data.length; }
+  deleteRow(i) { this._data.splice(i - 1, 1); }
+}
+
+class FakeSpreadsheet {
+  constructor() { this.sheets = {}; }
+  getSheetByName(n) { return this.sheets[n] || null; }
+  insertSheet(n) { return (this.sheets[n] = new FakeSheet(n)); }
+}
+
+const SS = new FakeSpreadsheet();
+const LOGGER = [];
+
+const sandbox = {
+  SpreadsheetApp: { getActiveSpreadsheet: () => SS },
+  Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+  Logger: { log: (m) => LOGGER.push(String(m)) },
+  Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+  ContentService: {
+    MimeType: { JAVASCRIPT: 'js', JSON: 'json' },
+    createTextOutput: (texto) => ({ _texto: texto, setMimeType() { return this; } }),
+  },
+  HtmlService: { createHtmlOutputFromFile: () => ({ setTitle() { return this; }, setXFrameOptionsMode() { return this; }, addMetaTag() { return this; } }), XFrameOptionsMode: { ALLOWALL: 1 } },
+  console,
+};
+
+const ctx = vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(SRC, 'utf8'), ctx);
+
+// doGet devolve a resposta JSONP; aqui só interessa o objeto que ela embrulha.
+function chamar(params) {
+  const saida = ctx.doGet({ parameter: params });
+  return JSON.parse(saida._texto);
+}
+
+let fail = 0;
+function check(name, fn) {
+  try { fn(); console.log('  ✓ ' + name); }
+  catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+
+const ATALHOS = JSON.stringify({
+  shortcuts: [{
+    id: 'sc_1', kind: 'note', label: 'Fim do 2 Day', alias: '2day', order: 0,
+    payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [{ id: 'quickfill-in-no-show-bau', substatus: 'IN_Not_Reachable' }] },
+  }],
+});
+
+console.log('\n--- Preferências do agente (User_Prefs) ---');
+
+check('agente sem preferência nenhuma recebe {} , não erro', () => {
+  const r = chamar({ op: 'get_user_prefs', user: 'ninguem@google.com' });
+  if (r.status !== 'success') throw new Error('status: ' + JSON.stringify(r));
+  if (JSON.stringify(r.prefs) !== '{}') throw new Error('esperava {}, veio ' + JSON.stringify(r.prefs));
+});
+
+check('a aba nasce com cabeçalho', () => {
+  const aba = SS.getSheetByName('User_Prefs');
+  if (!aba) throw new Error('a aba não foi criada');
+  if (JSON.stringify(aba._data[0]) !== JSON.stringify(['User_Email', 'Prefs_JSON', 'LastUpdated'])) {
+    throw new Error('cabeçalho inesperado: ' + JSON.stringify(aba._data[0]));
+  }
+});
+
+check('salvar e ler de volta devolve o mesmo blob', () => {
+  const s = chamar({ op: 'save_user_prefs', user: 'ana@google.com', prefs: ATALHOS });
+  if (s.status !== 'success' || s.action !== 'create') throw new Error(JSON.stringify(s));
+
+  const r = chamar({ op: 'get_user_prefs', user: 'ana@google.com' });
+  if (JSON.stringify(r.prefs) !== ATALHOS) throw new Error('o blob voltou diferente: ' + JSON.stringify(r.prefs));
+});
+
+check('salvar de novo SUBSTITUI a linha, não empilha', () => {
+  const novo = JSON.stringify({ shortcuts: [], shortcutsSortByUsage: false });
+  const s = chamar({ op: 'save_user_prefs', user: 'ana@google.com', prefs: novo });
+  if (s.action !== 'update') throw new Error('esperava update, veio ' + s.action);
+
+  const aba = SS.getSheetByName('User_Prefs');
+  const linhasDaAna = aba._data.filter((l) => String(l[0]).includes('ana@'));
+  if (linhasDaAna.length !== 1) throw new Error(`a pessoa ficou com ${linhasDaAna.length} linhas`);
+
+  const r = chamar({ op: 'get_user_prefs', user: 'ana@google.com' });
+  if (JSON.stringify(r.prefs) !== novo) throw new Error('leu a versão antiga');
+});
+
+check('e-mail é normalizado: maiúsculas e espaços não criam uma segunda linha', () => {
+  chamar({ op: 'save_user_prefs', user: '  ANA@google.com ', prefs: ATALHOS });
+  const aba = SS.getSheetByName('User_Prefs');
+  const linhasDaAna = aba._data.filter((l) => String(l[0]).toLowerCase().includes('ana@'));
+  if (linhasDaAna.length !== 1) throw new Error(`virou ${linhasDaAna.length} linhas para a mesma pessoa`);
+});
+
+check('o blob de um agente não vaza para outro', () => {
+  chamar({ op: 'save_user_prefs', user: 'bruno@google.com', prefs: JSON.stringify({ shortcuts: [{ id: 'sc_b', payload: { subStatus: 'NI_Attempted_Contact' } }] }) });
+
+  const ana = chamar({ op: 'get_user_prefs', user: 'ana@google.com' });
+  if (JSON.stringify(ana.prefs).includes('sc_b')) throw new Error('a Ana enxergou o atalho do Bruno');
+
+  const bruno = chamar({ op: 'get_user_prefs', user: 'bruno@google.com' });
+  if (!JSON.stringify(bruno.prefs).includes('sc_b')) throw new Error('o Bruno perdeu o próprio atalho');
+});
+
+check('sem e-mail, a escrita é recusada', () => {
+  const r = chamar({ op: 'save_user_prefs', prefs: ATALHOS });
+  if (r.status !== 'error') throw new Error('aceitou salvar sem dono');
+});
+
+check('sem e-mail, a leitura é recusada', () => {
+  const r = chamar({ op: 'get_user_prefs' });
+  if (r.status !== 'error') throw new Error('aceitou ler sem dono');
+});
+
+check('JSON inválido é recusado na ESCRITA, não descoberto na próxima sessão', () => {
+  const r = chamar({ op: 'save_user_prefs', user: 'ana@google.com', prefs: '{isso não é json' });
+  if (r.status !== 'error') throw new Error('gravou lixo na planilha');
+
+  const depois = chamar({ op: 'get_user_prefs', user: 'ana@google.com' });
+  if (JSON.stringify(depois.prefs) === '{}') throw new Error('a recusa apagou o que já estava salvo');
+});
+
+check('payload que não é objeto é recusado', () => {
+  const r = chamar({ op: 'save_user_prefs', user: 'ana@google.com', prefs: '[1,2,3]' });
+  if (r.status !== 'error') throw new Error('aceitou um array como preferências');
+});
+
+check('blob acima do teto é recusado', () => {
+  const gigante = JSON.stringify({ lixo: 'x'.repeat(9000) });
+  const r = chamar({ op: 'save_user_prefs', user: 'ana@google.com', prefs: gigante });
+  if (r.status !== 'error') throw new Error('aceitou um payload maior que o teto');
+});
+
+check('linha corrompida na planilha devolve {} em vez de derrubar o agente', () => {
+  // Plausível: alguém edita a planilha na mão, ou uma versão futura grava outra
+  // coisa. O agente não pode ficar trancado fora das próprias preferências.
+  const aba = SS.getSheetByName('User_Prefs');
+  const linha = aba._data.findIndex((l) => String(l[0]).toLowerCase().includes('ana@'));
+  aba._data[linha][1] = '{quebrado';
+
+  const r = chamar({ op: 'get_user_prefs', user: 'ana@google.com' });
+  if (r.status !== 'success') throw new Error('a leitura falhou em vez de degradar');
+  if (JSON.stringify(r.prefs) !== '{}') throw new Error('esperava {}, veio ' + JSON.stringify(r.prefs));
+  if (!LOGGER.some((m) => m.includes('User_Prefs ilegível'))) throw new Error('o caso não foi registrado no log');
+});
+
+console.log('\n' + (fail ? '✗' : '✓') + ` preferências: ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -9,6 +9,28 @@ O objeto `fullPayload` deve conter:
 - As chaves mapeadas no `db-schema.md`.
 - Campos irrelevantes no fluxo de Descarte (ex: `availability`, `taskType`) devem ser forçados para `""` (string vazia).
 
+## Preferências do agente (`get_user_prefs` / `save_user_prefs`)
+
+Contrato das duas ops que servem as preferências por pessoa (hoje: os atalhos do
+Ctrl+K). Esquema da aba em `db-schema.md`.
+
+| Op | Params | Resposta |
+| :--- | :--- | :--- |
+| `get_user_prefs` | `user` (e-mail, obrigatório) | `{ status: 'success', prefs: {...} }` — `{}` para quem nunca salvou nada |
+| `save_user_prefs` | `user`, `prefs` (JSON **serializado**) | `{ status: 'success', action: 'create' \| 'update' }` |
+
+### Regras
+- `prefs` viaja como **string JSON**, não como objeto: o transporte é JSONP
+  (GET), tudo vira query string.
+- **Substituição total, não merge.** O cliente sempre manda o estado completo; o
+  backend troca a linha inteira da pessoa. Não existe atualização parcial de
+  chave.
+- **Falha de rede devolve `null`, não `{}`.** `DataService.getUserPrefs()`
+  distingue "esta pessoa não tem preferência" de "não deu pra perguntar" — sem
+  isso, uma queda de rede zeraria o cache local do agente.
+- Sem `user`, ambas as ops falham. Sem e-mail capturado, o cliente opera só com
+  o cache local e avisa que salvou apenas no navegador.
+
 ## Construção do Payload (Edição)
 - **Bloqueio de Data Wiping:** Ao editar, o `bau-form.js` **NÃO DEVE** injetar fallbacks de string vazia (`|| ""`) para campos que o usuário não interagiu ou que não existem na tela atual.
 - Se o campo não foi modificado ou não faz parte do fluxo, não o envie no payload ou envie estritamente como `undefined`. Isso permite que o Back-end saiba que deve manter o dado original da planilha.

--- a/specs/data-models/db-schema.md
+++ b/specs/data-models/db-schema.md
@@ -29,3 +29,59 @@
 ## Regra de Atualização (Update)
 - NUNCA reescrever dados de uma coluna com `""` se o valor recebido for `undefined`. 
 - No Apps Script, a validação deve ser sempre: `p.chave !== undefined ? p.chave : valorAntigoDaPlanilha`.
+
+---
+
+# Aba `User_Prefs` (Preferências do Agente)
+
+- **Nome/Constante:** `SHEET_USER_PREFS` (`"User_Prefs"`)
+- **Cardinalidade:** **uma linha por agente**. Diferente de `Database_Snippets`,
+  que é uma lista de itens, aqui o registro inteiro é substituído a cada
+  escrita — o cliente sempre envia o estado completo das preferências dele.
+
+| Índice | Nome da Coluna (Header) | Chave do Payload | Notas |
+| :--- | :--- | :--- | :--- |
+| `0` | User_Email | `user` | Chave da linha. Sempre gravado em minúsculas e sem espaços — `ANA@ ` e `ana@` são a mesma pessoa. |
+| `1` | Prefs_JSON | `prefs` | Blob JSON do objeto de preferências (ver abaixo). |
+| `2` | LastUpdated | (gerado no backend) | ISO String |
+
+## Formato do blob `Prefs_JSON`
+
+```json
+{
+  "shortcuts": [
+    {
+      "id": "sc_abc123",
+      "kind": "note",
+      "label": "Fim do 2 Day Rule",
+      "alias": "2day",
+      "order": 0,
+      "payload": {
+        "caseType": "bau",
+        "status": "IN",
+        "subStatus": "IN_Not_Reachable",
+        "scenarios": [{ "id": "quickfill-in-no-show-bau", "substatus": "IN_Not_Reachable" }]
+      }
+    }
+  ],
+  "shortcutsSortByUsage": true
+}
+```
+
+### Regras do blob
+- **Só referências, nunca texto de nota.** O atalho guarda o **id** do cenário;
+  o texto vem do catálogo na hora de aplicar. Isso mantém o blob pequeno (o
+  transporte é JSONP/GET) e faz o atalho herdar as correções publicadas na
+  Central de Conteúdo.
+- **Teto de 8000 bytes** (`USER_PREFS_MAX_BYTES`), recusado na escrita. Com o
+  teto de 8 atalhos o blob real fica na casa de 1 KB.
+- **Validação é na escrita, não na leitura.** `save_user_prefs` recusa JSON
+  inválido, array ou primitivo. Uma linha corrompida na leitura devolve `{}` e
+  registra no `Logger` — o agente nunca fica trancado fora das preferências.
+- **`kind` existe para crescer**: hoje só `"note"`. Um atalho de e-mail ou de
+  link entra como outro `kind` sem migrar o dado de ninguém.
+- A **contagem de uso** dos atalhos NÃO vive aqui: é local
+  (`cw_shortcut_usage_v1` no `localStorage`), porque sincronizá-la significaria
+  uma escrita na nuvem a cada Ctrl+K.
+
+Ver `docs/decisions/0002-atalhos-ctrl-k-por-agente.md`.

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import { initBAUForm } from './modules/bau-form/bau-form-assistant.js';
 import { DataService, fetchUserProfile } from './modules/shared/data-service.js';
 import { getAgentEmail } from './modules/shared/page-data.js';
 import { applyProfileLanguage } from './modules/shared/i18n.js';
+import { UserPrefsService } from './modules/shared/user-prefs-service.js';
 
 // 2. Importação do Núcleo Compartilhado
 import { initCommandCenter } from './modules/shared/command-center.js';
@@ -109,6 +110,12 @@ function initApp() {
             // pela primeira vez veria o tutorial em PT por um instante mesmo
             // sendo hispanofalante, já que o perfil ainda não teria chegado.
             const agentEmail = getAgentEmail();
+
+            // Preferências do agente (hoje: os atalhos do Ctrl+K). Não bloqueia
+            // nada: a tela já abre com o cache local e se atualiza quando a
+            // planilha responder - o Ctrl+K relê a lista a cada abertura.
+            UserPrefsService.sync();
+
             const languagePromise = agentEmail
                 ? fetchUserProfile(agentEmail.split('@')[0])
                     .then(profile => { if (profile) applyProfileLanguage(profile); })

--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -453,6 +453,11 @@ export function initConfigsAssistant() {
         visible = !visible;
         toggleGenieAnimation(visible, popup, 'cw-btn-configs');
         if (visible) {
+            // A lista de atalhos é montada uma vez, no boot, mas o agente pode
+            // ter criado um no Case Notes ("Salvar como atalho") desde então -
+            // sem isto, ele abriria Configurações e não veria o que acabou de
+            // salvar.
+            shortcutsSection.refresh();
             lockBodyScroll();
             SoundManager.playClick();
         } else {

--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -8,6 +8,7 @@ import { toggleGenieAnimation } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
 import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
 import { getLanguage, setLanguage, onLanguageChange, createTranslator } from "../shared/i18n.js";
+import { createShortcutsSection } from "./shortcuts-section.js";
 
 const CONFIGS_DICT = {
     pt: {
@@ -24,6 +25,35 @@ const CONFIGS_DICT = {
         langDesc: "Escolha o idioma dos menus, botões e mensagens do Case Wizard.",
         supportSectionTitle: "Suporte & Feedback",
         reportBug: "Reportar Bug/Sugestões",
+        scSectionTitle: "Meus Atalhos (Ctrl+K)",
+        scSortLabel: "Ordenar por frequência de uso",
+        scSortDesc: "Desligue para definir você mesmo a ordem, arrastando os atalhos.",
+        scEmpty: "Você ainda não tem atalhos. Crie um aqui ou monte uma nota no Case Notes e clique em “Salvar como atalho”.",
+        scAdd: "+ Criar atalho",
+        scLimit: "Limite de {max} atalhos atingido",
+        scEdit: "Editar atalho",
+        scDelete: "Excluir atalho",
+        scReorder: "Reordenar (arraste ou use as setas)",
+        scDeleteConfirm: "Excluir o atalho “{name}”?",
+        scBroken: "⚠ cenário indisponível",
+        scOneScenario: "1 cenário",
+        scNScenarios: "{n} cenários",
+        scName: "Nome",
+        scNamePlaceholder: "Ex: Fim do 2 Day Rule",
+        scAlias: "Apelido de busca",
+        scAliasPlaceholder: "Ex: 2day",
+        scAliasDesc: "Palavra que encontra este atalho no Ctrl+K, além do nome.",
+        scFlow: "Fluxo",
+        scStatus: "Status",
+        scSubStatus: "Substatus",
+        scScenarios: "Cenários",
+        scScenariosDesc: "Opcional: sem nenhum, o atalho só abre a nota já no substatus certo.",
+        scPickSubStatus: "Escolha um substatus primeiro.",
+        scNoScenarios: "Nenhum cenário disponível para esta combinação.",
+        scCancel: "Cancelar",
+        scSave: "Salvar",
+        scSaved: "Atalho salvo!",
+        scSavedLocal: "Atalho salvo neste navegador (sem conexão com a nuvem).",
     },
     es: {
         title: "Configuración",
@@ -39,6 +69,35 @@ const CONFIGS_DICT = {
         langDesc: "Elige el idioma de los menús, botones y mensajes del Case Wizard.",
         supportSectionTitle: "Soporte y Comentarios",
         reportBug: "Reportar error o sugerencia",
+        scSectionTitle: "Mis Atajos (Ctrl+K)",
+        scSortLabel: "Ordenar por frecuencia de uso",
+        scSortDesc: "Desactívalo para definir tú mismo el orden, arrastrando los atajos.",
+        scEmpty: "Todavía no tienes atajos. Crea uno aquí o arma una nota en Case Notes y haz clic en “Guardar como atajo”.",
+        scAdd: "+ Crear atajo",
+        scLimit: "Límite de {max} atajos alcanzado",
+        scEdit: "Editar atajo",
+        scDelete: "Eliminar atajo",
+        scReorder: "Reordenar (arrastra o usa las flechas)",
+        scDeleteConfirm: "¿Eliminar el atajo “{name}”?",
+        scBroken: "⚠ escenario no disponible",
+        scOneScenario: "1 escenario",
+        scNScenarios: "{n} escenarios",
+        scName: "Nombre",
+        scNamePlaceholder: "Ej: Fin del 2 Day Rule",
+        scAlias: "Apodo de búsqueda",
+        scAliasPlaceholder: "Ej: 2day",
+        scAliasDesc: "Palabra que encuentra este atajo en el Ctrl+K, además del nombre.",
+        scFlow: "Flujo",
+        scStatus: "Estado",
+        scSubStatus: "Subestado",
+        scScenarios: "Escenarios",
+        scScenariosDesc: "Opcional: sin ninguno, el atajo solo abre la nota ya en el subestado correcto.",
+        scPickSubStatus: "Elige un subestado primero.",
+        scNoScenarios: "Ningún escenario disponible para esta combinación.",
+        scCancel: "Cancelar",
+        scSave: "Guardar",
+        scSaved: "¡Atajo guardado!",
+        scSavedLocal: "Atajo guardado en este navegador (sin conexión con la nube).",
     },
 };
 
@@ -319,6 +378,12 @@ export function initConfigsAssistant() {
     });
     container.appendChild(langSection);
 
+    // --- SEÇÃO: MEUS ATALHOS (Ctrl+K) ---
+    // Fica logo abaixo do perfil, antes de som/idioma: é a única seção com
+    // conteúdo do agente, e a razão mais provável de ele abrir Configurações.
+    const shortcutsSection = createShortcutsSection(t, COLORS);
+    container.appendChild(shortcutsSection);
+
     // --- SEÇÃO: SOM ---
     const soundSection = document.createElement("div");
     soundSection.className = "cw-configs-section";
@@ -365,6 +430,8 @@ export function initConfigsAssistant() {
         langSection.querySelector(".js-lang-label").textContent = t('langLabel');
         langSection.querySelector(".js-lang-desc").textContent = t('langDesc');
         syncLangToggleButtons();
+
+        shortcutsSection.applyTexts();
 
         soundSection.querySelector(".js-sound-section-title").textContent = t('soundSectionTitle');
         soundSection.querySelector(".js-sound-label").textContent = t('soundLabel');

--- a/src/modules/configs/shortcuts-section.js
+++ b/src/modules/configs/shortcuts-section.js
@@ -1,0 +1,445 @@
+// src/modules/configs/shortcuts-section.js
+//
+// Seção "Meus Atalhos" de Configurações: onde o agente gerencia os comandos que
+// o Ctrl+K oferece a ele. Vive num arquivo próprio porque é a única parte de
+// Configurações com estado e edição - o resto da tela são três toggles.
+//
+// A criação do zero aqui usa a MESMA fonte que o Case Notes
+// (SUBSTATUS_TEMPLATES + getScenariosFor), justamente pra não existir uma
+// segunda verdade sobre "quais cenários valem neste substatus".
+
+import { SoundManager } from "../shared/sound-manager.js";
+import { confirmDialog, showToast } from "../shared/utils.js";
+import { ShortcutService, MAX_SHORTCUTS, shortcutIssues } from "../shared/shortcut-service.js";
+import {
+    SUBSTATUS_TEMPLATES,
+    getScenariosFor,
+    scenarioLabel,
+} from "../notes/data/notes-data.js";
+
+const BOLT = `<svg viewBox="0 0 24 24" fill="currentColor" style="width:14px;height:14px;"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>`;
+const GRIP = `<svg viewBox="0 0 24 24" fill="currentColor" style="width:14px;height:14px;"><circle cx="9" cy="6" r="1.6"/><circle cx="15" cy="6" r="1.6"/><circle cx="9" cy="12" r="1.6"/><circle cx="15" cy="12" r="1.6"/><circle cx="9" cy="18" r="1.6"/><circle cx="15" cy="18" r="1.6"/></svg>`;
+const PENCIL = `<svg viewBox="0 0 24 24" fill="currentColor" style="width:14px;height:14px;"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`;
+const TRASH = `<svg viewBox="0 0 24 24" fill="currentColor" style="width:14px;height:14px;"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>`;
+
+function injectStyles(COLORS) {
+    if (document.getElementById("cw-shortcuts-styles")) return;
+    const style = document.createElement("style");
+    style.id = "cw-shortcuts-styles";
+    style.innerHTML = `
+        .cw-sc-item {
+            display: flex; align-items: center; gap: 10px; padding: 10px 12px;
+            border: 1px solid ${COLORS.border}; border-radius: 10px; background: #fff;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+        }
+        .cw-sc-item + .cw-sc-item { margin-top: 8px; }
+        .cw-sc-item:hover { border-color: #bdc1c6; }
+        .cw-sc-item.dragging { opacity: 0.4; }
+        .cw-sc-item.drop-target { border-color: ${COLORS.primary}; box-shadow: 0 0 0 2px rgba(26,115,232,0.15); }
+        .cw-sc-item.broken { border-color: #f9ab00; background: #fffbf0; }
+        .cw-sc-grip {
+            color: #9aa0a6; cursor: grab; display: flex; background: none; border: none;
+            padding: 2px; border-radius: 4px;
+        }
+        .cw-sc-grip:active { cursor: grabbing; }
+        .cw-sc-grip:focus-visible { outline: 2px solid ${COLORS.primary}; outline-offset: 1px; }
+        .cw-sc-bolt {
+            width: 26px; height: 26px; border-radius: 8px; background: #FEF7E0; color: #F9A825;
+            display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+        }
+        .cw-sc-text { flex: 1; min-width: 0; }
+        .cw-sc-label {
+            font-size: 13px; font-weight: 600; color: ${COLORS.text};
+            white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+        }
+        .cw-sc-meta { font-size: 11px; color: ${COLORS.textSub}; margin-top: 2px; }
+        .cw-sc-warn { color: #b06000; font-weight: 600; }
+        .cw-sc-iconbtn {
+            width: 28px; height: 28px; border-radius: 8px; border: none; background: transparent;
+            color: ${COLORS.textSub}; cursor: pointer; display: flex; align-items: center;
+            justify-content: center; transition: background 0.15s ease, color 0.15s ease;
+        }
+        .cw-sc-iconbtn:hover { background: #f1f3f4; color: ${COLORS.text}; }
+        .cw-sc-iconbtn.danger:hover { background: #fce8e6; color: #d93025; }
+        .cw-sc-empty {
+            font-size: 12px; color: ${COLORS.textSub}; text-align: center;
+            padding: 18px 12px; border: 1px dashed ${COLORS.border}; border-radius: 10px;
+        }
+        .cw-sc-add {
+            margin-top: 10px; width: 100%; padding: 10px; border-radius: 10px;
+            border: 1px dashed ${COLORS.border}; background: transparent; cursor: pointer;
+            font-family: inherit; font-weight: 600; font-size: 12px; color: ${COLORS.textSub};
+            transition: all 0.2s ease;
+        }
+        .cw-sc-add:hover:not(:disabled) { border-color: ${COLORS.primary}; color: ${COLORS.primary}; }
+        .cw-sc-add:disabled { opacity: 0.5; cursor: not-allowed; }
+        .cw-sc-field { display: flex; flex-direction: column; gap: 6px; }
+        .cw-sc-field label { font-size: 11px; font-weight: 700; color: ${COLORS.textSub}; text-transform: uppercase; letter-spacing: 0.5px; }
+        .cw-sc-field input, .cw-sc-field select {
+            padding: 9px 10px; border-radius: 8px; border: 1px solid ${COLORS.border};
+            font-family: inherit; font-size: 13px; color: ${COLORS.text}; background: #fff; outline: none;
+        }
+        .cw-sc-field input:focus, .cw-sc-field select:focus { border-color: ${COLORS.primary}; }
+        .cw-sc-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+        .cw-sc-chip {
+            padding: 6px 10px; border-radius: 14px; border: 1px solid ${COLORS.border};
+            background: #fff; font-size: 12px; color: ${COLORS.text}; cursor: pointer;
+            font-family: inherit; transition: all 0.15s ease;
+        }
+        .cw-sc-chip.on { background: #e8f0fe; border-color: ${COLORS.primary}; color: #1967d2; font-weight: 600; }
+        .cw-sc-editor-actions { display: flex; gap: 8px; }
+        .cw-sc-editor-actions button {
+            flex: 1; padding: 10px; border-radius: 10px; font-family: inherit;
+            font-weight: 600; font-size: 13px; cursor: pointer;
+        }
+        .cw-sc-cancel { border: 1px solid ${COLORS.border}; background: #fff; color: ${COLORS.textSub}; }
+        .cw-sc-save { border: none; background: ${COLORS.primary}; color: #fff; }
+    `;
+    document.head.appendChild(style);
+}
+
+// t: tradutor de configs-assistant.js. COLORS: mesma paleta da tela.
+export function createShortcutsSection(t, COLORS) {
+    injectStyles(COLORS);
+
+    const section = document.createElement("div");
+    section.className = "cw-configs-section";
+    section.innerHTML = `
+        <div class="cw-configs-section-title js-sc-title"></div>
+        <div class="cw-configs-card">
+            <div class="cw-configs-row">
+                <div>
+                    <div class="cw-configs-label js-sc-sort-label"></div>
+                    <div class="cw-configs-desc js-sc-sort-desc"></div>
+                </div>
+                <label class="cw-toggle-switch">
+                    <input type="checkbox" class="js-sc-sort-toggle">
+                    <span class="cw-toggle-track"></span>
+                </label>
+            </div>
+            <div class="js-sc-body"></div>
+        </div>
+    `;
+
+    const body = section.querySelector(".js-sc-body");
+    const sortToggle = section.querySelector(".js-sc-sort-toggle");
+
+    sortToggle.onchange = async (e) => {
+        SoundManager.playClick();
+        await ShortcutService.setSortedByUsage(e.target.checked);
+        renderList();
+    };
+
+    // ----------------------------------------------------------------
+    //  LISTA
+    // ----------------------------------------------------------------
+    function meta(shortcut) {
+        const tpl = SUBSTATUS_TEMPLATES[shortcut.payload.subStatus];
+        const nomeSub = tpl ? tpl.name : shortcut.payload.subStatus;
+        const qtd = (shortcut.payload.scenarios || []).length;
+        const partes = [
+            shortcut.payload.caseType.toUpperCase(),
+            nomeSub,
+            qtd === 1 ? t("scOneScenario") : t("scNScenarios").replace("{n}", qtd),
+        ];
+        if (shortcut.alias) partes.push(`"${shortcut.alias}"`);
+        return partes.join(" · ");
+    }
+
+    function renderList() {
+        body.innerHTML = "";
+        sortToggle.checked = ShortcutService.isSortedByUsage();
+
+        const lista = ShortcutService.listRaw();
+        const podeArrastar = !ShortcutService.isSortedByUsage();
+
+        if (!lista.length) {
+            const vazio = document.createElement("div");
+            vazio.className = "cw-sc-empty";
+            vazio.textContent = t("scEmpty");
+            body.appendChild(vazio);
+        }
+
+        lista.forEach((shortcut, idx) => {
+            const quebrados = shortcutIssues(shortcut);
+            const item = document.createElement("div");
+            item.className = "cw-sc-item" + (quebrados.length ? " broken" : "");
+            item.dataset.id = shortcut.id;
+            item.dataset.index = String(idx);
+
+            item.innerHTML = `
+                ${podeArrastar ? `<button type="button" class="cw-sc-grip" aria-label="${t('scReorder')}">${GRIP}</button>` : ""}
+                <span class="cw-sc-bolt">${BOLT}</span>
+                <span class="cw-sc-text">
+                    <span class="cw-sc-label"></span>
+                    <span class="cw-sc-meta"></span>
+                </span>
+                <button type="button" class="cw-sc-iconbtn js-sc-edit" aria-label="${t('scEdit')}">${PENCIL}</button>
+                <button type="button" class="cw-sc-iconbtn danger js-sc-del" aria-label="${t('scDelete')}">${TRASH}</button>
+            `;
+            item.querySelector(".cw-sc-label").textContent = shortcut.label;
+            item.querySelector(".cw-sc-meta").innerHTML = quebrados.length
+                ? `<span class="cw-sc-warn">${t("scBroken")}</span> · ${meta(shortcut)}`
+                : meta(shortcut);
+
+            item.querySelector(".js-sc-edit").onclick = () => renderEditor(shortcut);
+            item.querySelector(".js-sc-del").onclick = () => remover(shortcut);
+
+            if (podeArrastar) wireDrag(item, idx);
+            body.appendChild(item);
+        });
+
+        const add = document.createElement("button");
+        add.type = "button";
+        add.className = "cw-sc-add";
+        add.textContent = t("scAdd");
+        add.disabled = lista.length >= MAX_SHORTCUTS;
+        if (add.disabled) add.textContent = t("scLimit").replace("{max}", MAX_SHORTCUTS);
+        add.onclick = () => renderEditor(null);
+        body.appendChild(add);
+    }
+
+    async function remover(shortcut) {
+        const ok = await confirmDialog(t("scDeleteConfirm").replace("{name}", shortcut.label), { danger: true });
+        if (!ok) return;
+        await ShortcutService.remove(shortcut.id);
+        SoundManager.playClick();
+        renderList();
+    }
+
+    // Arrastar para reordenar. O punho também aceita teclado (setas): arrastar
+    // é a única forma óbvia com mouse, mas não pode ser a única forma possível.
+    function wireDrag(item, idx) {
+        const grip = item.querySelector(".cw-sc-grip");
+        item.draggable = false;
+
+        grip.onmousedown = () => { item.draggable = true; };
+        grip.onmouseup = () => { item.draggable = false; };
+
+        grip.onkeydown = async (e) => {
+            const delta = e.key === "ArrowUp" ? -1 : e.key === "ArrowDown" ? 1 : 0;
+            if (!delta) return;
+            e.preventDefault();
+            await ShortcutService.reorder(item.dataset.id, idx + delta);
+            SoundManager.playClick();
+            renderList();
+            // Devolve o foco ao mesmo punho, agora na nova posição.
+            const alvo = body.querySelector(`.cw-sc-item[data-index="${Math.max(0, idx + delta)}"] .cw-sc-grip`);
+            if (alvo) alvo.focus();
+        };
+
+        item.ondragstart = (e) => {
+            e.dataTransfer.effectAllowed = "move";
+            e.dataTransfer.setData("text/plain", item.dataset.id);
+            item.classList.add("dragging");
+        };
+        item.ondragend = () => {
+            item.classList.remove("dragging");
+            item.draggable = false;
+            body.querySelectorAll(".drop-target").forEach((el) => el.classList.remove("drop-target"));
+        };
+        item.ondragover = (e) => {
+            e.preventDefault();
+            item.classList.add("drop-target");
+        };
+        item.ondragleave = () => item.classList.remove("drop-target");
+        item.ondrop = async (e) => {
+            e.preventDefault();
+            item.classList.remove("drop-target");
+            const id = e.dataTransfer.getData("text/plain");
+            if (!id || id === item.dataset.id) return;
+            await ShortcutService.reorder(id, Number(item.dataset.index));
+            SoundManager.playClick();
+            renderList();
+        };
+    }
+
+    // ----------------------------------------------------------------
+    //  EDITOR
+    // ----------------------------------------------------------------
+    function statusList() {
+        const vistos = [];
+        for (const key in SUBSTATUS_TEMPLATES) {
+            const st = SUBSTATUS_TEMPLATES[key].status;
+            if (st && !vistos.includes(st)) vistos.push(st);
+        }
+        return vistos;
+    }
+
+    function renderEditor(shortcut) {
+        const editando = !!shortcut;
+        const estado = editando
+            ? JSON.parse(JSON.stringify(shortcut))
+            : {
+                kind: "note",
+                label: "",
+                alias: "",
+                payload: { caseType: "bau", status: "", subStatus: "", scenarios: [] },
+            };
+
+        body.innerHTML = "";
+        const form = document.createElement("div");
+        form.style.cssText = "display: flex; flex-direction: column; gap: 14px;";
+        form.innerHTML = `
+            <div class="cw-sc-field">
+                <label for="cw-sc-name">${t("scName")}</label>
+                <input id="cw-sc-name" type="text" maxlength="60" placeholder="${t("scNamePlaceholder")}">
+            </div>
+            <div class="cw-sc-field">
+                <label for="cw-sc-alias">${t("scAlias")}</label>
+                <input id="cw-sc-alias" type="text" maxlength="40" placeholder="${t("scAliasPlaceholder")}">
+                <div class="cw-configs-desc">${t("scAliasDesc")}</div>
+            </div>
+            <div class="cw-sc-field">
+                <label for="cw-sc-type">${t("scFlow")}</label>
+                <select id="cw-sc-type">
+                    <option value="bau">BAU</option>
+                    <option value="lm">LM</option>
+                </select>
+            </div>
+            <div class="cw-sc-field">
+                <label for="cw-sc-status">${t("scStatus")}</label>
+                <select id="cw-sc-status"></select>
+            </div>
+            <div class="cw-sc-field">
+                <label for="cw-sc-sub">${t("scSubStatus")}</label>
+                <select id="cw-sc-sub"></select>
+            </div>
+            <div class="cw-sc-field">
+                <label>${t("scScenarios")}</label>
+                <div class="cw-sc-chips js-sc-scenarios"></div>
+                <div class="cw-configs-desc">${t("scScenariosDesc")}</div>
+            </div>
+            <div class="cw-sc-editor-actions">
+                <button type="button" class="cw-sc-cancel">${t("scCancel")}</button>
+                <button type="button" class="cw-sc-save">${t("scSave")}</button>
+            </div>
+        `;
+        body.appendChild(form);
+
+        const nome = form.querySelector("#cw-sc-name");
+        const alias = form.querySelector("#cw-sc-alias");
+        const tipo = form.querySelector("#cw-sc-type");
+        const status = form.querySelector("#cw-sc-status");
+        const sub = form.querySelector("#cw-sc-sub");
+        const chips = form.querySelector(".js-sc-scenarios");
+
+        nome.value = estado.label;
+        alias.value = estado.alias;
+        tipo.value = estado.payload.caseType;
+
+        status.innerHTML = `<option value="">—</option>` +
+            statusList().map((s) => `<option value="${s}">${s}</option>`).join("");
+        status.value = estado.payload.status;
+
+        function renderSubOptions() {
+            const atual = status.value;
+            sub.innerHTML = `<option value="">—</option>`;
+            for (const key in SUBSTATUS_TEMPLATES) {
+                if (SUBSTATUS_TEMPLATES[key].status !== atual) continue;
+                const opt = document.createElement("option");
+                opt.value = key;
+                opt.textContent = SUBSTATUS_TEMPLATES[key].name;
+                sub.appendChild(opt);
+            }
+            sub.disabled = !atual;
+        }
+
+        function renderScenarioChips() {
+            chips.innerHTML = "";
+            if (!sub.value) {
+                chips.innerHTML = `<div class="cw-configs-desc">${t("scPickSubStatus")}</div>`;
+                return;
+            }
+            const disponiveis = getScenariosFor(sub.value, tipo.value);
+            if (!disponiveis.length) {
+                chips.innerHTML = `<div class="cw-configs-desc">${t("scNoScenarios")}</div>`;
+                return;
+            }
+            disponiveis.forEach(([id]) => {
+                const chip = document.createElement("button");
+                chip.type = "button";
+                chip.className = "cw-sc-chip";
+                chip.textContent = scenarioLabel(id, sub.value);
+                const marcado = () => estado.payload.scenarios.some((r) => r.id === id);
+                chip.classList.toggle("on", marcado());
+                chip.onclick = () => {
+                    if (marcado()) {
+                        estado.payload.scenarios = estado.payload.scenarios.filter((r) => r.id !== id);
+                    } else {
+                        estado.payload.scenarios.push({ id, substatus: sub.value });
+                    }
+                    chip.classList.toggle("on", marcado());
+                    SoundManager.playClick();
+                };
+                chips.appendChild(chip);
+            });
+        }
+
+        renderSubOptions();
+        sub.value = estado.payload.subStatus;
+        renderScenarioChips();
+
+        status.onchange = () => {
+            // Trocar de status invalida substatus e cenários: manter os antigos
+            // criaria justamente o atalho impossível que este editor evita.
+            estado.payload.scenarios = [];
+            renderSubOptions();
+            sub.value = "";
+            renderScenarioChips();
+        };
+        sub.onchange = () => {
+            estado.payload.scenarios = [];
+            renderScenarioChips();
+        };
+        tipo.onchange = () => {
+            estado.payload.scenarios = [];
+            renderScenarioChips();
+        };
+
+        form.querySelector(".cw-sc-cancel").onclick = () => {
+            SoundManager.playClick();
+            renderList();
+        };
+
+        form.querySelector(".cw-sc-save").onclick = async () => {
+            if (!sub.value) {
+                SoundManager.playError();
+                showToast(t("scPickSubStatus"), { error: true });
+                return;
+            }
+            const rotulo = nome.value.trim() || SUBSTATUS_TEMPLATES[sub.value].name;
+            const resultado = await ShortcutService.save({
+                ...estado,
+                label: rotulo,
+                alias: alias.value.trim(),
+                payload: {
+                    ...estado.payload,
+                    caseType: tipo.value,
+                    status: status.value || String(sub.value).split("_")[0],
+                    subStatus: sub.value,
+                },
+            });
+
+            if (!resultado.ok) {
+                SoundManager.playError();
+                showToast(t("scLimit").replace("{max}", MAX_SHORTCUTS), { error: true });
+                return;
+            }
+            SoundManager.playSuccess();
+            showToast(resultado.synced ? t("scSaved") : t("scSavedLocal"));
+            renderList();
+        };
+    }
+
+    section.refresh = renderList;
+    section.applyTexts = () => {
+        section.querySelector(".js-sc-title").textContent = t("scSectionTitle");
+        section.querySelector(".js-sc-sort-label").textContent = t("scSortLabel");
+        section.querySelector(".js-sc-sort-desc").textContent = t("scSortDesc");
+        renderList();
+    };
+
+    renderList();
+    return section;
+}

--- a/src/modules/notes/components/step-scenarios.js
+++ b/src/modules/notes/components/step-scenarios.js
@@ -1,6 +1,6 @@
 // src/modules/notes/components/step-scenarios.js
 
-import { scenarioSnippets, getScenarioFields } from "../data/notes-data.js";
+import { getScenarioFields, getScenariosFor, scenarioLabel } from "../data/notes-data.js";
 import { SoundManager } from "../../shared/sound-manager.js";
 import { getLanguage } from "../../shared/i18n.js";
 
@@ -67,17 +67,12 @@ export function createScenariosComponent(onSelectCallback) {
       // DC), nunca o substatus - todo cenário de NI aparecia em qualquer um
       // dos 4 substatus de NI, sem diferenciação. Regras de quais cenários
       // pertencem a qual substatus: specs/workflow/case-notes-status-rules.md
-      const filtered = Object.entries(scenarioSnippets).filter(([id, data]) => {
-          const matchesType = !data.type || data.type === 'all' || data.type === caseType;
-          const matchesSubStatus = Array.isArray(data.substatus) && data.substatus.includes(subStatusKey);
-          return matchesType && matchesSubStatus;
-      });
+      const filtered = getScenariosFor(subStatusKey, caseType);
 
       grid.innerHTML = "";
       filtered.forEach(([id, data]) => {
           const chip = document.createElement("div");
-          const label = id.replace('quickfill-', '').replace(/-/g, ' ');
-          chip.textContent = label;
+          chip.textContent = scenarioLabel(id, subStatusKey);
           chip.dataset.id = id;
           chip.dataset.sound = "hover";
 
@@ -158,6 +153,11 @@ export function createScenariosComponent(onSelectCallback) {
           container.style.display = "block";
       }
   };
+
+  // Quais cenários estão marcados agora - é o que o botão "Salvar como atalho"
+  // captura. O Set é interno de propósito (o clique é a única forma de mexer
+  // nele); expor a leitura não abre mão disso.
+  container.getSelectedIds = () => [...selectedIds];
 
   container.appendChild(grid);
   container.appendChild(previewBox);

--- a/src/modules/notes/data/notes-data.js
+++ b/src/modules/notes/data/notes-data.js
@@ -56,6 +56,12 @@ export const translations = {
         'renomear_tooltip': 'Clique para renomear esta task',
         'renomear_hint': '✎ Renomear',
         'substituir_rascunho_confirm': 'Isso vai substituir o rascunho atual da nota. Deseja continuar?',
+        'salvar_como_atalho': 'Salvar como atalho do Ctrl+K',
+        'atalho_nome_pergunta': 'Como este atalho vai se chamar no Ctrl+K?',
+        'atalho_salvo': 'Atalho salvo! Já aparece no Ctrl+K.',
+        'atalho_salvo_local': 'Atalho salvo neste navegador (sem conexão com a nuvem).',
+        'atalho_limite': 'Você já tem {max} atalhos. Apague um em Configurações antes de criar outro.',
+        'atalho_cenario_sumiu': 'Este atalho apontava para um cenário que não existe mais. Revise-o em Configurações.',
         'restaurar_rascunho_confirm': 'Detectamos um rascunho não salvo da sua última sessão. Deseja restaurar?',
         'cole_link_placeholder': 'Cole o link aqui...',
         'copiado_sucesso': 'Texto copiado com sucesso',
@@ -158,6 +164,12 @@ export const translations = {
         'renomear_tooltip': 'Haz clic para renombrar esta tarea',
         'renomear_hint': '✎ Renombrar',
         'substituir_rascunho_confirm': 'Esto reemplazará el borrador actual de la nota. ¿Deseas continuar?',
+        'salvar_como_atalho': 'Guardar como atajo de Ctrl+K',
+        'atalho_nome_pergunta': '¿Cómo se va a llamar este atajo en el Ctrl+K?',
+        'atalho_salvo': '¡Atajo guardado! Ya aparece en el Ctrl+K.',
+        'atalho_salvo_local': 'Atajo guardado en este navegador (sin conexión con la nube).',
+        'atalho_limite': 'Ya tienes {max} atajos. Elimina uno en Configuración antes de crear otro.',
+        'atalho_cenario_sumiu': 'Este atajo apuntaba a un escenario que ya no existe. Revísalo en Configuración.',
         'restaurar_rascunho_confirm': 'Detectamos un borrador sin guardar de tu última sesión. ¿Deseas restaurarlo?',
         'cole_link_placeholder': 'Pega el enlace aquí...',
         'copiado_sucesso': 'Texto copiado con éxito',
@@ -473,6 +485,44 @@ export function getScenarioFields(snippet, lang, scenarioId) {
     const overrides = SCENARIO_ES[scenarioId];
     if (!overrides) return snippet;
     return { ...snippet, ...overrides };
+}
+
+// Quais cenários valem para um substatus e um tipo de caso. Regra ÚNICA, usada
+// pelos chips do Case Notes (components/step-scenarios.js) e pelo construtor de
+// atalhos em Configurações. Se as duas telas divergissem, o agente poderia
+// montar um atalho apontando pra um chip que aquela tela nunca mostra - e o
+// atalho abriria a nota sem o texto, sem erro nenhum.
+export function getScenariosFor(subStatusKey, caseType) {
+    return Object.entries(scenarioSnippets).filter(([, data]) => {
+        const matchesType = !data.type || data.type === 'all' || data.type === caseType;
+        const matchesSubStatus = Array.isArray(data.substatus) && data.substatus.includes(subStatusKey);
+        return matchesType && matchesSubStatus;
+    });
+}
+
+// O trecho identificador de um cenário, sem o prefixo da origem. Embutido aqui
+// ele é `quickfill-ni-cms-access`; publicado pela Central vira
+// `cw-<substatus>-<slug>` (note-templates-service.js#idDoModelo). O final é o
+// mesmo nos dois - é por ele que um atalho salvo num mundo se acha no outro.
+export function scenarioSlug(id, substatus) {
+    const raw = String(id || '');
+    if (raw.startsWith('quickfill-')) return raw.slice('quickfill-'.length);
+
+    if (substatus) {
+        const prefix = `cw-${String(substatus).toLowerCase()}-`;
+        if (raw.startsWith(prefix)) return raw.slice(prefix.length);
+    }
+    // A chave do substatus nunca tem hífen (é UPPER_SNAKE_CASE), então o
+    // primeiro hífen depois dela delimita o slug com segurança.
+    const m = raw.match(/^cw-[a-z0-9_]+-(.+)$/);
+    return m ? m[1] : raw;
+}
+
+// Nome legível de um cenário para exibir num chip ou numa lista. Passa pelo
+// slug de propósito: sem isso, um cenário publicado pela Central apareceria
+// como "cw in_not_reachable in no show bau" na tela do agente.
+export function scenarioLabel(id, substatus) {
+    return scenarioSlug(id, substatus).replace(/-/g, ' ');
 }
 
 // Campos presentes em quase todo template (17 dos 18) mas de baixo valor por
@@ -877,14 +927,6 @@ export const scenarioSnippets = {
     'quickfill-ni-attempted-2day': {
         type: 'bau',
         substatus: ['NI_Attempted_Contact'],
-        // Atalho de Ctrl+K (Quick Launch): ver notes-assistant.js#openWithPreset.
-        quickLaunch: {
-            status: 'NI',
-            subStatus: 'NI_Attempted_Contact',
-            label: 'NI Attempted — Início 2 Day Rule',
-            keywords: '2 day ligacao attempted contact inicio',
-            focusIds: ['field-SPEAKEASY_ID', 'evidence-l1', 'evidence-l2', 'evidence-msg']
-        },
         'field-REASON_COMMENTS': "Attempted Contact (Início 2 Day Rule)",
         'field-CONTEXTO_CALL': "• Fiz a primeira tentativa de ligação, sem sucesso.\n• Enviei uma message no chat para o AM.\n• Aguardei 5 minutos e fiz a segunda tentativa de ligação, novamente sem sucesso.\n• Aguardei mais 5 minutos e agora farei o acompanhamento 2 Day Rule.",
         'field-SCREENSHOTS': "• MSG AM -\n• Tentativa 1 -\n• Tentativa 2 -"
@@ -911,17 +953,6 @@ export const scenarioSnippets = {
     'quickfill-in-no-show-bau': {
         type: 'bau',
         substatus: ['IN_Not_Reachable'],
-        // Atalho de Ctrl+K (Quick Launch): abre o Case Notes já no status/substatus
-        // certo e com este cenário aplicado - ver notes-assistant.js#openWithPreset.
-        // focusIds: campo pra focar/realçar como "ainda falta preencher" depois de
-        // aplicar o preset, em ordem de prioridade.
-        quickLaunch: {
-            status: 'IN',
-            subStatus: 'IN_Not_Reachable',
-            label: 'IN Not Reachable — Finalização 2 Day Rule',
-            keywords: '2 day finalizacao nao atendeu ligacoes reachable',
-            focusIds: ['field-SPEAKEASY_ID']
-        },
         'field-REASON_COMMENTS': "Sem resposta ao 2 Day Rule.",
         'field-ON_CALL': "N/A",
         'field-COMENTARIOS': "• O caso foi gerado e entrei na chamada no horário agendado.\n• O anunciante não compareceu à reunião.\n• Segui o protocolo de espera (BAU): realizei duas tentativas de ligação, sem sucesso.\n• Nenhuma das ligações foi atendida (ex: Caixa Postal).\n• Caso inativado após 2 Day Rule.",

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -1,6 +1,6 @@
 // src/modules/notes/notes-assistant.js
 
-import { showToast, confirmDialog } from "../shared/utils.js";
+import { showToast, confirmDialog, promptDialog } from "../shared/utils.js";
 import { notesState } from "./core/notes-state.js";
 import { createNotesPopup, HEADER_DESC } from "./ui/notes-popup.js";
 import { COLORS, RADIUS, SHADOW, EASE } from "./notes-styles.js";
@@ -17,6 +17,7 @@ import { SoundManager } from "../shared/sound-manager.js";
 import { enableFilledCheck, lockBodyScroll, unlockBodyScroll, markPendingField } from "../shared/dom-utils.js";
 import { getPageData } from "../shared/page-data.js";
 import { getLanguage, onLanguageChange } from "../shared/i18n.js";
+import { ShortcutService, resolveScenarioId, MAX_SHORTCUTS } from "../shared/shortcut-service.js";
 import {
     SUBSTATUS_TEMPLATES,
     SUBSTATUS_SHORTCODES,
@@ -37,6 +38,10 @@ import { runEmailAutomation } from "../email-assistant/email-automation-service.
 import { triggerProcessingAnimation, updateNotesBadge, registerCaseCompleted } from "../shared/command-center.js";
 import { toggleGenieAnimation } from "../shared/animations.js";
 
+// Mesmo raio do Ctrl+K (command-palette.js): é a pista visual de que os dois
+// botões falam da mesma coisa.
+const BOLT_ICON = `<svg viewBox="0 0 24 24" fill="currentColor" style="width:13px;height:13px;flex-shrink:0;"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>`;
+
 export function initCaseNotesAssistant() {
     const CURRENT_VERSION = "v4.0.0";
 
@@ -56,6 +61,33 @@ export function initCaseNotesAssistant() {
         applyScenario(scenarioId, isSelected);
     });
     scenariosContainer.appendChild(scenarioSelector);
+
+    // "Salvar como atalho": captura a combinação que já está montada na tela
+    // (tipo de caso + status + substatus + cenários marcados) e a transforma
+    // num comando do Ctrl+K. Fica aqui, e não na barra de ações, porque é sobre
+    // a combinação escolhida acima - não sobre a nota pronta.
+    const saveShortcutBtn = document.createElement("button");
+    saveShortcutBtn.type = "button";
+    saveShortcutBtn.className = "cw-save-shortcut-btn";
+    saveShortcutBtn.style.cssText = `
+        margin-top: 10px; padding: 7px 12px; border-radius: 8px;
+        border: 1px dashed ${COLORS.border}; background: transparent;
+        color: ${COLORS.textSub}; font-family: inherit; font-size: 11.5px;
+        font-weight: 600; cursor: pointer; display: inline-flex; align-items: center;
+        gap: 6px; transition: all 0.2s ${EASE};
+    `;
+    saveShortcutBtn.onmouseenter = () => {
+        saveShortcutBtn.style.borderColor = COLORS.primary;
+        saveShortcutBtn.style.color = COLORS.primary;
+        SoundManager.playHover();
+    };
+    saveShortcutBtn.onmouseleave = () => {
+        saveShortcutBtn.style.borderColor = COLORS.border;
+        saveShortcutBtn.style.color = COLORS.textSub;
+    };
+    saveShortcutBtn.onclick = () => handleSaveAsShortcut();
+    saveShortcutBtn.innerHTML = `${BOLT_ICON}<span>${t('salvar_como_atalho')}</span>`;
+    scenariosContainer.appendChild(saveShortcutBtn);
 
     // --- Evidence Container (Attempted Contact) ---
     const evidenceContainer = document.createElement("div");
@@ -925,20 +957,29 @@ export function initCaseNotesAssistant() {
         notesState.isDirty = false;
     }
 
-    // Quick Launch (Ctrl+K -> preset de nota): abre o Case Notes já no
-    // status/substatus certo e com o cenário mais usado aplicado, pra quem
-    // hoje copia e cola essas notas em vez de passar pelo fluxo normal. Não
-    // reimplementa nada - só encadeia as mesmas peças que o clique manual já
-    // usa (troca de select, onSubStatusChange, clique no chip do cenário),
-    // então herda de graça qualquer ajuste futuro nelas.
-    async function openWithPreset(scenarioId) {
-        const scenario = scenarioSnippets[scenarioId];
-        const preset = scenario && scenario.quickLaunch;
-        if (!preset) return;
+    // Atalho do Ctrl+K: abre o Case Notes já no status/substatus certo e com os
+    // cenários do atalho aplicados, pra quem hoje copia e cola essas notas em
+    // vez de passar pelo fluxo normal. Não reimplementa nada - só encadeia as
+    // mesmas peças que o clique manual já usa (troca de select,
+    // onSubStatusChange, clique no chip), então herda de graça qualquer ajuste
+    // futuro nelas.
+    //
+    // Recebe o atalho inteiro (ver shortcut-service.js), não um id de cenário:
+    // um atalho pode combinar vários cenários, ou nenhum - abrir só no
+    // substatus certo já é um atalho útil.
+    async function openWithPreset(shortcut) {
+        const payload = shortcut && shortcut.payload;
+        if (!payload || !payload.subStatus) return { ok: false, reason: 'invalid' };
+
+        // Resolve ANTES de mexer na tela: se o cenário sumiu do catálogo, o
+        // agente precisa saber disso em vez de ver a nota abrir pela metade.
+        const refs = payload.scenarios || [];
+        const resolvidos = refs.map((ref) => resolveScenarioId(ref));
+        const perdidos = refs.filter((_, i) => !resolvidos[i]);
 
         if (notesState.isDirty) {
             const confirmed = await confirmDialog(t('substituir_rascunho_confirm'));
-            if (!confirmed) return;
+            if (!confirmed) return { ok: false, reason: 'cancelled' };
         }
 
         const wasVisible = notesState.visible;
@@ -950,34 +991,111 @@ export function initCaseNotesAssistant() {
         // trocar os selects no meio da animação de abertura ficava estranho.
         if (!wasVisible) await wait(550);
 
+        if (payload.caseType && payload.caseType !== notesState.currentCaseType) {
+            const typeBtn = content.querySelector(`#type-selector button[data-type="${payload.caseType}"]`);
+            if (typeBtn) typeBtn.click();
+            await wait(60);
+        }
+
         const mainSelect = content.querySelector('#main-status-select');
         const subSelect = content.querySelector('#sub-status-select');
-        mainSelect.value = preset.status;
-        notesState.setStatus(preset.status);
-        updateSubStatusOptions(preset.status, subSelect);
+        const status = payload.status || String(payload.subStatus).split('_')[0];
+        mainSelect.value = status;
+        notesState.setStatus(status);
+        updateSubStatusOptions(status, subSelect);
 
         await wait(60);
 
-        subSelect.value = preset.subStatus;
-        notesState.setSubStatus(preset.subStatus);
-        onSubStatusChange(preset.subStatus);
+        subSelect.value = payload.subStatus;
+        notesState.setSubStatus(payload.subStatus);
+        onSubStatusChange(payload.subStatus);
 
         await wait(160);
 
         // Clique real no chip (não chama applyScenario direto): assim o
         // cenário aparece visualmente selecionado, com o mesmo som de clique
         // de sempre - igual a um agente teria feito na mão.
-        const chip = scenariosContainer.querySelector(`[data-id="${scenarioId}"]`);
-        if (chip) chip.click();
+        for (const id of resolvidos.filter(Boolean)) {
+            const chip = scenariosContainer.querySelector(`[data-id="${id}"]`);
+            if (chip) chip.click();
+        }
 
         await wait(120);
-        SoundManager.playSuccess();
 
-        const pendingId = (preset.focusIds || []).find((id) => {
-            const el = document.getElementById(id);
-            return el && !el.value.trim();
-        });
-        if (pendingId) markPendingField(document.getElementById(pendingId));
+        if (perdidos.length) {
+            // Falhar em silêncio aqui é o pior desfecho possível: o agente
+            // acharia que a nota está completa e mandaria faltando texto.
+            SoundManager.playError();
+            showToast(t('atalho_cenario_sumiu'), { error: true });
+        } else {
+            SoundManager.playSuccess();
+        }
+
+        const pendente = firstEmptyFieldElement();
+        if (pendente) markPendingField(pendente);
+
+        return { ok: true, missing: perdidos.map((r) => r.id) };
+    }
+
+    // O primeiro campo que o atalho deixou vazio de propósito (tipicamente o
+    // SE ID, que só o agente sabe). Antes isso era uma lista `focusIds` escrita
+    // à mão por atalho; derivar da tela dispensa configuração e nunca aponta
+    // pra um campo que aquele substatus não tem.
+    function firstEmptyFieldElement() {
+        const candidatos = content.querySelectorAll(
+            'input[id^="field-"], textarea[id^="field-"], input[id^="evidence-"]'
+        );
+        for (const el of candidatos) {
+            if (el.offsetParent === null) continue; // campo escondido não conta
+            if (!String(el.value || '').trim()) return el;
+        }
+        return null;
+    }
+
+    async function handleSaveAsShortcut() {
+        const capturado = captureCurrentAsShortcut();
+        if (!capturado) {
+            SoundManager.playError();
+            showToast(t('select_substatus'), { error: true });
+            return;
+        }
+
+        if (ShortcutService.listRaw().length >= MAX_SHORTCUTS) {
+            SoundManager.playError();
+            showToast(t('atalho_limite').replace('{max}', MAX_SHORTCUTS), { error: true });
+            return;
+        }
+
+        const sugestao = SUBSTATUS_TEMPLATES[capturado.payload.subStatus]?.name || capturado.payload.subStatus;
+        const nome = await promptDialog(t('atalho_nome_pergunta'), sugestao);
+        if (nome === null) return;
+
+        const resultado = await ShortcutService.save({ ...capturado, label: String(nome).trim() || sugestao });
+        if (!resultado.ok) {
+            SoundManager.playError();
+            showToast(t('atalho_limite').replace('{max}', MAX_SHORTCUTS), { error: true });
+            return;
+        }
+
+        SoundManager.playSuccess();
+        showToast(resultado.synced ? t('atalho_salvo') : t('atalho_salvo_local'));
+    }
+
+    // O estado atual da tela, no formato que o atalho guarda. É o que o botão
+    // "Salvar como atalho" captura - por isso o agente nunca configura uma
+    // combinação que a tela não produziria.
+    function captureCurrentAsShortcut() {
+        if (!notesState.currentSubStatus) return null;
+        const selecionados = scenarioSelector.getSelectedIds ? scenarioSelector.getSelectedIds() : [];
+        return {
+            kind: 'note',
+            payload: {
+                caseType: notesState.currentCaseType,
+                status: notesState.currentStatus,
+                subStatus: notesState.currentSubStatus,
+                scenarios: selecionados.map((id) => ({ id, substatus: notesState.currentSubStatus })),
+            },
+        };
     }
 
     function t(key) {
@@ -1078,6 +1196,8 @@ export function initCaseNotesAssistant() {
 
         const lEmail = content.querySelector('.js-label-email-toggle');
         if (lEmail) lEmail.textContent = t('preencher_email_automaticamente');
+
+        saveShortcutBtn.innerHTML = `${BOLT_ICON}<span>${t('salvar_como_atalho')}</span>`;
 
         if (tagSupport && tagSupport.setLanguage) tagSupport.setLanguage(t);
         if (stepTasks && stepTasks.setLanguage) stepTasks.setLanguage(t);

--- a/src/modules/shared/command-palette.js
+++ b/src/modules/shared/command-palette.js
@@ -9,7 +9,7 @@
 import { SoundManager } from './sound-manager.js';
 import { lockBodyScroll, unlockBodyScroll } from './dom-utils.js';
 import { getLanguage, onLanguageChange } from './i18n.js';
-import { scenarioSnippets } from '../notes/data/notes-data.js';
+import { ShortcutService } from './shortcut-service.js';
 
 const ICONS = {
     notes: `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`,
@@ -79,6 +79,11 @@ function injectStyles() {
         .cw-palette-item-label { font-size: 14px; font-weight: 600; color: #202124; }
         .cw-palette-item-hint { font-size: 12px; color: #5F6368; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .cw-palette-empty { padding: 32px; text-align: center; color: #9AA0A6; font-size: 13px; }
+        .cw-palette-group {
+            padding: 10px 12px 4px; font-size: 10.5px; font-weight: 700;
+            color: #9AA0A6; text-transform: uppercase; letter-spacing: 0.8px;
+        }
+        .cw-palette-group:first-child { padding-top: 4px; }
 
         .cw-palette-footer { display: flex; gap: 16px; padding: 10px 20px; border-top: 1px solid #F1F3F4; background: #FAFAFA; font-size: 11px; color: #9AA0A6; font-weight: 600; }
         .cw-palette-footer span { display: flex; align-items: center; gap: 4px; }
@@ -95,6 +100,8 @@ const CP_DICT = {
         navigate: 'navegar',
         select: 'selecionar',
         close: 'esc fechar',
+        groupShortcuts: 'Meus atalhos',
+        groupModules: 'Módulos',
     },
     es: {
         ariaLabel: 'Búsqueda rápida',
@@ -103,6 +110,8 @@ const CP_DICT = {
         navigate: 'navegar',
         select: 'seleccionar',
         close: 'esc cerrar',
+        groupShortcuts: 'Mis atajos',
+        groupModules: 'Módulos',
     },
 };
 function cpt(key) {
@@ -121,33 +130,37 @@ export function initCommandPalette(actions) {
         return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
     }
 
-    // Atalhos de nota (Quick Launch): qualquer scenarioSnippet com um
-    // `quickLaunch` cadastrado em notes-data.js vira automaticamente uma
-    // entrada aqui - escalar pra mais notas é só adicionar o campo lá, sem
-    // tocar neste arquivo. Entram na mesma busca textual dos módulos, só com
-    // ícone de raio pra se destacar visualmente do resto.
+    // Atalhos do agente: vêm do ShortcutService (preferência da pessoa,
+    // sincronizada na nuvem), não mais de um campo dentro do cenário. São
+    // relidos a cada abertura porque o agente pode ter acabado de criar um em
+    // Configurações ou no próprio Case Notes.
     //
-    // O `label` vem de notes-data.js e é PT-only (é o nome do cenário); só o
-    // hint, que é texto nosso, tem as duas versões.
-    const notePresets = (typeof actions.toggleNotes === 'function' && typeof actions.toggleNotes.openWithPreset === 'function')
-        ? Object.entries(scenarioSnippets)
-            .filter(([, data]) => data.quickLaunch)
-            .map(([scenarioId, data]) => ({
-                id: `note-preset-${scenarioId}`,
-                label: data.quickLaunch.label,
-                hint: { pt: 'Atalho de nota · abre pré-preenchida', es: 'Atajo de nota · abre precompletada' },
-                keywords: `nota atalho atajo preset ${data.quickLaunch.keywords || ''}`,
-                icon: ICONS.bolt,
-                isPreset: true,
-                run: () => actions.toggleNotes.openWithPreset(scenarioId)
-            }))
-        : [];
+    // O `label` e o `alias` são escritos pelo próprio agente, então não têm
+    // versão por idioma; só o hint, que é texto nosso, tem as duas.
+    function noteShortcuts() {
+        if (typeof actions.toggleNotes !== 'function' ||
+            typeof actions.toggleNotes.openWithPreset !== 'function') return [];
+
+        return ShortcutService.list().map((shortcut) => ({
+            id: `shortcut-${shortcut.id}`,
+            label: shortcut.label,
+            hint: { pt: 'Atalho de nota · abre pré-preenchida', es: 'Atajo de nota · abre precompletada' },
+            keywords: `nota atalho atajo preset ${shortcut.alias || ''}`,
+            icon: ICONS.bolt,
+            group: 'shortcuts',
+            isPreset: true,
+            run: () => {
+                ShortcutService.registerUse(shortcut.id);
+                actions.toggleNotes.openWithPreset(shortcut);
+            }
+        }));
+    }
 
     // label fica em português mesmo pra ES: são os nomes dos módulos, e a
     // maioria já é em inglês (Case Notes, Call Script...) ou é curta o
     // bastante (Avisos, Configurações) pra não valer duplicar; só o hint
     // (descrição) e as keywords de busca variam por idioma.
-    const ALL_ACTIONS = [
+    const MODULE_ACTIONS = [
         { id: 'notes', label: 'Case Notes', hint: { pt: 'Montar a nota técnica do caso', es: 'Armar la nota técnica del caso' }, keywords: 'notas nota caso anotacoes anotaciones', icon: ICONS.notes, run: actions.toggleNotes },
         { id: 'bauform', label: 'BAU Form', hint: { pt: 'Solicitação de criação/descarte BAU', es: 'Solicitud de creación/descarte BAU' }, keywords: 'bau formulario solicitacao solicitud criacao creacion descarte', icon: ICONS.bauform, run: actions.toggleBAUForm },
         { id: 'email', label: 'Email Assistant', hint: { pt: 'Templates inteligentes de e-mail', es: 'Plantillas inteligentes de correo' }, keywords: 'email e-mail correio correo template plantilla', icon: ICONS.email, run: actions.toggleEmail },
@@ -157,14 +170,21 @@ export function initCommandPalette(actions) {
         { id: 'timezone', label: 'Fusos Horários', hint: { pt: 'Monitoramento e planejador de chamada', es: 'Monitoreo y planificador de llamada' }, keywords: 'fuso horario timezone', icon: ICONS.timezone, run: actions.toggleTimezone },
         { id: 'broadcast', label: 'Avisos', hint: { pt: 'Comunicados e disponibilidade BAU', es: 'Comunicados y disponibilidad BAU' }, keywords: 'avisos broadcast comunicados disponibilidade disponibilidad', icon: ICONS.broadcast, run: () => actions.broadcastControl && actions.broadcastControl.toggle() },
         { id: 'configs', label: 'Configurações', hint: { pt: 'Perfil, som e preferências', es: 'Perfil, sonido y preferencias' }, keywords: 'configuracoes configuracion config preferencias perfil som sonido', icon: ICONS.configs, run: actions.toggleConfigs },
-        ...notePresets,
-    ]
-        .filter(a => typeof a.run === 'function')
-        .map(a => ({ ...a, _haystack: normalize(`${a.label} ${a.hint.pt} ${a.hint.es} ${a.keywords}`) }));
+    ].map(a => ({ ...a, group: 'modules' }));
+
+    // Os atalhos do agente vêm primeiro: são dele, e são o que ele repete
+    // dezenas de vezes por dia. Os módulos seguem logo abaixo, na ordem de
+    // sempre.
+    function buildActions() {
+        return [...noteShortcuts(), ...MODULE_ACTIONS]
+            .filter(a => typeof a.run === 'function')
+            .map(a => ({ ...a, _haystack: normalize(`${a.label} ${a.hint.pt} ${a.hint.es} ${a.keywords}`) }));
+    }
 
     let isOpen = false;
     let selectedIndex = 0;
-    let filtered = ALL_ACTIONS;
+    let allActions = buildActions();
+    let filtered = allActions;
 
     const overlay = document.createElement('div');
     overlay.className = 'cw-palette-overlay';
@@ -198,7 +218,23 @@ export function initCommandPalette(actions) {
             list.innerHTML = `<div class="cw-palette-empty">${cpt('empty')}</div>`;
             return;
         }
+        // Cabeçalhos de grupo são elementos NÃO selecionáveis: entram no DOM
+        // mas ficam fora de `filtered`, que continua sendo só a lista de ações.
+        // É o que mantém a navegação por setas (selectedIndex) linear - inserir
+        // cabeçalho como item quebraria o índice a cada busca.
+        const itemEls = [];
+        let grupoAnterior = null;
+
         filtered.forEach((action, idx) => {
+            if (action.group !== grupoAnterior) {
+                grupoAnterior = action.group;
+                const header = document.createElement('div');
+                header.className = 'cw-palette-group';
+                header.textContent = cpt(action.group === 'shortcuts' ? 'groupShortcuts' : 'groupModules');
+                header.setAttribute('aria-hidden', 'true');
+                list.appendChild(header);
+            }
+
             const item = document.createElement('div');
             item.className = 'cw-palette-item' + (idx === selectedIndex ? ' selected' : '');
             item.innerHTML = `
@@ -211,8 +247,9 @@ export function initCommandPalette(actions) {
             item.onmouseenter = () => { selectedIndex = idx; render(); };
             item.onclick = () => activate(idx);
             list.appendChild(item);
+            itemEls.push(item);
         });
-        const selectedEl = list.children[selectedIndex];
+        const selectedEl = itemEls[selectedIndex];
         if (selectedEl) selectedEl.scrollIntoView({ block: 'nearest' });
     }
 
@@ -227,7 +264,10 @@ export function initCommandPalette(actions) {
     function open() {
         if (isOpen) return;
         isOpen = true;
-        filtered = ALL_ACTIONS;
+        // Relê os atalhos a cada abertura: o agente pode ter criado ou apagado
+        // um segundos atrás, em Configurações ou no Case Notes.
+        allActions = buildActions();
+        filtered = allActions;
         selectedIndex = 0;
         input.value = '';
         render();
@@ -255,8 +295,8 @@ export function initCommandPalette(actions) {
     input.addEventListener('input', () => {
         const term = normalize(input.value.trim());
         filtered = term
-            ? ALL_ACTIONS.filter(a => a._haystack.includes(term))
-            : ALL_ACTIONS;
+            ? allActions.filter(a => a._haystack.includes(term))
+            : allActions;
         selectedIndex = 0;
         render();
     });

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -365,6 +365,34 @@ sendBAUEscalation: async (payload, userEmail) => {
             console.error("Erro ao deletar snippet:", e);
             return false;
         }
+    },
+
+    // --- Preferências do agente (blob único por pessoa) ---
+    // Devolve null - e não {} - quando a busca falha: quem chama precisa saber
+    // distinguir "esta pessoa não tem preferência nenhuma" de "não deu pra
+    // perguntar", senão o cache local seria zerado por uma falha de rede.
+    getUserPrefs: async (userEmail) => {
+        try {
+            const response = await jsonpFetch('get_user_prefs', { user: userEmail });
+            if (response && response.status === 'success') return response.prefs || {};
+            return null;
+        } catch (e) {
+            console.warn("Erro ao carregar preferências:", e);
+            return null;
+        }
+    },
+
+    saveUserPrefs: async (prefs, userEmail) => {
+        try {
+            const response = await jsonpFetch('save_user_prefs', {
+                user: userEmail,
+                prefs: JSON.stringify(prefs || {})
+            });
+            return !!(response && response.status === 'success');
+        } catch (e) {
+            console.warn("Erro ao salvar preferências:", e);
+            return false;
+        }
     }
 };
 
@@ -376,3 +404,5 @@ export const fetchUserProfile = DataService.fetchUserProfile;
 export const getUserSnippets = DataService.getUserSnippets;
 export const saveSnippet = DataService.saveSnippet;
 export const deleteSnippet = DataService.deleteSnippet;
+export const getUserPrefs = DataService.getUserPrefs;
+export const saveUserPrefs = DataService.saveUserPrefs;

--- a/src/modules/shared/shortcut-service.js
+++ b/src/modules/shared/shortcut-service.js
@@ -210,13 +210,4 @@ export const ShortcutService = {
         } catch (e) { /* contador é acessório: nunca pode atrapalhar o atalho */ }
     },
 
-    getUsage() {
-        return readUsage();
-    },
-
-    onChange(callback) {
-        const offList = UserPrefsService.onChange(PREF_KEY, callback);
-        const offSort = UserPrefsService.onChange(PREF_KEY_SORT, callback);
-        return () => { offList(); offSort(); };
-    },
 };

--- a/src/modules/shared/shortcut-service.js
+++ b/src/modules/shared/shortcut-service.js
@@ -1,0 +1,222 @@
+// src/modules/shared/shortcut-service.js
+//
+// Atalhos do Ctrl+K escolhidos pelo próprio agente.
+//
+// Um atalho é uma combinação "status + substatus + cenários" com nome e apelido
+// próprios. Ele NÃO guarda o texto da nota: guarda a referência do cenário, e o
+// texto vem na hora do catálogo (embutido ou publicado na Central). Assim uma
+// correção publicada chega ao atalho sem o agente refazer nada.
+//
+// Por que uma entidade própria e não um campo dentro do cenário (o antigo
+// `quickLaunch`): ver docs/decisions/0002-atalhos-ctrl-k-por-agente.md. Em
+// resumo - o catálogo de cenários é reescrito inteiro pela Central de Conteúdo,
+// levando junto qualquer campo extra que morasse nele.
+
+import { UserPrefsService } from "./user-prefs-service.js";
+import { scenarioSnippets, scenarioSlug } from "../notes/data/notes-data.js";
+
+const PREF_KEY = "shortcuts";
+const PREF_KEY_SORT = "shortcutsSortByUsage";
+const USAGE_KEY = "cw_shortcut_usage_v1";
+
+// Teto deliberado: o Ctrl+K já lista 9 módulos. Passando disso a busca deixa de
+// ser "vejo tudo de relance" e vira rolagem, que é o que ele existe pra evitar.
+export const MAX_SHORTCUTS = 8;
+
+// Os dois atalhos que até aqui vinham embutidos em notes-data.js. Continuam
+// sendo o ponto de partida de quem nunca configurou nada - só que agora como
+// dado editável do agente, não como código.
+const DEFAULT_SHORTCUTS = [
+    {
+        // Id fixo (não gerado): a lista padrão é recalculada a cada leitura
+        // enquanto o agente não salva nada, e um id novo a cada chamada faria a
+        // contagem de uso e a seleção do Ctrl+K apontarem para o vazio.
+        id: "sc_default_ni_attempted",
+        kind: "note",
+        label: "NI Attempted — Início 2 Day Rule",
+        alias: "2day inicio",
+        payload: {
+            caseType: "bau",
+            status: "NI",
+            subStatus: "NI_Attempted_Contact",
+            scenarios: [{ id: "quickfill-ni-attempted-2day", substatus: "NI_Attempted_Contact" }],
+        },
+    },
+    {
+        id: "sc_default_in_not_reachable",
+        kind: "note",
+        label: "IN Not Reachable — Finalização 2 Day Rule",
+        alias: "2day fim",
+        payload: {
+            caseType: "bau",
+            status: "IN",
+            subStatus: "IN_Not_Reachable",
+            scenarios: [{ id: "quickfill-in-no-show-bau", substatus: "IN_Not_Reachable" }],
+        },
+    },
+];
+
+function newId() {
+    return "sc_" + Date.now().toString(36) + Math.floor(Math.random() * 1000).toString(36);
+}
+
+// Devolve o id que existe HOJE no catálogo para a referência guardada, ou null
+// se aquele cenário não existe mais. Nunca lança: um atalho órfão precisa
+// aparecer marcado na tela, não derrubar o Ctrl+K inteiro.
+export function resolveScenarioId(ref) {
+    if (!ref || !ref.id) return null;
+    if (scenarioSnippets[ref.id]) return ref.id;
+
+    const alvo = scenarioSlug(ref.id, ref.substatus);
+    const entries = Object.entries(scenarioSnippets);
+
+    const mesmoSubstatus = entries.find(([id, data]) =>
+        scenarioSlug(id, ref.substatus) === alvo &&
+        Array.isArray(data.substatus) && data.substatus.includes(ref.substatus)
+    );
+    if (mesmoSubstatus) return mesmoSubstatus[0];
+
+    const qualquer = entries.find(([id]) => scenarioSlug(id, ref.substatus) === alvo);
+    return qualquer ? qualquer[0] : null;
+}
+
+// Um atalho está quebrado quando alguma referência de cenário não resolve mais.
+// Sem cenário nenhum (só status+substatus) é um atalho válido e intencional.
+export function shortcutIssues(shortcut) {
+    const refs = (shortcut.payload && shortcut.payload.scenarios) || [];
+    return refs.filter((ref) => !resolveScenarioId(ref)).map((ref) => ref.id);
+}
+
+function readUsage() {
+    try {
+        return JSON.parse(localStorage.getItem(USAGE_KEY) || "{}");
+    } catch (e) {
+        return {};
+    }
+}
+
+function normalize(list) {
+    if (!Array.isArray(list)) return [];
+    return list
+        .filter((s) => s && s.id && s.payload && s.payload.subStatus)
+        .map((s, idx) => ({
+            id: s.id,
+            kind: s.kind || "note",
+            label: String(s.label || "Atalho"),
+            alias: String(s.alias || ""),
+            order: Number.isFinite(s.order) ? s.order : idx,
+            payload: {
+                caseType: s.payload.caseType || "bau",
+                status: s.payload.status || String(s.payload.subStatus).split("_")[0],
+                subStatus: s.payload.subStatus,
+                scenarios: Array.isArray(s.payload.scenarios)
+                    ? s.payload.scenarios.filter((r) => r && r.id).map((r) => ({
+                        id: r.id,
+                        substatus: r.substatus || s.payload.subStatus,
+                    }))
+                    : [],
+            },
+        }));
+}
+
+export const ShortcutService = {
+    // Lista na ordem de exibição. Por padrão os mais usados vêm primeiro (o
+    // agente não precisa configurar nada pra melhorar); trocando o modo em
+    // Configurações vale a ordem manual, e o arrastar passa a valer.
+    list() {
+        const stored = UserPrefsService.get(PREF_KEY, null);
+        const list = normalize(stored === null ? ShortcutService.defaults() : stored);
+        const usage = readUsage();
+
+        return list.slice().sort((a, b) => {
+            if (ShortcutService.isSortedByUsage()) {
+                const diff = (usage[b.id] || 0) - (usage[a.id] || 0);
+                if (diff) return diff;
+            }
+            return a.order - b.order;
+        });
+    },
+
+    // A lista crua, na ordem manual - é o que a tela de gerenciamento edita.
+    listRaw() {
+        const stored = UserPrefsService.get(PREF_KEY, null);
+        return normalize(stored === null ? ShortcutService.defaults() : stored)
+            .sort((a, b) => a.order - b.order);
+    },
+
+    defaults() {
+        return DEFAULT_SHORTCUTS.map((s, idx) => ({ ...s, order: idx }));
+    },
+
+    isSortedByUsage() {
+        return UserPrefsService.get(PREF_KEY_SORT, true) !== false;
+    },
+
+    setSortedByUsage(value) {
+        return UserPrefsService.set(PREF_KEY_SORT, !!value);
+    },
+
+    async save(shortcut) {
+        const list = ShortcutService.listRaw();
+        const idx = list.findIndex((s) => s.id === shortcut.id);
+
+        if (idx === -1 && list.length >= MAX_SHORTCUTS) {
+            return { ok: false, reason: "limit" };
+        }
+
+        const entry = normalize([{ ...shortcut, id: shortcut.id || newId() }])[0];
+        if (!entry) return { ok: false, reason: "invalid" };
+
+        if (idx === -1) {
+            entry.order = list.length;
+            list.push(entry);
+        } else {
+            entry.order = list[idx].order;
+            list[idx] = entry;
+        }
+
+        const result = await UserPrefsService.set(PREF_KEY, list);
+        return { ok: true, synced: result.synced, shortcut: entry };
+    },
+
+    async remove(id) {
+        const list = ShortcutService.listRaw()
+            .filter((s) => s.id !== id)
+            .map((s, idx) => ({ ...s, order: idx }));
+        await UserPrefsService.set(PREF_KEY, list);
+    },
+
+    // Reordena movendo um item para uma posição. A lista inteira é reescrita com
+    // `order` sequencial pra nunca depender de índices antigos.
+    async reorder(id, novoIndice) {
+        const list = ShortcutService.listRaw();
+        const atual = list.findIndex((s) => s.id === id);
+        if (atual === -1) return;
+
+        const [item] = list.splice(atual, 1);
+        const destino = Math.max(0, Math.min(novoIndice, list.length));
+        list.splice(destino, 0, item);
+
+        await UserPrefsService.set(PREF_KEY, list.map((s, idx) => ({ ...s, order: idx })));
+    },
+
+    // Contagem local, de propósito: é sinal de conveniência, não dado do agente.
+    // Sincronizar isso significaria uma escrita na nuvem a cada Ctrl+K.
+    registerUse(id) {
+        try {
+            const usage = readUsage();
+            usage[id] = (usage[id] || 0) + 1;
+            localStorage.setItem(USAGE_KEY, JSON.stringify(usage));
+        } catch (e) { /* contador é acessório: nunca pode atrapalhar o atalho */ }
+    },
+
+    getUsage() {
+        return readUsage();
+    },
+
+    onChange(callback) {
+        const offList = UserPrefsService.onChange(PREF_KEY, callback);
+        const offSort = UserPrefsService.onChange(PREF_KEY_SORT, callback);
+        return () => { offList(); offSort(); };
+    },
+};

--- a/src/modules/shared/user-prefs-service.js
+++ b/src/modules/shared/user-prefs-service.js
@@ -41,14 +41,10 @@ function saveLocal(prefs) {
 
 export const UserPrefsService = {
     // Leitura síncrona: sempre do cache. Quem quiser o dado fresco da nuvem
-    // chama sync() e reage ao onChange.
+    // chama sync(); as telas releem a lista ao abrir.
     get(key, fallback = null) {
         const prefs = loadLocal();
         return key in prefs ? prefs[key] : fallback;
-    },
-
-    getAll() {
-        return loadLocal();
     },
 
     // Escrita otimista: grava local e devolve na hora; a nuvem confirma depois.
@@ -58,7 +54,6 @@ export const UserPrefsService = {
         const prefs = loadLocal();
         prefs[key] = value;
         saveLocal(prefs);
-        notify(key, value);
 
         const userEmail = getAgentEmail();
         if (!userEmail) return { saved: true, synced: false };
@@ -92,7 +87,6 @@ export const UserPrefsService = {
                     const local = loadLocal();
                     if (JSON.stringify(remote) !== JSON.stringify(local)) {
                         saveLocal(remote);
-                        Object.keys(remote).forEach((k) => notify(k, remote[k]));
                     }
                 }
             } catch (e) {
@@ -107,21 +101,4 @@ export const UserPrefsService = {
 
         return syncPromise;
     },
-
-    onChange(key, callback) {
-        const set = listeners.get(key) || new Set();
-        set.add(callback);
-        listeners.set(key, set);
-        return () => set.delete(callback);
-    },
 };
-
-const listeners = new Map();
-
-function notify(key, value) {
-    const set = listeners.get(key);
-    if (!set) return;
-    set.forEach((fn) => {
-        try { fn(value); } catch (e) { console.warn("Listener de preferências falhou:", e); }
-    });
-}

--- a/src/modules/shared/user-prefs-service.js
+++ b/src/modules/shared/user-prefs-service.js
@@ -1,0 +1,127 @@
+// src/modules/shared/user-prefs-service.js
+//
+// Preferências do agente que precisam seguir a pessoa, não o navegador.
+//
+// Mesmo desenho da Biblioteca Pessoal (snippet-service.js): lê do cache local
+// na hora (a tela nunca espera a rede) e sincroniza com a planilha em segundo
+// plano. A diferença é que aqui é UM blob por agente, não uma lista - o que
+// cabe numa linha só e numa query string de JSONP.
+//
+// Por que não localStorage puro: o Case Wizard é um bookmarklet injetado no
+// CRM. Trocar de máquina ou de perfil do Chrome é rotina, e é exatamente aí que
+// perder a configuração custa mais caro. Ver docs/decisions/0002.
+
+import { DataService } from "./data-service.js";
+import { getAgentEmail } from "./page-data.js";
+
+const STORAGE_KEY = "cw_user_prefs_v1";
+
+// Enquanto uma escrita está em voo, a sincronia de leitura não pode sobrescrever
+// o que acabou de ser salvo localmente - mesmo "cadeado" que a Biblioteca usa.
+let isMutating = false;
+let syncPromise = null;
+
+function loadLocal() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        const parsed = raw ? JSON.parse(raw) : null;
+        return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (e) {
+        return {};
+    }
+}
+
+function saveLocal(prefs) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    } catch (e) {
+        console.warn("Não consegui gravar as preferências localmente:", e);
+    }
+}
+
+export const UserPrefsService = {
+    // Leitura síncrona: sempre do cache. Quem quiser o dado fresco da nuvem
+    // chama sync() e reage ao onChange.
+    get(key, fallback = null) {
+        const prefs = loadLocal();
+        return key in prefs ? prefs[key] : fallback;
+    },
+
+    getAll() {
+        return loadLocal();
+    },
+
+    // Escrita otimista: grava local e devolve na hora; a nuvem confirma depois.
+    // Devolve { saved, synced } pra quem quiser avisar o usuário que ficou só
+    // local (ex: sem e-mail capturado ainda).
+    async set(key, value) {
+        const prefs = loadLocal();
+        prefs[key] = value;
+        saveLocal(prefs);
+        notify(key, value);
+
+        const userEmail = getAgentEmail();
+        if (!userEmail) return { saved: true, synced: false };
+
+        isMutating = true;
+        let synced = false;
+        try {
+            synced = await DataService.saveUserPrefs(prefs, userEmail);
+        } catch (e) {
+            console.warn("Falha ao salvar preferências na nuvem:", e);
+        } finally {
+            // Mesma folga de 2s da Biblioteca: dá tempo da planilha refletir a
+            // escrita antes de uma leitura de fundo poder sobrescrever o local.
+            setTimeout(() => { isMutating = false; }, 2000);
+        }
+        return { saved: true, synced };
+    },
+
+    // Busca o blob da nuvem e adota o que vier, exceto se houver escrita em voo.
+    // Chamada uma vez no boot; deduplicada porque vários módulos a pedem.
+    sync() {
+        if (syncPromise) return syncPromise;
+
+        syncPromise = (async () => {
+            const userEmail = getAgentEmail();
+            if (!userEmail) return loadLocal();
+
+            try {
+                const remote = await DataService.getUserPrefs(userEmail);
+                if (remote && typeof remote === "object" && !isMutating) {
+                    const local = loadLocal();
+                    if (JSON.stringify(remote) !== JSON.stringify(local)) {
+                        saveLocal(remote);
+                        Object.keys(remote).forEach((k) => notify(k, remote[k]));
+                    }
+                }
+            } catch (e) {
+                console.warn("Preferências indisponíveis; seguindo com o cache local.", e);
+            } finally {
+                // Uma nova chamada depois desta pode querer buscar de novo (ex:
+                // o e-mail do agente só ficou disponível agora).
+                syncPromise = null;
+            }
+            return loadLocal();
+        })();
+
+        return syncPromise;
+    },
+
+    onChange(key, callback) {
+        const set = listeners.get(key) || new Set();
+        set.add(callback);
+        listeners.set(key, set);
+        return () => set.delete(callback);
+    },
+};
+
+const listeners = new Map();
+
+function notify(key, value) {
+    const set = listeners.get(key);
+    if (!set) return;
+    set.forEach((fn) => {
+        try { fn(value); } catch (e) { console.warn("Listener de preferências falhou:", e); }
+    });
+}


### PR DESCRIPTION
## O problema

O Ctrl+K oferecia dois atalhos de nota iguais para todo mundo, definidos por um campo `quickLaunch` embutido em dois cenários de `notes-data.js`. O agente não escolhia os dele.

Investigando, apareceu um segundo problema, mais sério e ainda invisível: **os dois atalhos de hoje sumiriam do Ctrl+K no dia em que a Central de Conteúdo publicasse os modelos de nota.** `applyNoteTemplateContent()` apaga `scenarioSnippets` inteiro e o repovoa com ids derivados (`cw-<substatus>-<slug>`), sem carregar o campo `quickLaunch` — o `filter(([, d]) => d.quickLaunch)` do palette passaria a devolver zero, sem erro, sem log. Ninguém ligaria o desaparecimento à publicação do conteúdo.

## A solução

Os atalhos deixam de ser propriedade do catálogo de cenários e viram **dado do agente**, com entidade própria e persistência por pessoa.

- **Criar**: dois caminhos. O botão **"Salvar como atalho"** no Case Notes captura a combinação que o agente já montou na tela (tipo de caso + status + substatus + cenários marcados); e o construtor em **Configurações → Meus Atalhos** monta do zero. Os dois usam a mesma fonte de "quais cenários valem neste substatus" (`getScenariosFor()`), então não existe como configurar um atalho que a tela do Case Notes não produziria.
- **Gerenciar**: lista em Configurações com renomear, apelido de busca, reordenar (arrastando ou pelas setas, com o punho focável) e excluir. Teto de 8.
- **Usar**: o palette agrupa "Meus atalhos" acima de "Módulos" e, por padrão, ordena por frequência de uso (desligável, e aí vale a ordem manual). O apelido entra na busca.
- **Guardar**: aba nova `User_Prefs` (uma linha por agente, blob JSON) com as ops `get_user_prefs`/`save_user_prefs` — cache-first, mesmo padrão da Biblioteca Pessoal, para a configuração seguir a pessoa entre máquinas.

Quem nunca configurou nada continua recebendo os dois atalhos de sempre — agora editáveis e apagáveis.

Decisão estrutural registrada em `docs/decisions/0002-atalhos-ctrl-k-por-agente.md`. **Presets de time ficaram deliberadamente fora**, por decisão do dono do produto.

## Correções que vieram junto

- O atalho referencia o cenário com **resolução tolerante** (id exato → slug dentro do mesmo substatus), então sobrevive à troca embutido ↔ publicado nos dois sentidos.
- Cenário que não existe mais: antes o `chip.click()` simplesmente não acontecia e a nota abria pela metade em silêncio. Agora o agente é avisado e o atalho aparece marcado como quebrado em Configurações.
- Cenários publicados pela Central apareciam nos chips com o id cru (`cw in_not_reachable in no show bau`); passam pelo `scenarioLabel()` compartilhado.
- A lista de Configurações era montada no boot e não via um atalho criado depois no Case Notes (**achado pelo smoke**).
- O campo pendente deixa de vir de uma lista `focusIds` escrita à mão por atalho e é derivado da tela — nunca aponta para um campo que aquele substatus não tem.

## Como foi verificado

Três camadas, cada uma para um risco que as outras não pegam:

| Suíte | Casos | O que prova |
| --- | --- | --- |
| `npm run test:shortcuts` | 16 | Resolução do cenário nos dois mundos (inclusive simulando a reescrita da Central), limite, edição, reordenação, blob corrompido |
| `npm run test:prefs` | 12 | As ops novas contra planilha stubada: uma linha por agente, sem vazamento entre pessoas, payload inválido recusado na escrita, linha corrompida degradando para `{}` |
| `npm run smoke:shortcuts` | 10 | Playwright sobre o `mock-crm.html`: Ctrl+K → atalho → nota montada com o cenário aplicado e o cursor no SE ID; captura; Configurações |

O smoke existe porque a parte cara é temporal (genie, troca de `<select>`, rebuild do formulário, clique nos chips): se a ordem quebrar, os testes de unidade seguem verdes com a nota abrindo vazia.

Suítes existentes sem regressão: `test:note-templates` (27→26), `test:content` (55), `test:call-script` (71), `test:emails` (8).

## Behavior diff

| | Antes | Depois |
| --- | --- | --- |
| Quais atalhos | 2, fixos, iguais para todos | Até 8, escolhidos por cada agente |
| Cenários por atalho | Exatamente 1 | 0 a N |
| Onde configura | Só mexendo em código | Case Notes ou Configurações |
| Ao publicar na Central | Atalhos somem sem aviso | Continuam funcionando |
| Cenário removido | Nota abre pela metade, em silêncio | Avisa e marca o atalho |
| Troca de máquina | (não havia o que perder) | Atalhos acompanham a pessoa |

## Depois do merge

O push em `refactor-structure` já leva o backend ao deployment de **dev** pela CI, e a aba `User_Prefs` nasce sozinha no primeiro uso — nada a preparar na planilha. Para **produção**, falta o `clasp deploy` manual de sempre (`RELEASE.md`); até lá, em produção os atalhos funcionam mas ficam só no navegador de cada pessoa, que é o fallback previsto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)