### PR TITLE
fix(css): painel coberto pelo painel lateral e nome de atalho por cima dos botões

### DIFF
--- a/src/modules/bau-form/bau-form-styles.js
+++ b/src/modules/bau-form/bau-form-styles.js
@@ -1,3 +1,4 @@
+import { Z } from "../shared/z-layers.js";
 
 export const COLORS = {
   blue: "#1A73E8",
@@ -45,7 +46,7 @@ export const injectStyles = () => {
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      z-index: 9999;
+      z-index: ${Z.MODULE_RESTING};
       
       background: #FFFFFF; 
       display: flex;

--- a/src/modules/configs/shortcuts-section.js
+++ b/src/modules/configs/shortcuts-section.js
@@ -41,7 +41,7 @@ function injectStyles(COLORS) {
         .cw-sc-item.broken { border-color: ${COLORS.warnBorder}; background: ${COLORS.warnBg}; }
         .cw-sc-grip {
             color: #9aa0a6; cursor: grab; display: flex; background: none; border: none;
-            padding: 2px; border-radius: 4px;
+            padding: 2px; border-radius: 4px; flex-shrink: 0;
         }
         .cw-sc-grip:active { cursor: grabbing; }
         .cw-sc-grip:focus-visible { outline: 2px solid ${COLORS.primary}; outline-offset: 1px; }
@@ -50,17 +50,24 @@ function injectStyles(COLORS) {
             display: flex; align-items: center; justify-content: center; flex-shrink: 0;
         }
         .cw-sc-text { flex: 1; min-width: 0; }
+        /* display:block é o que faz o ellipsis existir: label e meta são
+           <span>, e overflow/text-overflow não valem em caixa inline - sem
+           isso o nome comprido do atalho passava por cima do lápis e da
+           lixeira em vez de ser cortado. */
         .cw-sc-label {
+            display: block;
             font-size: 13px; font-weight: 600; color: ${COLORS.text};
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
         .cw-sc-meta {
+            display: block;
             font-size: 11px; color: ${COLORS.textSub}; margin-top: 2px;
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
         .cw-sc-warn { color: ${COLORS.warnText}; font-weight: 600; }
         .cw-sc-iconbtn {
-            width: 28px; height: 28px; border-radius: 8px; border: none; background: transparent;
+            width: 28px; height: 28px; flex-shrink: 0;
+            border-radius: 8px; border: none; background: transparent;
             color: ${COLORS.textSub}; cursor: pointer; display: flex; align-items: center;
             justify-content: center; transition: background 0.15s var(--cw-ease-standard), color 0.15s var(--cw-ease-standard);
         }

--- a/src/modules/email-assistant/email-automation-service.js
+++ b/src/modules/email-assistant/email-automation-service.js
@@ -5,6 +5,7 @@ import { getAgentName } from '../shared/page-data.js';
 import { esperar, simularCliqueReal } from '../shared/dom-utils.js';
 import { SoundManager } from '../shared/sound-manager.js';
 import { getLanguage } from '../shared/i18n.js';
+import { Z } from '../shared/z-layers.js';
 
 const EAS_DICT = {
     pt: {
@@ -79,7 +80,7 @@ function createFloatingWarning(targetElement, message) {
         align-items: flex-start;
         justify-content: space-between;
         gap: 10px;
-        z-index: 999999;
+        z-index: ${Z.TOAST};
         font-family: 'Google Sans', Roboto, sans-serif;
         font-size: 13px;
         color: #202124;

--- a/src/modules/notes/automation/case-log-scraper.js
+++ b/src/modules/notes/automation/case-log-scraper.js
@@ -4,6 +4,7 @@ import { SoundManager } from '../../shared/sound-manager.js';
 import { ensureOriginalLanguage } from '../../shared/page-data.js';
 import { esperar, simularClique } from '../../shared/dom-utils.js';
 import { getLanguage } from '../../shared/i18n.js';
+import { Z } from '../../shared/z-layers.js';
 
 const CLS_DICT = {
     pt: {
@@ -54,7 +55,7 @@ if (!document.getElementById(styleId)) {
             
             /* Traz para frente do Overlay */
             position: relative;
-            z-index: 1000000 !important; 
+            z-index: ${Z.PAGE_SPOTLIGHT_TARGET} !important; 
             pointer-events: none;
         }
 
@@ -68,7 +69,7 @@ if (!document.getElementById(styleId)) {
             background: rgba(255, 255, 255, 0.4); /* Branco Translúcido */
             backdrop-filter: blur(5px);           /* O Desfoque Apple Glass */
             -webkit-backdrop-filter: blur(5px);
-            z-index: 999999;                      /* Fica atrás do Input (1000000) */
+            z-index: ${Z.PAGE_SPOTLIGHT_OVERLAY};   /* Fica atrás do Input */
             opacity: 0;
             transition: opacity 0.3s ease;
             pointer-events: all;                  /* Bloqueia cliques na página */

--- a/src/modules/shared/animations.js
+++ b/src/modules/shared/animations.js
@@ -1,6 +1,7 @@
 // src/modules/shared/animations.js
 
 import { SoundManager } from "./sound-manager.js";
+import { Z } from "./z-layers.js";
 
 // --- PARÂMETROS DA ANIMAÇÃO "GENIE" ---
 // Abrir é mais longo que fechar de propósito: entrar em cena merece ser
@@ -24,6 +25,11 @@ if (!document.getElementById('cw-module-styles')) {
     style.innerHTML = `
         /* MÓDULO BASE */
         .cw-module-window {
+            /* Degrau de repouso da janela. Precisa estar AQUI, e não só
+               no estilo inline de stylePopup(): o fim do fechamento faz
+               popup.style.zIndex = '', o que apaga o inline e deixaria a
+               janela em z-index:auto na próxima abertura. */
+            z-index: ${Z.MODULE_RESTING};
             /* A transição real de abrir/fechar é aplicada inline por
                toggleGenieAnimation(); esta aqui só cobre as mudanças de
                estado visual (idle/foco) enquanto a janela está aberta. */
@@ -436,7 +442,7 @@ function setupIdleListener(popup, buttonId) {
         if (clickInModule) {
             // Clicou no módulo: FOCA
             popup.classList.remove('idle');
-            popup.style.zIndex = '2147483648'; // Traz pra frente
+            popup.style.zIndex = String(Z.MODULE_FOCUSED); // Traz pra frente
         } else if (clickInPill) {
             // Clicou na pílula:
             // NÃO faz nada aqui. O evento de click do botão vai cuidar de fechar.
@@ -444,7 +450,7 @@ function setupIdleListener(popup, buttonId) {
         } else {
             // Clicou no vazio: IDLE
             popup.classList.add('idle');
-            popup.style.zIndex = '2147483646'; // Recua
+            popup.style.zIndex = String(Z.MODULE_RESTING); // Recua
         }
     };
 

--- a/src/modules/shared/utils.js
+++ b/src/modules/shared/utils.js
@@ -4,9 +4,13 @@ import { captureNameWithMagic, getSmartGreeting } from "./page-data.js";
 import { SoundManager } from "./sound-manager.js";
 import { esperar, clamp } from "./dom-utils.js";
 import { getLanguage } from "./i18n.js";
+import { Z } from "./z-layers.js";
 
-// Variável global para controlar a pilha de janelas
-let highestZIndex = 10000;
+// Variável global para controlar a pilha de janelas.
+// Começa NO degrau de repouso das janelas (antes começava em 10000, bem
+// abaixo do z-index que a própria janela já tinha: arrastar mandava o
+// painel pra trás do resto da página em vez de trazê-lo pra frente).
+let highestZIndex = Z.MODULE_RESTING;
 
 export function initGlobalStylesAndFont() {
     // Evita duplicidade
@@ -288,7 +292,7 @@ export function showToast(message, opts = {}) {
     fontSize: "14px",
     fontWeight: "500",
     lineHeight: "20px",
-    zIndex: "9999999",
+    zIndex: String(Z.TOAST),
     opacity: "0",
     transition: "all 0.4s var(--cw-ease-spring)", // Efeito Mola
     pointerEvents: "none",
@@ -356,7 +360,9 @@ export function makeDraggable(element, handle = null) {
 
     // --------------------------------------
 
-    highestZIndex++;
+    // Teto no degrau de foco: sem isso, arrastar muitas vezes numa mesma
+    // sessão acabaria passando por cima do backdrop e da pílula.
+    highestZIndex = Math.min(highestZIndex + 1, Z.MODULE_FOCUSED);
     element.style.zIndex = highestZIndex;
     pos3 = e.clientX;
     pos4 = e.clientY;
@@ -446,7 +452,7 @@ export const stylePopup = {
   left: "50%",
   width: "400px",
    maxHeight: "85vh",
-  zIndex: "99999",
+  zIndex: String(Z.MODULE_RESTING),
   overflow: "hidden",
 
   // O SEGREDO APPLE (Glassmorphism + Sombra em Camadas)
@@ -754,7 +760,7 @@ export async function playStartupAnimation() {
             /* Google Sans já vem via <link> logo acima em initGlobalStylesAndFont(),
                chamada antes da splash - esse @import era uma 3a requisição redundante
                pra fonte (a 1a é o <link>, a 2a era o do command-center.js). */
-            .splash-container { font-family: 'Google Sans', sans-serif; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background-color: #202124; z-index: 2147483647; display: flex; flex-direction: column; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.5s cubic-bezier(0.4, 0.0, 0.2, 1); }
+            .splash-container { font-family: 'Google Sans', sans-serif; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background-color: #202124; z-index: ${Z.TOP}; display: flex; flex-direction: column; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.5s cubic-bezier(0.4, 0.0, 0.2, 1); }
             .splash-exit { animation: focus-out 0.9s cubic-bezier(0.4, 0.0, 0.2, 1) forwards; }
             @keyframes focus-out { 0% { opacity: 1; transform: scale(1); filter: blur(0); } 100% { opacity: 0; transform: scale(1.15); filter: blur(15px); } }
 
@@ -1110,7 +1116,7 @@ function createBaseOverlay() {
         position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
         background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(8px)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        zIndex: 2147483647, opacity: 0, transition: 'opacity 0.3s ease'
+        zIndex: Z.TOP, opacity: 0, transition: 'opacity 0.3s ease'
     });
     return overlay;
 }

--- a/src/modules/shared/z-layers.js
+++ b/src/modules/shared/z-layers.js
@@ -1,0 +1,39 @@
+// src/modules/shared/z-layers.js
+//
+// Escala única de empilhamento do app.
+//
+// Antes cada módulo escolhia o próprio número (9999, 10000, 99999, 999999,
+// 1000000, 2147483648...) e o resultado aparecia na tela: a janela de módulo
+// nascia em 99999, abaixo do painel lateral do Gmail, e só subia pra frente
+// depois do primeiro clique dentro dela (o listener de foco em animations.js).
+// Quem abria o Case Notes via a metade direita do painel coberta pelo add-on.
+// Arrastar a janela era pior ainda: o contador de "trazer pra frente" começava
+// em 10000, ou seja, arrastar EMPURRAVA a janela pra trás.
+//
+// 2147483647 é o teto real: é o maior int de 32 bits com sinal, e o navegador
+// grampeia qualquer valor acima disso. Era o caso do 2147483648 que
+// animations.js usava pra "focar" a janela - na prática ele empatava com a
+// pílula em vez de ficar acima dela, e a janela focada acabava cobrindo o
+// próprio lançador.
+//
+// Os dois últimos degraus já existem hardcoded em command-center.js
+// (.cw-focus-backdrop e .cw-pill / .cw-processing-card) e em utils.js
+// (.splash-container, .cw-dialog-overlay); estão listados aqui pra que a ordem
+// completa fique legível num lugar só.
+export const Z = {
+    // Janela de módulo em repouso ou em segundo plano (.idle).
+    MODULE_RESTING: 2147483640,
+    // Janela de módulo que acabou de receber clique - sobe acima das irmãs.
+    MODULE_FOCUSED: 2147483641,
+    // Blur que a automação joga sobre a PÁGINA (CRM/Gmail) pra destacar o
+    // campo que ela vai preencher. Fica acima das janelas de módulo.
+    PAGE_SPOTLIGHT_OVERLAY: 2147483642,
+    // O campo destacado, acima do próprio blur.
+    PAGE_SPOTLIGHT_TARGET: 2147483643,
+    // Toasts e avisos ancorados na página: acima de tudo que é conteúdo.
+    TOAST: 2147483644,
+    // Escurecimento de foco do card de processamento (command-center.js).
+    FOCUS_BACKDROP: 2147483646,
+    // Pílula, paleta Ctrl+K, splash, diálogos modais e o card de processamento.
+    TOP: 2147483647,
+};


### PR DESCRIPTION
Corrige os dois defeitos das capturas.

### 1. O painel do Case Notes abria coberto pela metade direita

`.cw-module-window` não tinha `z-index` no CSS: quem mandava era o inline de `stylePopup()`, em **99999** — abaixo do painel lateral do Gmail. Ao abrir o módulo, a metade direita ficava escondida atrás do add-on e só voltava ao normal depois do **primeiro clique dentro da janela**, que é quando `setupIdleListener()` a promovia. Por isso o bug parecia intermitente.

Arrastar era pior: o contador de "trazer pra frente" do `makeDraggable()` começava em `10000`, ou seja, arrastar **empurrava a janela pra trás**.

- A escala de empilhamento vira um módulo só: `src/modules/shared/z-layers.js`.
- O degrau de repouso da janela passa a estar no **CSS base**, não só no inline — o fim do fechamento faz `popup.style.zIndex = ''`, que apagava o inline e deixava a janela em `z-index: auto` na abertura seguinte.
- Some o `2147483648` que era usado pra "focar" a janela: é maior que o maior int de 32 bits, o navegador grampeava pra `2147483647` e a janela focada empatava com a pílula em vez de ficar abaixo dela.

### 2. Nome comprido de atalho passava por cima do lápis e da lixeira

`.cw-sc-label` e `.cw-sc-meta` já pediam ellipsis, mas são `<span>`: `overflow` e `text-overflow` **não se aplicam a caixa inline**, então o texto simplesmente vazava. `display: block` resolve, e `flex-shrink: 0` nos botões e no punho evita que eles sejam esmagados no lugar do texto.

### Verificação

`npm run build`, `test:shortcuts`, `test:prefs` e `smoke:shortcuts` — todos verdes.

Checagem extra no navegador sobre o `mock-crm.html`:

- `z-index = 2147483640` já na abertura do Case Notes, **sem clique dentro dela**;
- o CSS base segura a camada mesmo depois de limpar o inline;
- pílula (`2147483647`) continua acima da janela focada (`2147483641`);
- atalho com nome de 76 caracteres cortado com reticências, terminando 10px antes do lápis, com os botões em 28px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)