### PR TITLE
fix(shortcuts): seis defeitos da revisão + alinhar a seção ao padrão visual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ versions follow [Semantic Versioning](https://semver.org/).
   módulos agora seguem o idioma único da sessão, trocado em Configurações.
 
 ### Fixed
+- **Atalhos: seis defeitos achados na revisão do próprio código.** Dois cliques
+  no "Salvar" criavam dois atalhos idênticos (o id só nascia na escrita; agora
+  é carimbado ao abrir o editor, e o botão fica desabilitado com estado
+  "Salvando…" enquanto o JSONP não responde). O apelido do agente era
+  interpolado num `innerHTML` — um `<` quebrava a linha e uma tag **executava**;
+  agora nome e apelido entram só por `textContent`. A lista de Configurações
+  mostrava sempre a ordem manual, contradizendo o Ctrl+K no modo padrão
+  (ordenado por uso). Uma preferência salva sem rede era descartada em silêncio
+  pela sincronia seguinte (portado o `_pendingSync` da Biblioteca Pessoal). A
+  seta ↓ no último item perdia o foco do teclado. Soltar o mouse fora do punho
+  deixava o item arrastável pelo corpo inteiro.
+- **Atalhos: a seção destoava do padrão visual do app** — sem
+  `prefers-reduced-motion` (que o próprio `configs-assistant.js` já respeita),
+  com foco de teclado visível só no punho de arrastar, transições com `ease` cru
+  em vez dos tokens `--cw-ease-*`, e chips de cenário com forma diferente da que
+  o Case Notes usa para os mesmos objetos.
 - **Os atalhos de nota do Ctrl+K sumiriam sem aviso quando a Central de Conteúdo
   publicasse os modelos de nota.** `applyNoteTemplateContent()` reescreve
   `scenarioSnippets` inteiro com ids derivados e sem o campo `quickLaunch`, do

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -12,6 +12,27 @@ Include the minimal code snippet / command when it is the fix.
 
 ---
 
+## Texto escrito pelo agente entra no DOM por `textContent`, nunca por `innerHTML`
+
+**Why**: na revisão dos atalhos do Ctrl+K (2026-08-20), o **nome** do atalho
+estava correto (`textContent`) mas o **apelido de busca** era interpolado num
+template de `innerHTML`, junto com o resto da linha de metadados. Um apelido com
+`<` já quebrava a exibição, e um apelido com `<img src=x onerror=...>`
+**executava** — provado revertendo a correção e vendo o smoke acusar "o HTML do
+apelido foi executado". É self-XSS (dado do próprio agente), mas o blob de
+preferências passa pela planilha e volta, e o custo de errar isso é zero-benefício.
+
+O padrão que evita a classe inteira: montar a linha com `document.createElement`
++ `textContent` para as partes que vêm da pessoa, e reservar `innerHTML` para
+markup **nosso** (ícones, estrutura). Quando os dois se misturam numa string, é
+questão de tempo até um campo novo entrar na parte errada.
+
+**When to apply**: em qualquer render que interpole valor digitado pelo agente —
+atalhos, snippets da Biblioteca, nomes de rascunho, campos do BAU Form. Vale
+também para `title=`/`aria-label=` dentro de template string, e para o
+`promptDialog()` de `utils.js`, que hoje injeta o `defaultValue` num
+`value="${...}"`.
+
 ## Não pendure dado novo dentro de uma estrutura que a Central de Conteúdo reescreve
 
 **Why**: os atalhos do Ctrl+K nasceram como um campo `quickLaunch` dentro de dois

--- a/scripts/smoke-shortcuts.mjs
+++ b/scripts/smoke-shortcuts.mjs
@@ -205,6 +205,67 @@ await check('Configurações lista os atalhos e permite excluir um', async () =>
     if (depois !== 2) throw new Error(`esperava 2 depois de excluir, veio ${depois}`);
 });
 
+await check('apelido com HTML aparece como texto, não é interpretado', async () => {
+    // O nome e o apelido são texto do agente. Antes o apelido era interpolado
+    // num innerHTML: um "<" quebrava a linha e uma tag executava.
+    await page.evaluate(() => {
+        const prefs = JSON.parse(localStorage.getItem('cw_user_prefs_v1') || '{}');
+        prefs.shortcuts = [{
+            id: 'sc_xss', kind: 'note', label: 'Teste', order: 0,
+            alias: '<img src=x onerror="window.__executou=true">',
+            payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [] },
+        }];
+        localStorage.setItem('cw_user_prefs_v1', JSON.stringify(prefs));
+        window.__executou = false;
+    });
+
+    // Reabre Configurações para a seção se redesenhar com o dado plantado.
+    await abrirPalette('configuracoes');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(700);
+    await abrirPalette('configuracoes');
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('.cw-sc-item', { timeout: 10000 });
+    await page.waitForTimeout(700);
+
+    const executou = await page.evaluate(() => window.__executou === true);
+    if (executou) throw new Error('o HTML do apelido foi executado');
+
+    const imgs = await page.locator('.cw-sc-meta img').count();
+    if (imgs) throw new Error('o apelido virou elemento no DOM');
+
+    const texto = await page.locator('.cw-sc-meta').first().textContent();
+    if (!texto.includes('<img')) throw new Error('o apelido não apareceu como texto: ' + texto);
+});
+
+await check('a lista de Configurações segue a mesma ordem do Ctrl+K', async () => {
+    await page.evaluate(() => {
+        const prefs = JSON.parse(localStorage.getItem('cw_user_prefs_v1') || '{}');
+        prefs.shortcuts = [
+            { id: 'sc_a', kind: 'note', label: 'Alpha', alias: '', order: 0, payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [] } },
+            { id: 'sc_b', kind: 'note', label: 'Beta', alias: '', order: 1, payload: { caseType: 'bau', status: 'IN', subStatus: 'IN_Not_Reachable', scenarios: [] } },
+        ];
+        prefs.shortcutsSortByUsage = true;
+        localStorage.setItem('cw_user_prefs_v1', JSON.stringify(prefs));
+        // Beta usado duas vezes: no modo padrão ele tem que vir primeiro nos DOIS lugares.
+        localStorage.setItem('cw_shortcut_usage_v1', JSON.stringify({ sc_b: 2 }));
+    });
+
+    await abrirPalette();
+    const noPalette = (await page.locator('.cw-palette-item .cw-palette-item-label').allTextContents()).slice(0, 2);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(400);
+
+    await abrirPalette('configuracoes');
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('.cw-sc-item', { timeout: 10000 });
+    await page.waitForTimeout(700);
+    const emConfigs = await page.locator('.cw-sc-item .cw-sc-label').allTextContents();
+
+    if (noPalette[0] !== 'Beta') throw new Error('o palette não ordenou por uso: ' + JSON.stringify(noPalette));
+    if (emConfigs[0] !== 'Beta') throw new Error('Configurações mostrou outra ordem: ' + JSON.stringify(emConfigs));
+});
+
 await check('o construtor de Configurações só oferece cenários do substatus escolhido', async () => {
     // O popup ainda está terminando o voo do genie; clicar no meio da animação
     // é instável (o alvo se move debaixo do ponteiro).

--- a/scripts/test-shortcuts.mjs
+++ b/scripts/test-shortcuts.mjs
@@ -49,7 +49,43 @@ async function carregar() {
 }
 
 const sc = await carregar();
-const { ShortcutService, resolveScenarioId, shortcutIssues, MAX_SHORTCUTS } = sc;
+const { ShortcutService, resolveScenarioId, shortcutIssues, MAX_SHORTCUTS, newShortcutId } = sc;
+
+// Para exercitar a sincronia é preciso controlar a nuvem e a identidade. Em vez
+// de arquivos de stub, o próprio bundle troca os dois módulos por implementações
+// falsas - assim o teste continua num arquivo só.
+async function carregarPrefsComNuvemFalsa() {
+    const stubs = {
+        name: 'stubs',
+        setup(build) {
+            build.onLoad({ filter: /data-service\.js$/ }, () => ({
+                contents: `export const DataService = {
+                    saveUserPrefs: (prefs, user) => globalThis.__nuvem.salvar(prefs, user),
+                    getUserPrefs: (user) => globalThis.__nuvem.ler(user),
+                };`,
+                loader: 'js',
+            }));
+            build.onLoad({ filter: /page-data\.js$/ }, () => ({
+                contents: `export const getAgentEmail = () => globalThis.__email;`,
+                loader: 'js',
+            }));
+        },
+    };
+
+    const bundle = await build({
+        entryPoints: [resolve(here, '../src/modules/shared/user-prefs-service.js')],
+        bundle: true,
+        write: false,
+        format: 'cjs',
+        platform: 'node',
+        logLevel: 'silent',
+        plugins: [stubs],
+    });
+    const mod = { exports: {} };
+    // eslint-disable-next-line no-new-func
+    new Function('module', 'exports', 'require', bundle.outputFiles[0].text)(mod, mod.exports, require);
+    return mod.exports.UserPrefsService;
+}
 
 let fail = 0;
 function check(name, fn) {
@@ -248,6 +284,23 @@ await checkAsync('ordenar por uso põe o mais usado na frente sem perder ningué
     if (manual[0].id !== lista[0].id) throw new Error('desligar a ordenação por uso não voltou à ordem manual');
 });
 
+await checkAsync('dois cliques no "Salvar" não criam dois atalhos iguais', async () => {
+    // O editor carimba o id ao abrir justamente por isto: a escrita passa por
+    // JSONP e pode demorar, então o segundo clique chega antes do primeiro
+    // terminar. Sem o id fixo, cada chamada gerava um novo e o agente ficava
+    // com duas cópias.
+    limparPrefs();
+    const antes = ShortcutService.listRaw().length;
+    const rascunho = { ...novoAtalho('Clique duplo'), id: newShortcutId() };
+
+    await Promise.all([ShortcutService.save(rascunho), ShortcutService.save(rascunho)]);
+
+    const lista = ShortcutService.listRaw();
+    const iguais = lista.filter((s) => s.label === 'Clique duplo');
+    if (iguais.length !== 1) throw new Error(`ficaram ${iguais.length} cópias`);
+    if (lista.length !== antes + 1) throw new Error(`a lista foi de ${antes} para ${lista.length}`);
+});
+
 check('dado corrompido nas preferências não derruba a lista', () => {
     // Um blob inválido é plausível: vem da nuvem, de outra versão do app.
     store['cw_user_prefs_v1'] = JSON.stringify({ shortcuts: [null, { id: 'x' }, 'lixo'] });
@@ -256,7 +309,69 @@ check('dado corrompido nas preferências não derruba a lista', () => {
     if (lista.length !== 0) throw new Error(`esperava descartar tudo que é inválido, sobrou ${lista.length}`);
 });
 
+// ----------------------------------------------------------------
+//  Sincronia com a nuvem (o caso que some sem avisar)
+// ----------------------------------------------------------------
+console.log('\n--- Preferências: escrita pendente ---');
+
+const Prefs = await carregarPrefsComNuvemFalsa();
+globalThis.__email = 'ana@google.com';
+
+await checkAsync('o que foi salvo sem rede NÃO é descartado pela sincronia seguinte', async () => {
+    limparPrefs();
+    delete store['cw_user_prefs_pending_v1'];
+
+    // A nuvem tem um estado antigo; a escrita local falha (rede fora).
+    globalThis.__nuvem = {
+        salvar: async () => false,
+        ler: async () => ({ shortcuts: [{ id: 'antigo', payload: { subStatus: 'IN_Not_Reachable' } }] }),
+    };
+
+    const r = await Prefs.set('shortcuts', [{ id: 'novo', payload: { subStatus: 'IN_Not_Reachable' } }]);
+    if (r.synced) throw new Error('o teste não simulou a falha');
+
+    // Sessão seguinte: sem a marca de pendente, o sync adotaria a nuvem e o
+    // atalho recém-criado sumiria sem o agente jamais saber.
+    await Prefs.sync();
+
+    const depois = Prefs.get('shortcuts', []);
+    if (!depois.some((s) => s.id === 'novo')) throw new Error('o atalho salvo offline foi descartado');
+});
+
+await checkAsync('quando a rede volta, a pendência é empurrada e a marca some', async () => {
+    let enviado = null;
+    globalThis.__nuvem = {
+        salvar: async (prefs) => { enviado = prefs; return true; },
+        ler: async () => ({ shortcuts: [] }),
+    };
+
+    await Prefs.sync();
+
+    if (!enviado) throw new Error('a pendência não foi reenviada');
+    if (!enviado.shortcuts.some((s) => s.id === 'novo')) throw new Error('reenviou o conteúdo errado');
+    if (store['cw_user_prefs_pending_v1']) throw new Error('a marca de pendente ficou de pé');
+});
+
+await checkAsync('sem pendência, a nuvem continua sendo a verdade', async () => {
+    // Espera o cadeado de 2s que o serviço mantém depois de cada escrita (ele
+    // existe pra planilha ter tempo de refletir o save antes de uma leitura de
+    // fundo poder sobrescrever o local). Sem esperar, este teste mediria o
+    // cadeado, não a adoção da nuvem.
+    await new Promise((r) => setTimeout(r, 2100));
+
+    globalThis.__nuvem = {
+        salvar: async () => true,
+        ler: async () => ({ shortcuts: [{ id: 'da-nuvem', payload: { subStatus: 'IN_Not_Reachable' } }] }),
+    };
+
+    await Prefs.sync();
+
+    const depois = Prefs.get('shortcuts', []);
+    if (!depois.some((s) => s.id === 'da-nuvem')) throw new Error('o local não adotou a nuvem');
+});
+
 limparPrefs();
+delete store['cw_user_prefs_pending_v1'];
 
 console.log('\n' + (fail ? '✗' : '✓') + ` atalhos: ${fail} falhas\n`);
 process.exit(fail ? 1 : 0);

--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -52,6 +52,7 @@ const CONFIGS_DICT = {
         scNoScenarios: "Nenhum cenário disponível para esta combinação.",
         scCancel: "Cancelar",
         scSave: "Salvar",
+        scSaving: "Salvando…",
         scSaved: "Atalho salvo!",
         scSavedLocal: "Atalho salvo neste navegador (sem conexão com a nuvem).",
     },
@@ -96,6 +97,7 @@ const CONFIGS_DICT = {
         scNoScenarios: "Ningún escenario disponible para esta combinación.",
         scCancel: "Cancelar",
         scSave: "Guardar",
+        scSaving: "Guardando…",
         scSaved: "¡Atajo guardado!",
         scSavedLocal: "Atajo guardado en este navegador (sin conexión con la nube).",
     },
@@ -114,6 +116,11 @@ export function initConfigsAssistant() {
         text: "#202124",
         textSub: "#5F6368",
         border: "#DADCE0",
+        // Alerta suave, no tom que o design system pede para fluxo secundário:
+        // chama atenção sem parecer erro de sistema (ver specs/ui-ux).
+        warnBorder: "#F9AB00",
+        warnBg: "#FFFBF0",
+        warnText: "#B06000",
     };
 
     const styleId = "cw-configs-styles";

--- a/src/modules/configs/shortcuts-section.js
+++ b/src/modules/configs/shortcuts-section.js
@@ -10,7 +10,7 @@
 
 import { SoundManager } from "../shared/sound-manager.js";
 import { confirmDialog, showToast } from "../shared/utils.js";
-import { ShortcutService, MAX_SHORTCUTS, shortcutIssues } from "../shared/shortcut-service.js";
+import { ShortcutService, MAX_SHORTCUTS, shortcutIssues, newShortcutId } from "../shared/shortcut-service.js";
 import {
     SUBSTATUS_TEMPLATES,
     getScenariosFor,
@@ -30,13 +30,15 @@ function injectStyles(COLORS) {
         .cw-sc-item {
             display: flex; align-items: center; gap: 10px; padding: 10px 12px;
             border: 1px solid ${COLORS.border}; border-radius: 10px; background: #fff;
-            transition: border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+            transition: border-color 0.2s var(--cw-ease-standard),
+                        box-shadow 0.2s var(--cw-ease-standard),
+                        opacity 0.2s var(--cw-ease-standard);
         }
         .cw-sc-item + .cw-sc-item { margin-top: 8px; }
         .cw-sc-item:hover { border-color: #bdc1c6; }
         .cw-sc-item.dragging { opacity: 0.4; }
         .cw-sc-item.drop-target { border-color: ${COLORS.primary}; box-shadow: 0 0 0 2px rgba(26,115,232,0.15); }
-        .cw-sc-item.broken { border-color: #f9ab00; background: #fffbf0; }
+        .cw-sc-item.broken { border-color: ${COLORS.warnBorder}; background: ${COLORS.warnBg}; }
         .cw-sc-grip {
             color: #9aa0a6; cursor: grab; display: flex; background: none; border: none;
             padding: 2px; border-radius: 4px;
@@ -52,12 +54,15 @@ function injectStyles(COLORS) {
             font-size: 13px; font-weight: 600; color: ${COLORS.text};
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
-        .cw-sc-meta { font-size: 11px; color: ${COLORS.textSub}; margin-top: 2px; }
-        .cw-sc-warn { color: #b06000; font-weight: 600; }
+        .cw-sc-meta {
+            font-size: 11px; color: ${COLORS.textSub}; margin-top: 2px;
+            white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+        }
+        .cw-sc-warn { color: ${COLORS.warnText}; font-weight: 600; }
         .cw-sc-iconbtn {
             width: 28px; height: 28px; border-radius: 8px; border: none; background: transparent;
             color: ${COLORS.textSub}; cursor: pointer; display: flex; align-items: center;
-            justify-content: center; transition: background 0.15s ease, color 0.15s ease;
+            justify-content: center; transition: background 0.15s var(--cw-ease-standard), color 0.15s var(--cw-ease-standard);
         }
         .cw-sc-iconbtn:hover { background: #f1f3f4; color: ${COLORS.text}; }
         .cw-sc-iconbtn.danger:hover { background: #fce8e6; color: #d93025; }
@@ -69,7 +74,7 @@ function injectStyles(COLORS) {
             margin-top: 10px; width: 100%; padding: 10px; border-radius: 10px;
             border: 1px dashed ${COLORS.border}; background: transparent; cursor: pointer;
             font-family: inherit; font-weight: 600; font-size: 12px; color: ${COLORS.textSub};
-            transition: all 0.2s ease;
+            transition: all 0.2s var(--cw-ease-standard);
         }
         .cw-sc-add:hover:not(:disabled) { border-color: ${COLORS.primary}; color: ${COLORS.primary}; }
         .cw-sc-add:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -81,12 +86,15 @@ function injectStyles(COLORS) {
         }
         .cw-sc-field input:focus, .cw-sc-field select:focus { border-color: ${COLORS.primary}; }
         .cw-sc-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+        /* Mesma forma dos chips de cenário do Case Notes (step-scenarios.js):
+           é o mesmo objeto aparecendo em duas telas. */
         .cw-sc-chip {
-            padding: 6px 10px; border-radius: 14px; border: 1px solid ${COLORS.border};
-            background: #fff; font-size: 12px; color: ${COLORS.text}; cursor: pointer;
-            font-family: inherit; transition: all 0.15s ease;
+            padding: 6px 12px; border-radius: 16px; border: 1px solid #dadce0;
+            background: #ffffff; font-size: 13px; color: #3c4043; cursor: pointer;
+            font-family: inherit; transition: all 0.2s var(--cw-ease-elastic);
         }
-        .cw-sc-chip.on { background: #e8f0fe; border-color: ${COLORS.primary}; color: #1967d2; font-weight: 600; }
+        .cw-sc-chip:hover:not(.on) { background: #f1f3f4; }
+        .cw-sc-chip.on { background: #e8f0fe; border-color: #1a73e8; color: #1967d2; font-weight: 600; }
         .cw-sc-editor-actions { display: flex; gap: 8px; }
         .cw-sc-editor-actions button {
             flex: 1; padding: 10px; border-radius: 10px; font-family: inherit;
@@ -94,6 +102,28 @@ function injectStyles(COLORS) {
         }
         .cw-sc-cancel { border: 1px solid ${COLORS.border}; background: #fff; color: ${COLORS.textSub}; }
         .cw-sc-save { border: none; background: ${COLORS.primary}; color: #fff; }
+        .cw-sc-save:disabled { opacity: 0.6; cursor: progress; }
+
+        /* Foco de teclado visível em TODO controle da seção - antes só o punho
+           de arrastar tinha, e quem navega por Tab ficava sem saber onde está. */
+        .cw-sc-iconbtn:focus-visible,
+        .cw-sc-chip:focus-visible,
+        .cw-sc-add:focus-visible,
+        .cw-sc-editor-actions button:focus-visible,
+        .cw-sc-field input:focus-visible,
+        .cw-sc-field select:focus-visible {
+            outline: 2px solid ${COLORS.primary};
+            outline-offset: 1px;
+        }
+
+        /* Mesma cortesia que o resto do app já faz (configs-assistant.js,
+           animations.js, step-scenarios.js): quem pediu menos movimento não
+           deve receber transição nenhuma daqui. */
+        @media (prefers-reduced-motion: reduce) {
+            .cw-sc-item, .cw-sc-iconbtn, .cw-sc-add, .cw-sc-chip {
+                transition: none !important;
+            }
+        }
     `;
     document.head.appendChild(style);
 }
@@ -146,12 +176,31 @@ export function createShortcutsSection(t, COLORS) {
         return partes.join(" · ");
     }
 
+    // O nome e o apelido são texto do agente: entram por textContent, nunca por
+    // innerHTML. Antes o apelido era interpolado num template de innerHTML - um
+    // "<" quebrava a linha e uma tag executava.
+    function preencherMeta(el, shortcut, quebrado) {
+        el.textContent = "";
+        if (quebrado) {
+            const aviso = document.createElement("span");
+            aviso.className = "cw-sc-warn";
+            aviso.textContent = t("scBroken");
+            el.appendChild(aviso);
+            el.appendChild(document.createTextNode(" · "));
+        }
+        el.appendChild(document.createTextNode(meta(shortcut)));
+    }
+
     function renderList() {
         body.innerHTML = "";
         sortToggle.checked = ShortcutService.isSortedByUsage();
 
-        const lista = ShortcutService.listRaw();
-        const podeArrastar = !ShortcutService.isSortedByUsage();
+        // Mostra a MESMA ordem que o Ctrl+K vai mostrar. Listar sempre a ordem
+        // manual fazia a tela de gerenciamento contradizer o palette justamente
+        // no modo padrão (ordenado por uso).
+        const porUso = ShortcutService.isSortedByUsage();
+        const lista = porUso ? ShortcutService.list() : ShortcutService.listRaw();
+        const podeArrastar = !porUso;
 
         if (!lista.length) {
             const vazio = document.createElement("div");
@@ -177,15 +226,15 @@ export function createShortcutsSection(t, COLORS) {
                 <button type="button" class="cw-sc-iconbtn js-sc-edit" aria-label="${t('scEdit')}">${PENCIL}</button>
                 <button type="button" class="cw-sc-iconbtn danger js-sc-del" aria-label="${t('scDelete')}">${TRASH}</button>
             `;
-            item.querySelector(".cw-sc-label").textContent = shortcut.label;
-            item.querySelector(".cw-sc-meta").innerHTML = quebrados.length
-                ? `<span class="cw-sc-warn">${t("scBroken")}</span> · ${meta(shortcut)}`
-                : meta(shortcut);
+            const labelEl = item.querySelector(".cw-sc-label");
+            labelEl.textContent = shortcut.label;
+            labelEl.title = shortcut.label; // nome longo é truncado com ellipsis
+            preencherMeta(item.querySelector(".cw-sc-meta"), shortcut, quebrados.length > 0);
 
             item.querySelector(".js-sc-edit").onclick = () => renderEditor(shortcut);
             item.querySelector(".js-sc-del").onclick = () => remover(shortcut);
 
-            if (podeArrastar) wireDrag(item, idx);
+            if (podeArrastar) wireDrag(item, idx, lista.length);
             body.appendChild(item);
         });
 
@@ -209,33 +258,49 @@ export function createShortcutsSection(t, COLORS) {
 
     // Arrastar para reordenar. O punho também aceita teclado (setas): arrastar
     // é a única forma óbvia com mouse, mas não pode ser a única forma possível.
-    function wireDrag(item, idx) {
+    function wireDrag(item, idx, total) {
         const grip = item.querySelector(".cw-sc-grip");
-        item.draggable = false;
 
-        grip.onmousedown = () => { item.draggable = true; };
-        grip.onmouseup = () => { item.draggable = false; };
+        // O item fica sempre `draggable` e o arrasto é CANCELADO quando não
+        // começou no punho. Alternar o atributo no mousedown/mouseup do punho
+        // deixava o item arrastável pelo corpo inteiro sempre que o mouse era
+        // solto fora dele.
+        item.draggable = true;
+        let veioDoPunho = false;
+        grip.onmousedown = () => { veioDoPunho = true; };
+        item.onmouseup = () => { veioDoPunho = false; };
 
         grip.onkeydown = async (e) => {
             const delta = e.key === "ArrowUp" ? -1 : e.key === "ArrowDown" ? 1 : 0;
             if (!delta) return;
             e.preventDefault();
-            await ShortcutService.reorder(item.dataset.id, idx + delta);
+
+            const destino = idx + delta;
+            if (destino < 0 || destino >= total) return; // já está na ponta
+
+            await ShortcutService.reorder(item.dataset.id, destino);
             SoundManager.playClick();
             renderList();
-            // Devolve o foco ao mesmo punho, agora na nova posição.
-            const alvo = body.querySelector(`.cw-sc-item[data-index="${Math.max(0, idx + delta)}"] .cw-sc-grip`);
+
+            // Reencontra o punho pelo ID, não pela posição: com a lista
+            // reordenada, procurar pelo índice antigo devolvia null e o foco
+            // do teclado se perdia.
+            const alvo = body.querySelector(`.cw-sc-item[data-id="${item.dataset.id}"] .cw-sc-grip`);
             if (alvo) alvo.focus();
         };
 
         item.ondragstart = (e) => {
+            if (!veioDoPunho) {
+                e.preventDefault();
+                return;
+            }
             e.dataTransfer.effectAllowed = "move";
             e.dataTransfer.setData("text/plain", item.dataset.id);
             item.classList.add("dragging");
         };
         item.ondragend = () => {
             item.classList.remove("dragging");
-            item.draggable = false;
+            veioDoPunho = false;
             body.querySelectorAll(".drop-target").forEach((el) => el.classList.remove("drop-target"));
         };
         item.ondragover = (e) => {
@@ -271,6 +336,9 @@ export function createShortcutsSection(t, COLORS) {
         const estado = editando
             ? JSON.parse(JSON.stringify(shortcut))
             : {
+                // Id já aqui, não no primeiro save: assim dois cliques no botão
+                // atualizam o mesmo atalho em vez de criar dois iguais.
+                id: newShortcutId(),
                 kind: "note",
                 label: "",
                 alias: "",
@@ -402,12 +470,22 @@ export function createShortcutsSection(t, COLORS) {
             renderList();
         };
 
-        form.querySelector(".cw-sc-save").onclick = async () => {
+        const btnSalvar = form.querySelector(".cw-sc-save");
+        btnSalvar.onclick = async () => {
             if (!sub.value) {
                 SoundManager.playError();
                 showToast(t("scPickSubStatus"), { error: true });
                 return;
             }
+
+            // A escrita passa por JSONP e pode levar até os 15s do watchdog. Sem
+            // desabilitar, o botão aceita cliques repetidos e o agente fica sem
+            // saber se algo está acontecendo (dom-standards.md: toda chamada à
+            // API precisa de estado visual de loading).
+            const textoOriginal = btnSalvar.textContent;
+            btnSalvar.disabled = true;
+            btnSalvar.textContent = t("scSaving");
+
             const rotulo = nome.value.trim() || SUBSTATUS_TEMPLATES[sub.value].name;
             const resultado = await ShortcutService.save({
                 ...estado,
@@ -422,13 +500,15 @@ export function createShortcutsSection(t, COLORS) {
             });
 
             if (!resultado.ok) {
+                btnSalvar.disabled = false;
+                btnSalvar.textContent = textoOriginal;
                 SoundManager.playError();
                 showToast(t("scLimit").replace("{max}", MAX_SHORTCUTS), { error: true });
                 return;
             }
             SoundManager.playSuccess();
             showToast(resultado.synced ? t("scSaved") : t("scSavedLocal"));
-            renderList();
+            renderList(); // troca o editor pela lista: o botão sai do DOM junto
         };
     }
 

--- a/src/modules/notes/notes-assistant.js
+++ b/src/modules/notes/notes-assistant.js
@@ -17,7 +17,7 @@ import { SoundManager } from "../shared/sound-manager.js";
 import { enableFilledCheck, lockBodyScroll, unlockBodyScroll, markPendingField } from "../shared/dom-utils.js";
 import { getPageData } from "../shared/page-data.js";
 import { getLanguage, onLanguageChange } from "../shared/i18n.js";
-import { ShortcutService, resolveScenarioId, MAX_SHORTCUTS } from "../shared/shortcut-service.js";
+import { ShortcutService, resolveScenarioId, MAX_SHORTCUTS, newShortcutId } from "../shared/shortcut-service.js";
 import {
     SUBSTATUS_TEMPLATES,
     SUBSTATUS_SHORTCODES,
@@ -1070,15 +1070,28 @@ export function initCaseNotesAssistant() {
         const nome = await promptDialog(t('atalho_nome_pergunta'), sugestao);
         if (nome === null) return;
 
-        const resultado = await ShortcutService.save({ ...capturado, label: String(nome).trim() || sugestao });
-        if (!resultado.ok) {
-            SoundManager.playError();
-            showToast(t('atalho_limite').replace('{max}', MAX_SHORTCUTS), { error: true });
-            return;
-        }
+        // A escrita passa por JSONP (até 15s de watchdog): sem desabilitar, um
+        // segundo clique dispara outro save e cria um atalho duplicado.
+        saveShortcutBtn.disabled = true;
+        saveShortcutBtn.style.opacity = '0.6';
+        try {
+            const resultado = await ShortcutService.save({
+                ...capturado,
+                id: newShortcutId(),
+                label: String(nome).trim() || sugestao
+            });
+            if (!resultado.ok) {
+                SoundManager.playError();
+                showToast(t('atalho_limite').replace('{max}', MAX_SHORTCUTS), { error: true });
+                return;
+            }
 
-        SoundManager.playSuccess();
-        showToast(resultado.synced ? t('atalho_salvo') : t('atalho_salvo_local'));
+            SoundManager.playSuccess();
+            showToast(resultado.synced ? t('atalho_salvo') : t('atalho_salvo_local'));
+        } finally {
+            saveShortcutBtn.disabled = false;
+            saveShortcutBtn.style.opacity = '';
+        }
     }
 
     // O estado atual da tela, no formato que o atalho guarda. É o que o botão

--- a/src/modules/shared/shortcut-service.js
+++ b/src/modules/shared/shortcut-service.js
@@ -56,7 +56,10 @@ const DEFAULT_SHORTCUTS = [
     },
 ];
 
-function newId() {
+// Exportado porque quem abre um editor precisa carimbar o id ANTES do primeiro
+// save: sem isso, dois cliques no botão "Salvar" (o JSONP pode demorar até os
+// 15s do watchdog) geram dois ids e o agente termina com dois atalhos iguais.
+export function newShortcutId() {
     return "sc_" + Date.now().toString(36) + Math.floor(Math.random() * 1000).toString(36);
 }
 
@@ -164,7 +167,7 @@ export const ShortcutService = {
             return { ok: false, reason: "limit" };
         }
 
-        const entry = normalize([{ ...shortcut, id: shortcut.id || newId() }])[0];
+        const entry = normalize([{ ...shortcut, id: shortcut.id || newShortcutId() }])[0];
         if (!entry) return { ok: false, reason: "invalid" };
 
         if (idx === -1) {

--- a/src/modules/shared/user-prefs-service.js
+++ b/src/modules/shared/user-prefs-service.js
@@ -15,6 +15,11 @@ import { DataService } from "./data-service.js";
 import { getAgentEmail } from "./page-data.js";
 
 const STORAGE_KEY = "cw_user_prefs_v1";
+// Marca que a última escrita não chegou na nuvem. Enquanto ela estiver de pé, a
+// sincronia NÃO pode adotar o que vem do servidor - senão a preferência salva
+// numa hora sem rede é descartada silenciosamente na sessão seguinte, que é
+// exatamente o bug que o `_pendingSync` da Biblioteca Pessoal existe pra evitar.
+const PENDING_KEY = "cw_user_prefs_pending_v1";
 
 // Enquanto uma escrita está em voo, a sincronia de leitura não pode sobrescrever
 // o que acabou de ser salvo localmente - mesmo "cadeado" que a Biblioteca usa.
@@ -39,6 +44,21 @@ function saveLocal(prefs) {
     }
 }
 
+function setPending(value) {
+    try {
+        if (value) localStorage.setItem(PENDING_KEY, "1");
+        else localStorage.removeItem(PENDING_KEY);
+    } catch (e) { /* sem localStorage não há o que marcar */ }
+}
+
+function hasPending() {
+    try {
+        return localStorage.getItem(PENDING_KEY) === "1";
+    } catch (e) {
+        return false;
+    }
+}
+
 export const UserPrefsService = {
     // Leitura síncrona: sempre do cache. Quem quiser o dado fresco da nuvem
     // chama sync(); as telas releem a lista ao abrir.
@@ -56,7 +76,10 @@ export const UserPrefsService = {
         saveLocal(prefs);
 
         const userEmail = getAgentEmail();
-        if (!userEmail) return { saved: true, synced: false };
+        if (!userEmail) {
+            setPending(true);
+            return { saved: true, synced: false };
+        }
 
         isMutating = true;
         let synced = false;
@@ -65,6 +88,7 @@ export const UserPrefsService = {
         } catch (e) {
             console.warn("Falha ao salvar preferências na nuvem:", e);
         } finally {
+            setPending(!synced);
             // Mesma folga de 2s da Biblioteca: dá tempo da planilha refletir a
             // escrita antes de uma leitura de fundo poder sobrescrever o local.
             setTimeout(() => { isMutating = false; }, 2000);
@@ -82,6 +106,16 @@ export const UserPrefsService = {
             if (!userEmail) return loadLocal();
 
             try {
+                // Escrita pendente: o local é a versão boa: tenta empurrá-la de
+                // novo e NÃO adota o servidor nesta rodada. Adotar aqui apagaria
+                // o que a pessoa salvou quando a rede estava fora.
+                if (hasPending()) {
+                    const local = loadLocal();
+                    const ok = await DataService.saveUserPrefs(local, userEmail);
+                    setPending(!ok);
+                    return local;
+                }
+
                 const remote = await DataService.getUserPrefs(userEmail);
                 if (remote && typeof remote === "object" && !isMutating) {
                     const local = loadLocal();


### PR DESCRIPTION
Revisão do código que entrou em #279, feita com olhos frescos. Seis defeitos de comportamento e quatro pontos onde a seção nova destoava do resto do app.

## Os dois que doem

**Duplo clique no "Salvar" criava dois atalhos idênticos.** O id só nascia dentro da escrita (`shortcut.id || newShortcutId()`), e um atalho novo não tem id — então cada clique gerava um. Como a escrita passa por JSONP e pode levar até os 15s do watchdog, a janela para o segundo clique é enorme. Agora o editor **carimba o id ao abrir** (salvar duas vezes atualiza o mesmo atalho) e o botão desabilita com estado "Salvando…". Isso também fecha duas regras dos specs que eu tinha violado: `dom-standards.md` ("toda chamada à API deve ser acompanhada de estado visual de loading") e `design-system.md` ("ao executar ações, os botões devem ser desabilitados temporariamente").

**O apelido do agente era interpolado num `innerHTML`.** O `label` estava certo (`textContent`), mas o `alias` viajava dentro da linha de metadados montada como string. Um `<` quebrava a exibição e uma tag **executava** — não é teoria: revertendo só essa linha, o novo teste acusa `o HTML do apelido foi executado`. É self-XSS (dado do próprio agente), mas o blob passa pela planilha e volta, e o custo de corrigir é uma função. Nome e apelido agora entram exclusivamente por `textContent`.

## Os outros quatro

- **A lista de Configurações ignorava o modo de ordenação**: mostrava sempre a ordem manual, contradizendo o Ctrl+K justamente no modo padrão (ordenado por uso). Agora as duas telas mostram a mesma ordem.
- **Preferência salva sem rede era descartada em silêncio.** Se o `saveUserPrefs` falhava, o dado ficava local e o agente era avisado — mas o `sync()` da sessão seguinte via divergência e **sobrescrevia o local**. Portado o `_pendingSync` da Biblioteca Pessoal: marca local, reenvia quando a rede volta, e nunca adota o servidor enquanto houver pendência.
- **Seta ↓ no último item perdia o foco do teclado** (procurava o punho pelo índice antigo; agora pelo id, e as pontas não disparam reorder).
- **Soltar o mouse fora do punho** deixava o item arrastável pelo corpo inteiro. O arrasto agora é cancelado quando não começa no punho.

## CSS

A seção nova não seguia o padrão que o resto do app já segue — inclusive o `configs-assistant.js` que a hospeda:

| Ponto | Antes | Depois |
| --- | --- | --- |
| Movimento | Sem `prefers-reduced-motion` | Bloco `@media` desligando as transições |
| Foco de teclado | Só o punho de arrastar | `:focus-visible` em todos os controles |
| Easing | `0.2s ease` cru | Tokens `--cw-ease-standard` / `--cw-ease-elastic` |
| Chips de cenário | Raio 14px, padding e fonte próprios | Mesma forma dos chips do Case Notes |
| Cores de alerta | `#f9ab00`/`#fffbf0`/`#b06000` soltos | Tokens `warnBorder`/`warnBg`/`warnText` |
| Nome longo | Truncado sem tooltip | `title` com o nome inteiro; meta também truncada |

Ficaram fora, por decisão de escopo: `<optgroup>` no substatus do editor e semântica `role="list"` — polimento, sem defeito associado.

## Verificação

`test:shortcuts` 20 casos · `test:prefs` 12 · `smoke:shortcuts` 12 — todos verdes. Quatro casos novos, um deles validado ao contrário (revertendo a correção para ver o teste falhar). Demais suítes sem regressão: note-templates (27→26), content (55), call-script (71), e-mails (8). Build de produção em 635 KB.

O aprendizado do `innerHTML` virou entrada em `docs/LEARNINGS.md`, com o ponto adjacente registrado: `promptDialog()` em `utils.js` injeta o `defaultValue` num `value="${...}"` — hoje sem exposição real (os dois chamadores passam texto nosso), mas é o mesmo padrão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
