### PR TITLE
feat: separa backend por ambiente e reconstrói os wizards de onboarding e changelog

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,15 +24,22 @@ jobs:
       - name: Install esbuild
         run: npm install esbuild
 
+      # `--define:__CW_BUILD_ENV__` é o que faz src/modules/shared/data-service.js
+      # escolher entre o deployment de produção e o de desenvolvimento do Apps
+      # Script. Sem ele o bundle cai no fallback "development" e produção passa
+      # a falar com o backend que este mesmo workflow republica a cada push na
+      # refactor-structure. Se um dia alguém adicionar um terceiro build aqui,
+      # ele PRECISA vir com o define - o fallback é silencioso.
+
       # --- BUILD DE PRODUÇÃO (Apenas na main) ---
       - name: Build Production (bundle.js)
         if: github.ref == 'refs/heads/main'
-        run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle.js --minify
+        run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle.js --minify --define:__CW_BUILD_ENV__='"production"'
 
       # --- BUILD DE DESENVOLVIMENTO (Apenas na refactor) ---
       - name: Build Development (bundle-dev.js)
         if: github.ref == 'refs/heads/refactor-structure'
-        run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --minify
+        run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --minify --define:__CW_BUILD_ENV__='"development"'
         
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ TechSol Operations Assistant — a productivity and automation suite for a corpo
 
 - Install deps: `npm install`
 - Run dev: `npm run dev` — builds `dist/bundle-dev.js`; there is no localhost target, load it into the real CRM via the Dev bookmarklet (see `README.md`)
-- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts` drives the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
+- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts` and `npm run smoke:wizards` drive the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
 - Lint: none configured
 - Build: `npm run build` — builds `dist/bundle.js` (minified, production)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,9 +39,14 @@ clasp deploy -i <production-deployment-id> -d "Release $(date -u +%F) - $(git re
 
 - **`CLASPRC_JSON`** (GitHub Actions secret) — `clasp` OAuth credentials CI uses to authenticate before `clasp push`/`clasp deploy`. Regenerate locally with `clasp login`, then update the repo secret (Settings → Secrets → Actions) with the resulting `~/.clasprc.json` contents.
 - **`scriptId`** (`gas-backend/.clasp.json`, committed) — identifies which Apps Script project `clasp push` targets. Same for both branches/environments; only the *deployment* differs.
-- **`SCRIPT_ID`** (`src/modules/shared/data-service.js`, hardcoded) — used to build the `/exec` and `/dev` API URLs the frontend calls.
-- **`DEPLOYMENT_ID`** (`.github/workflows/deploy.yml`, hardcoded) — the pinned *development* deployment CI auto-promotes on `refactor-structure`. Must match the `SCRIPT_ID` in `data-service.js` used by that branch — update both together if the script is ever rotated.
-- **Production deployment ID** — intentionally **not** automated/hardcoded in CI; used manually via `clasp deploy -i <id>` or the Apps Script UI (Deploy → Manage deployments).
+- **`DEPLOYMENTS`** (`src/modules/shared/data-service.js`, committed) — a map with **both** Apps Script deployment IDs, `production` and `development`. Which one the bundle uses is decided at build time, not at runtime.
+- **`__CW_BUILD_ENV__`** (`.github/workflows/deploy.yml`, injected via `esbuild --define`) — `"production"` on `main`, `"development"` on `refactor-structure`. **Any new build step must pass this flag**: without it `data-service.js` falls back to `"development"` silently, and a production bundle would start talking to the dev backend. (That is exactly the state `main` would have inherited from a plain merge before this split existed.) Building locally with no `--define` is the one case where the fallback is correct.
+- **`DEPLOYMENT_ID`** (`.github/workflows/deploy.yml`, hardcoded) — the pinned *development* deployment CI auto-promotes on `refactor-structure`. Must match `DEPLOYMENTS.development` in `data-service.js` — update both together if the deployment is ever rotated.
+- **Production deployment ID** — `DEPLOYMENTS.production` in `data-service.js`. Deliberately **not** promoted by CI; promoted manually via `clasp deploy -i <id>` or the Apps Script UI (Deploy → Manage deployments). Pushing `main` updates the frontend and the backend HEAD, never the live production deployment.
+
+### App version
+
+`APP_VERSION` (`src/app.js`) drives *when* the "what's new" modal fires; `RELEASE_NOTES.version` (`src/modules/changelog/changelog-data.js`) drives *what it says*. **Bump both in the same commit.** If they diverge, `checkAndShowChangelog` suppresses the modal and logs a warning rather than showing the new version's badge over the old version's content.
 
 ## Rollback
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "TechSol Operations Assistant - Productivity Suite",
   "main": "src/app.js",
   "scripts": {
-    "build": "esbuild src/app.js --bundle --minify --outfile=dist/bundle.js",
-    "dev": "esbuild src/app.js --bundle --outfile=dist/bundle-dev.js",
+    "build": "esbuild src/app.js --bundle --minify --outfile=dist/bundle.js --define:__CW_BUILD_ENV__='\"production\"'",
+    "dev": "esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --define:__CW_BUILD_ENV__='\"development\"'",
     "portfolio": "python3 generate-portfolio.py",
     "test:content": "node scripts/test-content-api.js",
     "test:call-script": "node scripts/test-call-script-roundtrip.mjs",
@@ -18,6 +18,7 @@
     "test:shortcuts": "node scripts/test-shortcuts.mjs",
     "test:prefs": "node scripts/test-user-prefs.js",
     "smoke:shortcuts": "node scripts/smoke-shortcuts.mjs",
+    "smoke:wizards": "node scripts/smoke-wizards.mjs",
     "seed:note-templates": "node scripts/generate-note-templates-seed.mjs"
   },
   "dependencies": {

--- a/scripts/smoke-shortcuts.mjs
+++ b/scripts/smoke-shortcuts.mjs
@@ -46,7 +46,12 @@ page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); 
 await page.goto('file://' + resolve(raiz, 'mock-crm.html'));
 await page.evaluate(() => {
     localStorage.setItem('cw_onboarding_seen_v1', 'true');
-    localStorage.setItem('cw_changelog_seen_version', '99.9');
+    // Nada a fazer pelo changelog: sem 'cw_last_version' gravada, ele trata a
+    // sessão como usuário novo, grava a versão e sai calado - o modal não abre.
+    // (Havia aqui um setItem('cw_changelog_seen_version', ...), chave que não
+    // existe em lugar nenhum; funcionava por acidente, por este mesmo caminho.
+    // Gravar uma versão *diferente* da atual é que faria o modal abrir e cobrir
+    // a UI no meio do smoke.)
 });
 await page.addScriptTag({ content: script });
 

--- a/scripts/smoke-wizards.mjs
+++ b/scripts/smoke-wizards.mjs
@@ -1,0 +1,350 @@
+// scripts/smoke-wizards.mjs
+//
+// Smoke dos dois wizards de slides - o Onboarding (primeira vez que alguém
+// abre o app) e o Changelog (quando o APP_VERSION muda) - no navegador de
+// verdade. Os dois compartilham shared/wizard-shell.js, então este teste
+// cobre a casca uma vez e o conteúdo de cada um em cima dela.
+//
+// Existe porque tudo que quebra nesses dois modais é temporal ou visual, e
+// portanto invisível num teste de unidade: cross-fade sincronizado com o
+// setTimeout que troca o texto, foco preso no card, scroll travado enquanto
+// aberto, prefers-reduced-motion, e o rodapé cabendo numa viewport estreita
+// (a versão anterior estourava a 380px com três botões na linha).
+//
+// Cobre também a guarda de descompasso de versão: se APP_VERSION e
+// RELEASE_NOTES.version divergirem, o modal tem que ser suprimido em vez de
+// mostrar o selo de uma versão sobre o texto de outra - que foi exatamente o
+// que aconteceu em produção entre a v5.1 e a v5.2.
+//
+// Uso: npm run smoke:wizards
+
+import { chromium } from 'playwright';
+import { build } from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const raiz = resolve(here, '..');
+
+// Entrada sintética: em vez de subir o app inteiro (que espera o DOM do CRM,
+// faz JSONP e leva ~12s de animação de boot), monta só a camada dos wizards e
+// expõe gatilhos. É a fronteira certa - o que se quer testar aqui é a casca de
+// slides, não a inicialização do app.
+const bundle = await build({
+    stdin: {
+        contents: `
+            import { initGlobalStylesAndFont } from "./src/modules/shared/utils.js";
+            import { initOnboarding } from "./src/modules/onboarding/onboarding-wizard.js";
+            import { checkAndShowChangelog } from "./src/modules/changelog/changelog-wizard.js";
+            import { setLanguage } from "./src/modules/shared/i18n.js";
+
+            initGlobalStylesAndFont();
+
+            window.__cw = {
+                onboarding: (lang) => {
+                    setLanguage(lang || "pt", { persist: false });
+                    localStorage.removeItem("cw_onboarding_seen_v1");
+                    initOnboarding();
+                },
+                changelog: (lang) => {
+                    setLanguage(lang || "pt", { persist: false });
+                    localStorage.setItem("cw_last_version", "v0.0");
+                    checkAndShowChangelog(APP_VERSION);
+                },
+                // APP_VERSION que não existe no changelog-data.js: a guarda
+                // tem que suprimir o modal em vez de mentir o selo.
+                changelogMismatch: () => {
+                    localStorage.setItem("cw_last_version", "v0.0");
+                    checkAndShowChangelog("v99.9");
+                },
+            };
+        `,
+        resolveDir: raiz,
+        loader: 'js',
+    },
+    bundle: true,
+    write: false,
+    logLevel: 'silent',
+    // A versão real do app, lida de src/app.js, para o teste não fossilizar um
+    // número e continuar verde depois de um bump que esqueceu o changelog-data.
+    define: { APP_VERSION: JSON.stringify(await lerAppVersion()) },
+});
+const script = bundle.outputFiles[0].text;
+
+async function lerAppVersion() {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(resolve(raiz, 'src/app.js'), 'utf8');
+    const m = src.match(/APP_VERSION\s*=\s*["']([^"']+)["']/);
+    if (!m) throw new Error('não achei APP_VERSION em src/app.js');
+    return m[1];
+}
+
+let fail = 0;
+async function check(name, fn) {
+    try { await fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+function igual(atual, esperado, oque) {
+    if (atual !== esperado) throw new Error(`${oque}: esperado ${JSON.stringify(esperado)}, veio ${JSON.stringify(atual)}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+
+async function novaPagina(opcoes = {}) {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 }, ...opcoes });
+    await page.route('**script.google.com/**', (route) => route.abort());
+    page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
+    await page.goto('file://' + resolve(raiz, 'mock-crm.html'));
+    await page.addScriptTag({ content: script });
+    return page;
+}
+
+const slideAtivo = (page) => page.evaluate(() =>
+    Array.from(document.querySelectorAll('.cw-wiz-dot')).findIndex((d) => d.classList.contains('active')));
+
+console.log('\n--- Smoke: wizards de onboarding e changelog ---');
+
+// ---------------------------------------------------------------- onboarding
+{
+    const page = await novaPagina();
+    const avisos = [];
+    page.on('console', (m) => { if (m.type() === 'warning') avisos.push(m.text()); });
+
+    await page.evaluate(() => window.__cw.onboarding());
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(500);
+
+    await check('abre com mais de um slide', async () => {
+        const n = await page.locator('.cw-wiz-dot').count();
+        if (n < 2) throw new Error(`só ${n} dot(s)`);
+    });
+
+    await check('trava o scroll da página de fundo', async () =>
+        igual(await page.evaluate(() => document.body.style.overflow), 'hidden', 'body.overflow'));
+
+    await check('entra com foco no botão principal', async () => {
+        const cls = await page.evaluate(() => document.activeElement?.className || '');
+        if (!cls.includes('cw-wiz-btn-primary')) throw new Error('foco em ' + cls);
+    });
+
+    await check('usa o token --cw-primary, não hex cravado', async () =>
+        igual(await page.evaluate(() => getComputedStyle(document.querySelector('.cw-wiz-btn-primary')).backgroundColor),
+            'rgb(26, 115, 232)', 'cor do botão'));
+
+    await check('"Voltar" escondido no primeiro slide', async () => {
+        const escondido = await page.evaluate(() => document.querySelector('.cw-wiz-actions .cw-wiz-btn-ghost').hidden);
+        if (!escondido) throw new Error('Voltar visível no slide 1');
+    });
+
+    await check('seta direita avança, seta esquerda volta', async () => {
+        await page.keyboard.press('ArrowRight');
+        await page.waitForTimeout(400);
+        igual(await slideAtivo(page), 1, 'após ArrowRight');
+        await page.keyboard.press('ArrowLeft');
+        await page.waitForTimeout(400);
+        igual(await slideAtivo(page), 0, 'após ArrowLeft');
+    });
+
+    await check('dots são clicáveis e pulam direto', async () => {
+        const ultimo = (await page.locator('.cw-wiz-dot').count()) - 1;
+        await page.locator('.cw-wiz-dot').nth(ultimo).click();
+        await page.waitForTimeout(400);
+        igual(await slideAtivo(page), ultimo, 'após clicar no último dot');
+    });
+
+    await check('região aria-live anuncia o slide', async () => {
+        const texto = await page.evaluate(() => document.querySelector('.cw-wiz-live').textContent);
+        if (!/^Slide \d+ de \d+: .+/.test(texto)) throw new Error('aria-live: ' + JSON.stringify(texto));
+    });
+
+    await check('"Pular" some no último slide', async () => {
+        const escondido = await page.evaluate(() => document.querySelector('.cw-wiz-skip')?.hidden ?? true);
+        if (!escondido) throw new Error('Pular ainda visível no fim');
+    });
+
+    // aria-modal informa o leitor de tela mas não prende o foco - isso é
+    // trabalho nosso, e é a checagem que pega uma regressão silenciosa.
+    await check('Tab fica preso dentro do card', async () => {
+        await page.evaluate(() => document.querySelector('.cw-wiz-btn-primary').focus());
+        for (let i = 0; i < 20; i++) {
+            await page.keyboard.press('Tab');
+            const dentro = await page.evaluate(() =>
+                document.querySelector('.cw-wiz-card').contains(document.activeElement));
+            if (!dentro) throw new Error(`foco escapou no Tab #${i + 1}`);
+        }
+    });
+
+    await check('fecha, destrava o scroll e persiste a flag', async () => {
+        await page.locator('.cw-wiz-btn-primary').click();
+        await page.waitForTimeout(700);
+        igual(await page.locator('.cw-wiz-overlay').count(), 0, 'overlay no DOM');
+        igual(await page.evaluate(() => document.body.style.overflow), '', 'body.overflow');
+        igual(await page.evaluate(() => localStorage.getItem('cw_onboarding_seen_v1')), 'true', 'flag');
+    });
+
+    await check('segunda chamada não reabre', async () => {
+        await page.evaluate(() => {
+            localStorage.setItem('cw_onboarding_seen_v1', 'true');
+        });
+        await page.waitForTimeout(200);
+        igual(await page.locator('.cw-wiz-overlay').count(), 0, 'overlay');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------------------------ espanhol
+{
+    const page = await novaPagina();
+    await page.evaluate(() => window.__cw.onboarding('es'));
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(500);
+
+    await check('conteúdo em espanhol quando o perfil é es', async () => {
+        const titulo = await page.evaluate(() => document.querySelector('.cw-wiz-title').textContent);
+        if (!/Bienvenido/.test(titulo)) throw new Error('título: ' + JSON.stringify(titulo));
+    });
+
+    await check('a casca também traduz (Voltar/Volver, aria-live)', async () => {
+        await page.keyboard.press('ArrowRight');
+        await page.waitForTimeout(400);
+        igual(await page.evaluate(() => document.querySelector('.cw-wiz-actions .cw-wiz-btn-ghost').textContent),
+            'Volver', 'rótulo do botão de voltar');
+        const live = await page.evaluate(() => document.querySelector('.cw-wiz-live').textContent);
+        if (!live.startsWith('Diapositiva')) throw new Error('aria-live: ' + JSON.stringify(live));
+    });
+
+    // O onboarding é a tela que mais sofre com tradução mais longa: se o
+    // espanhol estourar, estoura aqui.
+    await check('sem scroll horizontal em espanhol', async () => {
+        const ok = await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1);
+        if (!ok) throw new Error('página rolando na horizontal');
+    });
+
+    await page.close();
+}
+
+// ----------------------------------------------------------------- changelog
+{
+    const page = await novaPagina();
+    const versao = await lerAppVersion();
+
+    await page.evaluate(() => window.__cw.changelog());
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(500);
+
+    await check('badge traz a versão corrente do app', async () =>
+        igual(await page.evaluate(() => document.querySelector('.cw-wiz-badge')?.textContent),
+            `Atualização ${versao}`, 'badge'));
+
+    await check('não oferece "Pular" (é a única vez que isso aparece)', async () => {
+        const escondido = await page.evaluate(() => document.querySelector('.cw-wiz-skip')?.hidden ?? true);
+        if (!escondido) throw new Error('Pular presente no changelog');
+    });
+
+    // Esc aqui DISPENSA. Uma versão intermediária avançava o slide no Esc,
+    // porque reaproveitava o clique do botão principal.
+    await check('Esc fecha e grava a versão', async () => {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(700);
+        igual(await page.locator('.cw-wiz-overlay').count(), 0, 'overlay');
+        igual(await page.evaluate(() => localStorage.getItem('cw_last_version')), versao, 'cw_last_version');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------- guarda de versão divergente
+{
+    const page = await novaPagina();
+    const avisos = [];
+    page.on('console', (m) => { if (m.type() === 'warning') avisos.push(m.text()); });
+
+    await page.evaluate(() => window.__cw.changelogMismatch());
+    await page.waitForTimeout(400);
+
+    await check('APP_VERSION != RELEASE_NOTES.version suprime o modal', async () =>
+        igual(await page.locator('.cw-wiz-overlay').count(), 0, 'overlay'));
+
+    await check('e avisa no console em vez de falhar em silêncio', async () => {
+        if (!avisos.some((a) => a.includes('[changelog]'))) {
+            throw new Error('nenhum warn: ' + JSON.stringify(avisos));
+        }
+    });
+
+    await page.close();
+}
+
+// ----------------------------------------------------------- reduced motion
+{
+    const page = await novaPagina({ reducedMotion: 'reduce' });
+    await page.evaluate(() => window.__cw.onboarding());
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(400);
+
+    await check('respeita prefers-reduced-motion no card', async () => {
+        const cs = await page.evaluate(() => {
+            const s = getComputedStyle(document.querySelector('.cw-wiz-card'));
+            return { transform: s.transform, transition: s.transitionProperty };
+        });
+        igual(cs.transform, 'none', 'transform do card');
+        igual(cs.transition, 'opacity', 'propriedades em transição');
+    });
+
+    await check('troca de slide é imediata com movimento reduzido', async () => {
+        await page.keyboard.press('ArrowRight');
+        await page.waitForTimeout(60); // menos que o cross-fade normal (160ms)
+        igual(await slideAtivo(page), 1, 'slide ativo');
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------------- layout apertado
+{
+    const page = await novaPagina({ viewport: { width: 900, height: 520 } });
+    await page.evaluate(() => window.__cw.onboarding());
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(400);
+
+    await check('card cabe numa viewport baixa (900x520)', async () => {
+        const r = await page.evaluate(() => {
+            const b = document.querySelector('.cw-wiz-card').getBoundingClientRect();
+            return { top: b.top, bottom: b.bottom, vh: window.innerHeight };
+        });
+        if (r.top < -1 || r.bottom > r.vh + 1) throw new Error(JSON.stringify(r));
+    });
+
+    await page.close();
+}
+
+{
+    const page = await novaPagina({ viewport: { width: 380, height: 700 } });
+    await page.evaluate(() => window.__cw.onboarding());
+    await page.waitForSelector('.cw-wiz-overlay.open');
+    await page.waitForTimeout(400);
+
+    await check('sem scroll horizontal numa viewport estreita (380px)', async () => {
+        const ok = await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1);
+        if (!ok) throw new Error('página rolando na horizontal');
+    });
+
+    // Com Voltar + Pular + Próximo no rodapé isto estourava: 294px de conteúdo
+    // em 268px úteis, espremendo o botão principal. Por isso o "Pular" foi pro
+    // canto superior - e por isso esta checagem existe.
+    await check('rodapé não estoura num slide do meio', async () => {
+        await page.locator('.cw-wiz-dot').nth(2).click();
+        await page.waitForTimeout(400);
+        const a = await page.evaluate(() => {
+            const el = document.querySelector('.cw-wiz-actions');
+            return { scrollW: el.scrollWidth, clientW: el.clientWidth };
+        });
+        if (a.scrollW > a.clientW + 1) throw new Error(JSON.stringify(a));
+    });
+
+    await page.close();
+}
+
+await browser.close();
+console.log('\n' + (fail ? '✗' : '✓') + ` smoke: ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ function initApp() {
     }
     window.techSolInitialized = true;
 
-    const APP_VERSION = "v5.2"; 
+    const APP_VERSION = "v6.0"; 
 
     console.log(`🚀 TechSol Suite Initializing (${APP_VERSION})...`);
 

--- a/src/modules/changelog/changelog-data.js
+++ b/src/modules/changelog/changelog-data.js
@@ -1,42 +1,49 @@
-
-
 // src/modules/changelog/changelog-data.js
+//
+// Conteúdo do modal "o que mudou", exibido quando o APP_VERSION visto pela
+// última vez difere do atual.
+//
+// REGRA: `version` aqui tem que ser igual ao APP_VERSION de src/app.js. Quem
+// manda em *quando* o modal aparece é o APP_VERSION; quem manda no *que ele
+// diz* é este arquivo. Quando os dois divergem, o modal aparece com o selo da
+// versão nova anunciando as novidades da versão velha - foi o que aconteceu
+// entre a v5.1 e a v5.2. Ao subir a versão, os dois sobem juntos.
 
 export const RELEASE_NOTES = {
-    version: "v5.1", 
-    
-    title: "Atualização: v5.1 - Produtividade Blindada 🛡️",
-    
+    version: "v6.0",
+
+    title: "Case Wizard v6.0",
+
     slides: [
         {
-            icon: "🅿️",
-            title: "Estacionamento de Casos",
-            text: "Interrupção urgente? Agora você pode 'Estacionar' seu atendimento atual (Notas + Tasks) com um clique e retomar depois exatamente de onde parou."
+            icon: "⌨️",
+            title: "Ctrl+K abre tudo",
+            text: "A nova paleta de comandos chega em qualquer módulo por um atalho. Digite parte do nome — com ou sem acento, \"fusos\" acha \"Fusos Horários\" — e vá direto."
         },
         {
-            icon: "🛟",
-            title: "Sistema 'Airbag'",
-            text: "Caiu a internet? Fechou a aba sem querer? O TechSol agora possui Auto-Save de emergência a cada 5 segundos. Seu texto está salvo, sempre."
+            icon: "📚",
+            title: "Minha Biblioteca",
+            text: "Seus snippets, templates de e-mail e respostas prontas agora vivem num módulo só, com busca e uma fila de \"usados recentemente\" pra copiar sem procurar."
         },
         {
-            icon: "🟠",
-            title: "Indicador de Progresso",
-            text: "Nunca mais esqueça uma nota aberta. Um indicador laranja ('Dirty State') avisa na Pílula principal se há trabalho não salvo/estacionado."
+            icon: "📝",
+            title: "Case Notes reconstruído",
+            text: "Campos que você apaga viram chips para readicionar, transferências dividem a nota corretamente, e o rascunho é salvo continuamente. Estacionar um caso e retomar depois ficou confiável."
         },
         {
-            icon: "🔍",
-            title: "Time Zone Pro",
-            text: "O módulo de fusos horários ganhou superpoderes: nova barra de pesquisa global, filtros rápidos por região e correção de visualização."
+            icon: "🧾",
+            title: "BAU Form e Avisos",
+            text: "O formulário de criação e descarte BAU ganhou fluxo próprio em etapas, e a leitura dos comunicados de disponibilidade agora entende datas e bandeiras quebradas em várias linhas."
         },
         {
-            icon: "🤖",
-            title: "Leitura de BAU Aprimorada",
-            text: "O sistema de Broadcast agora é mais inteligente ao ler avisos de disponibilidade, detectando datas e bandeiras mesmo quando quebradas em várias linhas."
+            icon: "♿",
+            title: "Teclado e leitor de tela",
+            text: "Navegação completa por teclado em todos os módulos, foco visível, rolagem travada corretamente com popups abertos e estados vazios que explicam o que fazer em vez de ficarem em branco."
         },
         {
-            icon: "🎨",
-            title: "Refinamento Visual",
-            text: "Botões padronizados, sombras suavizadas e micro-interações táteis em todo o sistema para uma experiência mais fluida e profissional."
+            icon: "🎬",
+            title: "Movimento revisado de ponta a ponta",
+            text: "Todas as animações passaram para quatro curvas canônicas, o descompasso entre a splash e a pílula acabou, e quem usa \"reduzir movimento\" no sistema agora é respeitado em todo o app."
         }
     ]
 };

--- a/src/modules/changelog/changelog-wizard.js
+++ b/src/modules/changelog/changelog-wizard.js
@@ -1,203 +1,91 @@
 // src/modules/changelog/changelog-wizard.js
+//
+// Modal "o que mudou nesta versão". Divide a casca de slides com o
+// Onboarding (shared/wizard-shell.js); aqui fica só a decisão de mostrar ou
+// não, e o texto do release (changelog-data.js).
 
-import { stylePopup, showToast } from "../shared/utils.js";
-import { SoundManager } from "../shared/sound-manager.js";
-import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
+import { showToast } from "../shared/utils.js";
+import { openWizardShell } from "../shared/wizard-shell.js";
 import { RELEASE_NOTES } from "./changelog-data.js";
 import { getLanguage } from "../shared/i18n.js";
 
+const LAST_VERSION_KEY = "cw_last_version";
+
 // O conteúdo de cada release (RELEASE_NOTES) ainda é só PT — texto editorial
-// por versão, fora do escopo desta rodada (fica junto com a tradução do
-// conteúdo do Notes numa fase seguinte). Só o texto fixo do wizard em si
-// (botões, badge, toast) é traduzido aqui.
+// por versão, deliberadamente fora do escopo da rodada de i18n (vai junto com
+// a tradução do conteúdo do Notes numa fase seguinte). Só o texto fixo do
+// wizard em si é traduzido aqui; o resto da casca traduz a si mesma.
 const CHANGELOG_DICT = {
     pt: {
         updateBadge: (version) => `Atualização ${version}`,
         nextBtn: "Próximo",
         doneBtn: "Entendi, vamos lá! 👍",
-        updatedToast: (version) => `TechSol atualizado para ${version}!`,
+        updatedToast: (version) => `Case Wizard atualizado para ${version}!`,
     },
     es: {
         updateBadge: (version) => `Actualización ${version}`,
         nextBtn: "Siguiente",
         doneBtn: "¡Entendido, vamos! 👍",
-        updatedToast: (version) => `TechSol actualizado a ${version}!`,
+        updatedToast: (version) => `¡Case Wizard actualizado a ${version}!`,
     },
 };
+
 function ct(key) {
     const lang = getLanguage();
     return CHANGELOG_DICT[lang]?.[key] ?? CHANGELOG_DICT.pt[key];
 }
 
+/**
+ * Decide se o modal de novidades deve aparecer neste boot.
+ *
+ * @param {string} currentAppVersion APP_VERSION de src/app.js.
+ */
 export function checkAndShowChangelog(currentAppVersion) {
-    const lastSeenVersion = localStorage.getItem("cw_last_version");
+    const lastSeenVersion = localStorage.getItem(LAST_VERSION_KEY);
 
-    // 1. Lógica de Verificação
-    // Se não tem versão salva (usuário novo), não mostra changelog (mostra tutorial).
-    // Se a versão salva for diferente da atual, mostra o changelog.
+    // Usuário novo: não tem o que "mudou" pra contar. Grava a versão em
+    // silêncio e sai - quem apresenta o app pra essa pessoa é o Onboarding.
     if (!lastSeenVersion) {
-        // Primeira vez usando o app: Salva a versão atual e sai silenciosamente
-        // (O Onboarding Wizard vai cuidar dele)
-        localStorage.setItem("cw_last_version", currentAppVersion);
+        localStorage.setItem(LAST_VERSION_KEY, currentAppVersion);
         return;
     }
 
-    if (lastSeenVersion !== currentAppVersion) {
-        // Versão mudou! Hora do show.
-        initChangelogModal(currentAppVersion);
+    if (lastSeenVersion === currentAppVersion) return;
+
+    // Guarda contra o descompasso que já aconteceu na prática: se o
+    // APP_VERSION subiu mas o changelog-data.js ficou pra trás, o modal
+    // apareceria com o selo da versão nova e o conteúdo da anterior. Melhor
+    // não mostrar nada do que mostrar informação errada - mas o aviso no
+    // console deixa claro pra quem está desenvolvendo que faltou atualizar.
+    if (RELEASE_NOTES.version !== currentAppVersion) {
+        console.warn(
+            `[changelog] APP_VERSION é ${currentAppVersion} mas RELEASE_NOTES.version é ` +
+            `${RELEASE_NOTES.version}. Modal suprimido até os dois baterem ` +
+            `(veja src/modules/changelog/changelog-data.js).`
+        );
+        localStorage.setItem(LAST_VERSION_KEY, currentAppVersion);
+        return;
     }
+
+    initChangelogModal(currentAppVersion);
 }
 
 function initChangelogModal(version) {
-    const SLIDES = RELEASE_NOTES.slides;
-    let currentSlide = 0;
-
-    // --- ESTILOS (Reutilizando a base do Onboarding para consistência) ---
-    const styles = {
-        overlay: {
-            position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh",
-            backgroundColor: "rgba(0,0,0,0.7)", backdropFilter: "blur(5px)",
-            zIndex: "2147483647",
-            display: "flex", alignItems: "center", justifyContent: "center",
-            opacity: "0", transition: "opacity 0.3s ease"
-        },
-        card: {
-            width: "400px", background: "#fff", borderRadius: "24px",
-            padding: "32px", textAlign: "center", position: "relative",
-            boxShadow: "0 24px 60px rgba(0,0,0,0.4)",
-            fontFamily: "'Google Sans', Roboto, sans-serif",
-            transform: "translateY(30px)", transition: "all 0.4s cubic-bezier(0.19, 1, 0.22, 1)"
-        },
-        badge: {
-            display: "inline-block", padding: "4px 12px", borderRadius: "12px",
-            background: "#E8F0FE", color: "#1967D2", fontSize: "11px", fontWeight: "700",
-            textTransform: "uppercase", marginBottom: "16px", letterSpacing: "0.5px"
-        },
-        icon: { fontSize: "42px", marginBottom: "16px", display: "block" },
-        title: { fontSize: "20px", fontWeight: "700", color: "#202124", marginBottom: "8px" },
-        text: { fontSize: "14px", color: "#5f6368", lineHeight: "1.5", marginBottom: "32px", minHeight: "42px" },
-        
-        dotsContainer: { display: "flex", justifyContent: "center", gap: "6px", marginBottom: "24px" },
-        dot: { width: "6px", height: "6px", borderRadius: "50%", background: "#dadce0", transition: "all 0.3s" },
-        dotActive: { background: "#1a73e8", width: "18px", borderRadius: "4px" },
-        
-        btn: {
-            width: "100%", padding: "12px", borderRadius: "12px", border: "none", cursor: "pointer",
-            fontSize: "14px", fontWeight: "600", transition: "all 0.2s",
-            background: "#1a73e8", color: "#fff", boxShadow: "0 4px 12px rgba(26,115,232,0.3)"
+    // A versão só é gravada no fechamento: se a pessoa fechar a aba no meio,
+    // ela merece rever o que mudou no próximo boot. É o oposto da regra do
+    // Onboarding (que grava na abertura) e de propósito - aqui o conteúdo é
+    // informação que se perde, lá é uma apresentação que cansa se repetir.
+    openWizardShell({
+        slides: RELEASE_NOTES.slides,
+        idPrefix: "cw-changelog",
+        badge: ct("updateBadge")(version),
+        nextLabel: ct("nextBtn"),
+        finalLabel: ct("doneBtn"),
+        // Sem "Pular": são poucos slides e é a única vez que essa informação
+        // aparece. Esc ainda fecha, e os dots deixam ir direto ao fim.
+        onClose: () => {
+            localStorage.setItem(LAST_VERSION_KEY, version);
+            showToast(ct("updatedToast")(version));
         }
-    };
-
-    // --- DOM ---
-    const overlay = document.createElement("div");
-    Object.assign(overlay.style, styles.overlay);
-    overlay.setAttribute("role", "dialog");
-    overlay.setAttribute("aria-modal", "true");
-    overlay.setAttribute("aria-labelledby", "cw-changelog-title");
-
-    const card = document.createElement("div");
-    Object.assign(card.style, styles.card);
-
-    // Badge de Versão
-    const badge = document.createElement("div");
-    Object.assign(badge.style, styles.badge);
-    badge.textContent = ct('updateBadge')(version);
-
-    const iconEl = document.createElement("div");
-    Object.assign(iconEl.style, styles.icon);
-
-    const titleEl = document.createElement("div");
-    titleEl.id = "cw-changelog-title";
-    Object.assign(titleEl.style, styles.title);
-
-    const textEl = document.createElement("div");
-    Object.assign(textEl.style, styles.text);
-
-    const dotsEl = document.createElement("div");
-    Object.assign(dotsEl.style, styles.dotsContainer);
-
-    const btnNext = document.createElement("button");
-    Object.assign(btnNext.style, styles.btn);
-    btnNext.onmouseover = () => btnNext.style.transform = "scale(1.02)";
-    btnNext.onmouseout = () => btnNext.style.transform = "scale(1)";
-
-    // Montagem
-    card.appendChild(badge);
-    card.appendChild(iconEl);
-    card.appendChild(titleEl);
-    card.appendChild(textEl);
-    card.appendChild(dotsEl);
-    card.appendChild(btnNext);
-    overlay.appendChild(card);
-    document.body.appendChild(overlay);
-    lockBodyScroll();
-
-    // --- LOGICA ---
-    function renderSlide(index) {
-        const slide = SLIDES[index];
-        
-        iconEl.textContent = slide.icon;
-        titleEl.textContent = slide.title;
-        textEl.textContent = slide.text;
-
-        // Dots
-        dotsEl.innerHTML = "";
-        SLIDES.forEach((_, i) => {
-            const d = document.createElement("div");
-            Object.assign(d.style, styles.dot);
-            if (i === index) Object.assign(d.style, styles.dotActive);
-            dotsEl.appendChild(d);
-        });
-
-        // Botão
-        if (index === SLIDES.length - 1) {
-            btnNext.textContent = ct('doneBtn');
-        } else {
-            btnNext.textContent = ct('nextBtn');
-        }
-    }
-
-    function close() {
-        // Atualiza a versão no cache para não mostrar mais
-        localStorage.setItem("cw_last_version", version);
-
-        overlay.style.opacity = "0";
-        card.style.transform = "translateY(30px)";
-        setTimeout(() => overlay.remove(), 400);
-        SoundManager.playSuccess();
-        showToast(ct('updatedToast')(version));
-        document.removeEventListener("keydown", handleKeydown);
-        unlockBodyScroll();
-    }
-
-    btnNext.onclick = () => {
-        SoundManager.playClick();
-        if (currentSlide < SLIDES.length - 1) {
-            currentSlide++;
-            renderSlide(currentSlide);
-        } else {
-            close();
-        }
-    };
-
-    // Enter avança slide a slide (ou fecha no último); Esc dispensa direto -
-    // não há "pular" aqui, só o aviso do que mudou.
-    function handleKeydown(e) {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            btnNext.click();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            close();
-        }
-    }
-    document.addEventListener("keydown", handleKeydown);
-
-    // Start
-    renderSlide(0);
-    requestAnimationFrame(() => {
-        overlay.style.opacity = "1";
-        card.style.transform = "translateY(0)";
     });
-    setTimeout(() => btnNext.focus(), 450);
 }

--- a/src/modules/onboarding/onboarding-wizard.js
+++ b/src/modules/onboarding/onboarding-wizard.js
@@ -1,252 +1,131 @@
 // src/modules/onboarding/onboarding-wizard.js
+//
+// Primeira coisa que alguém vê ao abrir o Case Wizard. Toda a mecânica de
+// slides (overlay, card, dots, teclado, movimento) mora em
+// shared/wizard-shell.js, compartilhada com o Changelog - aqui fica só o que
+// é do onboarding: o conteúdo, a trava de "já viu" e o que acontece no fim.
 
-import { stylePopup, showToast, confirmDialog } from "../shared/utils.js";
-import { SoundManager } from "../shared/sound-manager.js";
-import { lockBodyScroll, unlockBodyScroll } from "../shared/dom-utils.js";
+import { showToast, confirmDialog } from "../shared/utils.js";
+import { openWizardShell } from "../shared/wizard-shell.js";
 import { getLanguage } from "../shared/i18n.js";
 
-// O idioma aqui já vem resolvido do perfil (ver app.js: initOnboarding()
-// só roda depois que a promise do idioma se resolve), então não precisa
-// reagir a mudança em runtime como os popups persistentes - é uma tela
-// única, mostrada uma vez só, no boot.
+const SEEN_KEY = "cw_onboarding_seen_v1";
+
+// Os módulos citados aqui precisam bater com os rótulos reais da paleta de
+// comandos (shared/command-palette.js) - é por esse nome que a pessoa vai
+// procurar depois. Ao renomear ou remover um módulo, este texto vem junto:
+// a versão anterior deste arquivo ainda anunciava o "Quick Email", que já
+// tinha sido substituído pelo Email Assistant e pela Minha Biblioteca - e a
+// rodada de i18n acabou traduzindo o slide errado pro espanhol junto.
+//
+// O idioma já vem resolvido do perfil quando isto roda (app.js só chama
+// initOnboarding() depois que a promise do idioma se resolve), então basta
+// ler uma vez: é uma tela única, mostrada uma vez só, no boot.
 const SLIDES_BY_LANG = {
     pt: [
         {
             icon: "🚀",
-            title: "Bem-vindo ao TechSol Suite",
-            text: "Sua nova central de operações para maximizar produtividade e padronização no CRM."
+            title: "Bem-vindo ao Case Wizard",
+            text: "Uma camada de produtividade que roda por cima do CRM. Ela não substitui nada do que você já usa — só tira o trabalho repetitivo do caminho."
+        },
+        {
+            icon: "⌨️",
+            title: "Tudo começa em dois lugares",
+            text: "A pílula flutuante, sempre no canto da tela, abre qualquer módulo com um clique. E Ctrl+K (ou ⌘K) abre a paleta de comandos: digite o que quer e vá direto, sem tirar a mão do teclado."
         },
         {
             icon: "📝",
-            title: "Notas Automáticas",
-            text: "Gere notas de caso (BAU/LM) perfeitas em segundos. Selecione o Status, as Tasks e deixe o wizard escrever o texto técnico para você."
+            title: "Notas e BAU sem retrabalho",
+            text: "O Case Notes monta a nota técnica do caso a partir do status e das tasks que você marcar. O BAU Form cuida das solicitações de criação e descarte, passo a passo."
         },
         {
-            icon: "⚡",
-            title: "Quick Email & Scripts",
-            text: "Responda e-mails com templates inteligentes que detectam o contexto e use scripts de chamada interativos que guiam seu atendimento."
+            icon: "💬",
+            title: "Na hora de falar com o cliente",
+            text: "O Email Assistant sugere templates que leem o contexto do caso, e o Call Script te guia pela chamada com um roteiro interativo — sem script decorado."
         },
         {
-            icon: "📢",
-            title: "Fique Informado",
-            text: "O módulo Broadcast traz avisos importantes e disponibilidade BAU direto na sua tela, sem precisar abrir planilhas externas."
+            icon: "📚",
+            title: "Seu material e o do time",
+            text: "Minha Biblioteca guarda seus snippets e respostas prontas. A Central de Links reúne SOPs e ferramentas, os Avisos trazem disponibilidade BAU, e os Fusos Horários respondem \"que horas são pra ele agora?\"."
         },
         {
-            icon: "✅",
-            title: "Tudo Pronto!",
-            text: "Explore o Menu Flutuante para começar. Bom trabalho!",
-            isLast: true
+            icon: "🛟",
+            title: "Nada se perde",
+            text: "O que você digita é salvo sozinho a cada poucos segundos, e dá pra estacionar um caso no meio e retomar de onde parou. Fechar a aba sem querer não custa mais nada. Bom trabalho!"
         }
     ],
     es: [
         {
             icon: "🚀",
-            title: "Bienvenido a TechSol Suite",
-            text: "Tu nueva central de operaciones para maximizar la productividad y la estandarización en el CRM."
+            title: "Bienvenido a Case Wizard",
+            text: "Una capa de productividad que funciona sobre el CRM. No reemplaza nada de lo que ya usas — solo quita el trabajo repetitivo del camino."
+        },
+        {
+            icon: "⌨️",
+            title: "Todo empieza en dos lugares",
+            text: "La píldora flotante, siempre en la esquina de la pantalla, abre cualquier módulo con un clic. Y Ctrl+K (o ⌘K) abre la paleta de comandos: escribe lo que buscas y ve directo, sin soltar el teclado."
         },
         {
             icon: "📝",
-            title: "Notas Automáticas",
-            text: "Genera notas de caso (BAU/LM) perfectas en segundos. Selecciona el Estado, las Tareas y deja que el asistente escriba el texto técnico por ti."
+            title: "Notas y BAU sin rehacer trabajo",
+            text: "Case Notes arma la nota técnica del caso a partir del estado y de las tareas que marques. BAU Form se encarga de las solicitudes de creación y descarte, paso a paso."
         },
         {
-            icon: "⚡",
-            title: "Quick Email y Scripts",
-            text: "Responde correos con plantillas inteligentes que detectan el contexto y usa scripts de llamada interactivos que guían tu atención."
+            icon: "💬",
+            title: "A la hora de hablar con el cliente",
+            text: "Email Assistant sugiere plantillas que leen el contexto del caso, y Call Script te guía por la llamada con un guion interactivo — sin nada memorizado."
         },
         {
-            icon: "📢",
-            title: "Mantente Informado",
-            text: "El módulo Broadcast trae avisos importantes y disponibilidad BAU directo a tu pantalla, sin necesidad de abrir hojas de cálculo externas."
+            icon: "📚",
+            title: "Tu material y el del equipo",
+            text: "Mi Biblioteca guarda tus fragmentos y respuestas listas. La Central de Enlaces reúne SOPs y herramientas, los Avisos traen la disponibilidad BAU, y las Zonas Horarias responden \"¿qué hora es para él ahora?\"."
         },
         {
-            icon: "✅",
-            title: "¡Todo Listo!",
-            text: "Explora el Menú Flotante para empezar. ¡Buen trabajo!",
-            isLast: true
+            icon: "🛟",
+            title: "Nada se pierde",
+            text: "Lo que escribes se guarda solo cada pocos segundos, y puedes aparcar un caso a mitad de camino y retomarlo donde lo dejaste. Cerrar la pestaña sin querer ya no cuesta nada. ¡Buen trabajo!"
         }
     ],
 };
 
 const OB_DICT = {
-    pt: { skip: "Pular", next: "Próximo", start: "Começar 🚀", skipConfirm: "Pular o tutorial?", readyToast: "Tudo pronto! Use o menu flutuante." },
-    es: { skip: "Omitir", next: "Siguiente", start: "Empezar 🚀", skipConfirm: "¿Omitir el tutorial?", readyToast: "¡Todo listo! Usa el menú flotante." },
+    pt: {
+        next: "Próximo",
+        start: "Começar 🚀",
+        skip: "Pular",
+        skipConfirm: "Pular a apresentação? Você pode explorar tudo pelo menu flutuante.",
+        readyToast: "Tudo pronto! Use o menu flutuante ou Ctrl+K.",
+    },
+    es: {
+        next: "Siguiente",
+        start: "Empezar 🚀",
+        skip: "Omitir",
+        skipConfirm: "¿Omitir la presentación? Puedes explorar todo desde el menú flotante.",
+        readyToast: "¡Todo listo! Usa el menú flotante o Ctrl+K.",
+    },
 };
 
 export function initOnboarding() {
-    // 1. Verificação de Segurança (Já viu?)
-    if (localStorage.getItem("cw_onboarding_seen_v1")) {
-        return; // Sai se já viu
-    }
+    // Trava de "já viu". Fica antes de qualquer trabalho de DOM: para a
+    // esmagadora maioria dos boots, esta função não deve fazer nada.
+    if (localStorage.getItem(SEEN_KEY)) return;
+
+    // Marca como visto na ABERTURA, não no fechamento. Se a pessoa fechar a
+    // aba no meio do tour, ela não deve reencontrar o mesmo tour no próximo
+    // boot - o objetivo é apresentar o app uma vez, não completar um fluxo.
+    localStorage.setItem(SEEN_KEY, "true");
 
     const lang = getLanguage();
-    const SLIDES = SLIDES_BY_LANG[lang] || SLIDES_BY_LANG.pt;
+    const slides = SLIDES_BY_LANG[lang] || SLIDES_BY_LANG.pt;
     const ob = OB_DICT[lang] || OB_DICT.pt;
 
-    let currentSlide = 0;
-
-    // --- ESTILOS LOCAIS ---
-    const styles = {
-        overlay: {
-            position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh",
-            backgroundColor: "rgba(0,0,0,0.6)", backdropFilter: "blur(4px)",
-            zIndex: "2147483647", // Acima de tudo
-            display: "flex", alignItems: "center", justifyContent: "center",
-            opacity: "0", transition: "opacity 0.3s ease"
-        },
-        card: {
-            width: "380px", background: "#fff", borderRadius: "24px",
-            padding: "32px", textAlign: "center", position: "relative",
-            boxShadow: "0 20px 50px rgba(0,0,0,0.3)",
-            fontFamily: "'Google Sans', Roboto, sans-serif",
-            transform: "translateY(20px)", transition: "all 0.4s cubic-bezier(0.19, 1, 0.22, 1)"
-        },
-        icon: { fontSize: "48px", marginBottom: "20px", display: "block" },
-        title: { fontSize: "22px", fontWeight: "700", color: "#202124", marginBottom: "12px" },
-        text: { fontSize: "15px", color: "#5f6368", lineHeight: "1.6", marginBottom: "32px" },
-        dotsContainer: { display: "flex", justifyContent: "center", gap: "8px", marginBottom: "24px" },
-        dot: { width: "8px", height: "8px", borderRadius: "50%", background: "#dadce0", transition: "all 0.3s" },
-        dotActive: { background: "#1a73e8", width: "24px", borderRadius: "4px" },
-        btnContainer: { display: "flex", justifyContent: "space-between", alignItems: "center" },
-        btn: {
-            padding: "10px 24px", borderRadius: "20px", border: "none", cursor: "pointer",
-            fontSize: "14px", fontWeight: "600", transition: "background 0.2s"
-        },
-        btnSkip: { background: "transparent", color: "#5f6368" },
-        btnNext: { background: "#1a73e8", color: "#fff", boxShadow: "0 4px 12px rgba(26,115,232,0.3)" }
-    };
-
-    // --- CONSTRUÇÃO DA UI ---
-    const overlay = document.createElement("div");
-    Object.assign(overlay.style, styles.overlay);
-    overlay.setAttribute("role", "dialog");
-    overlay.setAttribute("aria-modal", "true");
-    overlay.setAttribute("aria-labelledby", "cw-onboarding-title");
-
-    const card = document.createElement("div");
-    Object.assign(card.style, styles.card);
-
-    // Elementos Internos
-    const iconEl = document.createElement("div");
-    Object.assign(iconEl.style, styles.icon);
-
-    const titleEl = document.createElement("div");
-    titleEl.id = "cw-onboarding-title";
-    Object.assign(titleEl.style, styles.title);
-
-    const textEl = document.createElement("div");
-    Object.assign(textEl.style, styles.text);
-
-    const dotsEl = document.createElement("div");
-    Object.assign(dotsEl.style, styles.dotsContainer);
-
-    const actionsEl = document.createElement("div");
-    Object.assign(actionsEl.style, styles.btnContainer);
-
-    // Botões
-    const btnSkip = document.createElement("button");
-    btnSkip.textContent = ob.skip;
-    Object.assign(btnSkip.style, styles.btn, styles.btnSkip);
-    btnSkip.onmouseover = () => btnSkip.style.color = "#202124";
-    btnSkip.onmouseout = () => btnSkip.style.color = "#5f6368";
-
-    const btnNext = document.createElement("button");
-    btnNext.textContent = ob.next;
-    Object.assign(btnNext.style, styles.btn, styles.btnNext);
-    btnNext.onmouseover = () => btnNext.style.transform = "scale(1.05)";
-    btnNext.onmouseout = () => btnNext.style.transform = "scale(1)";
-
-    // Montagem
-    actionsEl.appendChild(btnSkip);
-    actionsEl.appendChild(btnNext);
-
-    card.appendChild(iconEl);
-    card.appendChild(titleEl);
-    card.appendChild(textEl);
-    card.appendChild(dotsEl);
-    card.appendChild(actionsEl);
-    overlay.appendChild(card);
-    document.body.appendChild(overlay);
-    lockBodyScroll();
-
-    // --- LÓGICA DE RENDERIZAÇÃO ---
-    function renderSlide(index) {
-        const slide = SLIDES[index];
-        
-        // Conteúdo
-        iconEl.textContent = slide.icon;
-        titleEl.textContent = slide.title;
-        textEl.textContent = slide.text;
-
-        // Dots
-        dotsEl.innerHTML = "";
-        SLIDES.forEach((_, i) => {
-            const d = document.createElement("div");
-            Object.assign(d.style, styles.dot);
-            if (i === index) Object.assign(d.style, styles.dotActive);
-            dotsEl.appendChild(d);
-        });
-
-        // Botões
-        if (slide.isLast) {
-            btnSkip.style.display = "none";
-            btnNext.textContent = ob.start;
-            btnNext.style.width = "100%";
-        } else {
-            btnSkip.style.display = "block";
-            btnNext.textContent = ob.next;
-            btnNext.style.width = "auto";
-        }
-    }
-
-    function closeWizard() {
-        localStorage.setItem("cw_onboarding_seen_v1", "true");
-        overlay.style.opacity = "0";
-        card.style.transform = "translateY(20px)";
-        setTimeout(() => overlay.remove(), 400);
-        SoundManager.playSuccess();
-        showToast(ob.readyToast);
-        document.removeEventListener("keydown", handleKeydown);
-        unlockBodyScroll();
-    }
-
-    // --- LISTENERS ---
-    btnNext.onclick = () => {
-        SoundManager.playClick();
-        if (currentSlide < SLIDES.length - 1) {
-            currentSlide++;
-            renderSlide(currentSlide);
-        } else {
-            closeWizard();
-        }
-    };
-
-    btnSkip.onclick = async () => {
-        const confirmed = await confirmDialog(ob.skipConfirm);
-        if(confirmed) closeWizard();
-    };
-
-    // Enter avança para o próximo slide, Esc equivale a "Pular" - o wizard é
-    // linear e essa é a primeira tela que um usuário novo vê, então navegar
-    // sem tirar a mão do teclado importa mais aqui do que em qualquer outro popup.
-    function handleKeydown(e) {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            btnNext.click();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            btnSkip.click();
-        }
-    }
-    document.addEventListener("keydown", handleKeydown);
-
-    // Iniciar Animação de Entrada
-    renderSlide(0);
-    requestAnimationFrame(() => {
-        overlay.style.opacity = "1";
-        card.style.transform = "translateY(0)";
+    openWizardShell({
+        slides,
+        idPrefix: "cw-onboarding",
+        nextLabel: ob.next,
+        finalLabel: ob.start,
+        skipLabel: ob.skip,
+        onSkip: () => confirmDialog(ob.skipConfirm),
+        onClose: () => showToast(ob.readyToast)
     });
-    // Foco inicial no botão de ação principal - primeiro dialog modal que um
-    // usuário novo vê, então precisa entrar já com foco em algo operável.
-    setTimeout(() => btnNext.focus(), 450);
 }

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -2,16 +2,42 @@
 
 import { getAgentEmail } from './page-data.js'; 
 
-// 1. Verifica se está rodando localmente (Live Server no VS Code/Workstation)
-const isDevelopment = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+// --- ROTEAMENTO DE AMBIENTE ---------------------------------------------
+//
+// `clasp push` só atualiza o HEAD do projeto Apps Script; as URLs /exec e
+// /dev continuam presas à versão que foi *promovida* pela última vez. Por
+// isso produção e desenvolvimento têm deployments SEPARADOS, e o frontend
+// precisa saber em qual dos dois falar - senão o bundle de produção acaba
+// conversando com o deployment que o CI republica a cada push na branch de
+// desenvolvimento (foi exatamente o que este split veio corrigir).
+//
+// Quem decide é o build: o esbuild injeta __CW_BUILD_ENV__ via --define
+// (veja .github/workflows/deploy.yml). Sem o define - rodando direto no
+// Live Server, sem passar pelo bundler - o `typeof` cai no fallback
+// "development", que é o comportamento certo pra máquina local.
+//
+// Ao rotacionar um deployment, troque o ID AQUI e, se for o de
+// desenvolvimento, também o DEPLOYMENT_ID do deploy.yml - os dois precisam
+// apontar pro mesmo lugar.
+const DEPLOYMENTS = {
+    // Promovido manualmente (`clasp deploy -i <id>`), nunca pelo CI.
+    production:  "AKfycbxFxh1cVk6r0t_JTA2TBfHBLJe_mOBQFsidwL1jwsUDcBtQYk3afu25SN-FR3vafJChHw",
+    // Promovido automaticamente pelo CI a cada push em refactor-structure.
+    development: "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg",
+};
 
-// 2. Isola o ID do seu script para manter o código limpo
-const SCRIPT_ID = "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg";
+const BUILD_ENV = typeof __CW_BUILD_ENV__ !== "undefined" ? __CW_BUILD_ENV__ : "development";
 
-// 3. Roteia automaticamente para o endpoint correto
-const API_URL = isDevelopment 
-    ? `https://script.google.com/a/macros/google.com/s/${SCRIPT_ID}/dev` 
-    : `https://script.google.com/a/macros/google.com/s/${SCRIPT_ID}/exec`;
+// Live Server local continua falando com o /dev do deployment de
+// desenvolvimento (código não publicado, iteração rápida).
+const isLocalhost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+
+const SCRIPT_ID = DEPLOYMENTS[BUILD_ENV] || DEPLOYMENTS.development;
+const ENDPOINT = isLocalhost ? "dev" : "exec";
+
+const API_URL = `https://script.google.com/a/macros/google.com/s/${SCRIPT_ID}/${ENDPOINT}`;
+
+console.log(`[Case Wizard] backend: ${BUILD_ENV}/${ENDPOINT}`);
 
 const CACHE_KEY_BROADCAST = "cw_data_broadcast";
 const CACHE_KEY_TIPS = "cw_data_tips";

--- a/src/modules/shared/wizard-shell.js
+++ b/src/modules/shared/wizard-shell.js
@@ -1,0 +1,630 @@
+// src/modules/shared/wizard-shell.js
+//
+// Casca compartilhada dos dois wizards de slides do app: o Onboarding
+// (primeira vez que alguém abre o Case Wizard) e o Changelog (quando o
+// APP_VERSION muda). Os dois nasceram como arquivos separados com ~90% do
+// mesmo código - overlay, card, dots, troca de slide, animação de entrada -
+// e foi exatamente essa duplicação que os deixou pra trás na auditoria de
+// movimento: enquanto o resto do app migrou pras 4 curvas canônicas, ganhou
+// prefers-reduced-motion e perdeu o `transition: all`, esses dois seguiram
+// com hex cravado e curva literal. Uma casca só significa que eles não
+// conseguem mais divergir.
+//
+// O que a casca resolve, além da duplicação:
+//  - tokens --cw-* e as 4 curvas canônicas, em vez de valores literais;
+//  - prefers-reduced-motion (eram os dois últimos módulos sem cobertura);
+//  - transições com propriedades explícitas, nunca `transition: all`;
+//  - navegação de teclado completa (Enter, Esc, setas, Tab preso no card)
+//    e devolução do foco pra quem estava focado antes do modal abrir;
+//  - troca de slide em cross-fade, em vez de o texto trocar seco no meio
+//    da animação;
+//  - dots clicáveis e anunciados, e uma região aria-live que lê o slide
+//    novo pra leitor de tela - antes a troca era completamente silenciosa.
+
+import { SoundManager } from "./sound-manager.js";
+import { lockBodyScroll, unlockBodyScroll } from "./dom-utils.js";
+import { getLanguage } from "./i18n.js";
+
+const STYLE_ID = "cw-wizard-shell-styles";
+
+// Texto fixo da casca (botões e rótulos de acessibilidade). O conteúdo dos
+// slides vem de quem chama - cada wizard traz o seu. O idioma já está
+// resolvido quando estes modais abrem (app.js só chama initOnboarding() e
+// checkAndShowChangelog() depois da promise do perfil), então basta ler uma
+// vez na montagem, sem reagir a troca em runtime: é uma tela única.
+const SHELL_DICT = {
+    pt: {
+        back: "Voltar",
+        skip: "Pular",
+        next: "Próximo",
+        done: "Concluir",
+        dotsGroup: "Navegação entre os slides",
+        slideLabel: (i, n) => `Slide ${i} de ${n}`,
+        announce: (i, n, title, text) => `Slide ${i} de ${n}: ${title}. ${text}`,
+    },
+    es: {
+        back: "Volver",
+        skip: "Omitir",
+        next: "Siguiente",
+        done: "Finalizar",
+        dotsGroup: "Navegación entre las diapositivas",
+        slideLabel: (i, n) => `Diapositiva ${i} de ${n}`,
+        announce: (i, n, title, text) => `Diapositiva ${i} de ${n}: ${title}. ${text}`,
+    },
+};
+
+function wt(key) {
+    const lang = getLanguage();
+    return SHELL_DICT[lang]?.[key] ?? SHELL_DICT.pt[key];
+}
+
+// Duração do cross-fade entre slides. Precisa bater com --cw-wiz-swap no CSS
+// abaixo: é o intervalo em que o conteúdo antigo já sumiu e o novo ainda não
+// entrou, ou seja, o momento certo pra trocar o texto sem que ninguém veja a
+// troca. Dessincronizar os dois é o bug clássico de "conteúdo trocou no meio
+// da animação" que a Fase 5 da auditoria caçou em 4 lugares.
+const SWAP_MS = 160;
+
+// Duração da entrada/saída do modal. Espelha --cw-wiz-shell no CSS.
+const SHELL_MS = 320;
+
+const prefersReducedMotion = () =>
+    window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+        .cw-wiz-overlay {
+            --cw-wiz-swap: ${SWAP_MS}ms;
+            --cw-wiz-shell: ${SHELL_MS}ms;
+
+            position: fixed; inset: 0;
+            background: rgba(32, 33, 36, 0.62);
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+            z-index: 2147483646;
+            display: flex; align-items: center; justify-content: center;
+            padding: 24px;
+            box-sizing: border-box;
+            opacity: 0;
+            transition: opacity var(--cw-wiz-shell) var(--cw-ease-standard);
+        }
+        .cw-wiz-overlay.open { opacity: 1; }
+
+        .cw-wiz-card {
+            position: relative;
+            width: 400px;
+            max-width: 100%;
+            max-height: 100%;
+            overflow-y: auto;
+            box-sizing: border-box;
+            background: var(--cw-surface, #fff);
+            border-radius: 24px;
+            padding: 32px;
+            text-align: center;
+            font-family: 'Google Sans', Roboto, sans-serif;
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
+            /* A entrada é o único momento em que o card se move, então
+               will-change entra aqui e sai (removeProperty) assim que a
+               animação de abertura termina - Fase 2 da auditoria. */
+            opacity: 0;
+            transform: translateY(24px) scale(0.96);
+            transition:
+                opacity var(--cw-wiz-shell) var(--cw-ease-decelerate),
+                transform var(--cw-wiz-shell) var(--cw-ease-decelerate);
+        }
+        .cw-wiz-overlay.open .cw-wiz-card {
+            opacity: 1;
+            transform: translateY(0) scale(1);
+        }
+        /* Saída usa a curva de aceleração - sai mais rápido do que entrou,
+           que é a assimetria que o resto do app já segue (genie open/close). */
+        .cw-wiz-overlay.closing .cw-wiz-card {
+            transition:
+                opacity var(--cw-wiz-shell) var(--cw-ease-accelerate),
+                transform var(--cw-wiz-shell) var(--cw-ease-accelerate);
+        }
+
+        /* "Pular" vive no canto, não no rodapé. Com ele lá embaixo eram três
+           botões numa linha de 336px úteis, e a 380px de viewport a linha
+           estourava (scrollWidth > clientWidth) espremendo o botão principal.
+           No canto ele também para de competir visualmente com a ação que a
+           gente de fato quer que a pessoa tome. */
+        .cw-wiz-card.has-skip { padding-top: 48px; }
+        .cw-wiz-skip {
+            position: absolute;
+            top: 14px; right: 16px;
+            padding: 6px 12px;
+            border: none; border-radius: 14px;
+            background: transparent;
+            color: var(--cw-text-sub, #5f6368);
+            font-family: inherit; font-size: 13px; font-weight: 600;
+            cursor: pointer;
+            transition:
+                background-color 0.2s var(--cw-ease-standard),
+                color 0.2s var(--cw-ease-standard);
+        }
+        .cw-wiz-skip:hover {
+            background: rgba(60, 64, 67, 0.08);
+            color: var(--cw-text, #202124);
+        }
+        .cw-wiz-skip:focus-visible {
+            outline: 2px solid var(--cw-primary, #1a73e8);
+            outline-offset: 2px;
+        }
+        .cw-wiz-skip[hidden] { display: none; }
+
+        .cw-wiz-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            background: #E8F0FE;
+            color: #1967D2;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+        }
+
+        /* O "palco": tudo que troca de um slide pro outro vive aqui dentro,
+           pra que o cross-fade seja UM efeito só, e não três elementos
+           desaparecendo em tempos ligeiramente diferentes. */
+        .cw-wiz-stage {
+            transition:
+                opacity var(--cw-wiz-swap) var(--cw-ease-standard),
+                transform var(--cw-wiz-swap) var(--cw-ease-standard);
+        }
+        .cw-wiz-stage.swapping-next { opacity: 0; transform: translateX(-10px); }
+        .cw-wiz-stage.swapping-prev { opacity: 0; transform: translateX(10px); }
+
+        .cw-wiz-icon { font-size: 44px; line-height: 1; margin-bottom: 18px; display: block; }
+        .cw-wiz-title {
+            font-size: 21px; font-weight: 700; line-height: 1.3;
+            color: var(--cw-text, #202124); margin-bottom: 10px;
+        }
+        .cw-wiz-text {
+            font-size: 14.5px; line-height: 1.6;
+            color: var(--cw-text-sub, #5f6368);
+            /* Reserva a altura de ~3 linhas pra que slides curtos não encolham
+               o card e slides longos não o estiquem de repente - o card
+               "pulando" entre slides era o efeito mais perceptível dos dois
+               wizards antigos. */
+            min-height: 4.8em;
+            margin-bottom: 28px;
+        }
+
+        .cw-wiz-dots {
+            display: flex; justify-content: center; align-items: center;
+            gap: 8px; margin-bottom: 22px;
+        }
+        .cw-wiz-dot {
+            width: 8px; height: 8px; padding: 0;
+            border: none; border-radius: 50%;
+            background: var(--cw-border, #dadce0);
+            cursor: pointer; appearance: none;
+            transition:
+                width var(--cw-wiz-swap) var(--cw-ease-spring),
+                background-color var(--cw-wiz-swap) var(--cw-ease-standard);
+        }
+        .cw-wiz-dot:hover { background: #bdc1c6; }
+        .cw-wiz-dot.active {
+            width: 24px; border-radius: 4px;
+            background: var(--cw-primary, #1a73e8);
+        }
+        .cw-wiz-dot:focus-visible {
+            outline: 2px solid var(--cw-primary, #1a73e8);
+            outline-offset: 3px;
+        }
+
+        .cw-wiz-actions {
+            display: flex; align-items: center; gap: 8px;
+        }
+        .cw-wiz-btn {
+            padding: 11px 24px;
+            border-radius: 20px;
+            border: none;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 14px;
+            font-weight: 600;
+            /* Propriedades explícitas: "transition: all" foi removido de ~25
+               regras na Fase 5 e não volta por aqui. */
+            transition:
+                background-color 0.2s var(--cw-ease-standard),
+                box-shadow 0.2s var(--cw-ease-standard),
+                color 0.2s var(--cw-ease-standard);
+        }
+        .cw-wiz-btn:focus-visible {
+            outline: 2px solid var(--cw-primary, #1a73e8);
+            outline-offset: 2px;
+        }
+        /* Hover é background/sombra, nunca transform. O transform no hover é o
+           anti-padrão auto-referencial que a Fase 5 removeu de 7 lugares: o
+           elemento cresce, sai de baixo do cursor, dispara mouseout, encolhe,
+           volta pro cursor - e treme. */
+        .cw-wiz-btn-primary {
+            background: var(--cw-primary, #1a73e8);
+            color: #fff;
+            box-shadow: 0 4px 12px rgba(26, 115, 232, 0.3);
+            flex: 1;
+        }
+        .cw-wiz-btn-primary:hover {
+            background: var(--cw-primary-hover, #1557b0);
+            box-shadow: 0 6px 18px rgba(26, 115, 232, 0.38);
+        }
+        .cw-wiz-btn-ghost {
+            background: transparent;
+            color: var(--cw-text-sub, #5f6368);
+        }
+        .cw-wiz-btn-ghost:hover {
+            background: rgba(60, 64, 67, 0.08);
+            color: var(--cw-text, #202124);
+        }
+        .cw-wiz-btn[hidden] { display: none; }
+
+        /* Só existe pra leitor de tela: anuncia o slide novo. Sem isso, avançar
+           o wizard é uma troca de conteúdo completamente silenciosa. */
+        .cw-wiz-live {
+            position: absolute;
+            width: 1px; height: 1px;
+            margin: -1px; padding: 0; border: 0;
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+            overflow: hidden; white-space: nowrap;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cw-wiz-overlay,
+            .cw-wiz-overlay .cw-wiz-card,
+            .cw-wiz-overlay.closing .cw-wiz-card {
+                transition: opacity 0.15s linear !important;
+                transform: none !important;
+            }
+            .cw-wiz-stage {
+                transition: none !important;
+                transform: none !important;
+            }
+            /* O conteúdo ainda precisa sumir e voltar (senão a troca acontece
+               "por baixo" e some o feedback de que algo mudou), mas sem
+               deslocamento lateral. */
+            .cw-wiz-stage.swapping-next,
+            .cw-wiz-stage.swapping-prev { opacity: 0; }
+            .cw-wiz-dot { transition: none !important; }
+        }
+
+        /* Telas baixas (notebook em CRM com várias barras): o card encosta nas
+           bordas e o conteúdo rola por dentro, em vez de estourar a viewport. */
+        @media (max-height: 560px) {
+            .cw-wiz-card { padding: 24px; }
+            .cw-wiz-icon { font-size: 34px; margin-bottom: 12px; }
+            .cw-wiz-text { min-height: 0; margin-bottom: 20px; }
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+const FOCUSABLE = 'button:not([hidden]):not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Abre um wizard de slides.
+ *
+ * @param {Object}   cfg
+ * @param {Array}    cfg.slides      [{ icon, title, text }] - pelo menos um.
+ * @param {string}   cfg.idPrefix    Prefixo pros ids de acessibilidade.
+ * @param {string}  [cfg.badge]      Selo acima do ícone (ex.: "Atualização v6.0").
+ * @param {string}  [cfg.nextLabel]  Rótulo do botão em slides intermediários.
+ * @param {string}  [cfg.finalLabel] Rótulo do botão no último slide.
+ * @param {string}  [cfg.skipLabel]  Se vier, mostra o botão de pular.
+ * @param {Function}[cfg.onSkip]     async () => boolean - confirma o skip.
+ *                                   Sem isso, pular fecha direto.
+ * @param {Function}[cfg.onClose]    Chamado quando o wizard some do DOM.
+ * @returns {{ close: Function }}
+ */
+export function openWizardShell({
+    slides,
+    idPrefix,
+    badge = null,
+    nextLabel = null,
+    finalLabel = null,
+    skipLabel = null,
+    onSkip = null,
+    onClose = () => {},
+}) {
+    // Os rótulos padrão saem do dicionário da casca; quem chama só passa
+    // um label quando quer algo mais específico que "Próximo"/"Concluir".
+    const labels = {
+        next: nextLabel || wt("next"),
+        final: finalLabel || wt("done"),
+        skip: skipLabel,
+    };
+    if (!Array.isArray(slides) || slides.length === 0) {
+        console.warn("[wizard-shell] chamado sem slides; nada a mostrar.");
+        return { close: () => {} };
+    }
+
+    injectStyles();
+
+    const titleId = `${idPrefix}-title`;
+    const textId = `${idPrefix}-text`;
+
+    // Quem estava focado antes do modal abrir. Devolvemos o foco no fechamento
+    // pra não largar o usuário no <body> - especialmente relevante aqui, onde
+    // o modal abre sozinho 2,5s depois do boot, sem ninguém ter clicado nada.
+    const previouslyFocused = document.activeElement;
+
+    let currentSlide = 0;
+    let isClosing = false;
+    let swapTimer = null;
+
+    // --- DOM ---
+    const overlay = document.createElement("div");
+    overlay.className = "cw-wiz-overlay";
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.setAttribute("aria-labelledby", titleId);
+    overlay.setAttribute("aria-describedby", textId);
+
+    const card = document.createElement("div");
+    card.className = "cw-wiz-card";
+
+    if (badge) {
+        const badgeEl = document.createElement("div");
+        badgeEl.className = "cw-wiz-badge";
+        badgeEl.textContent = badge;
+        card.appendChild(badgeEl);
+    }
+
+    const stage = document.createElement("div");
+    stage.className = "cw-wiz-stage";
+
+    const iconEl = document.createElement("div");
+    iconEl.className = "cw-wiz-icon";
+    // O ícone é decorativo - o título logo abaixo já diz a mesma coisa em
+    // palavras, então deixá-lo no fluxo faria o leitor de tela anunciar
+    // "foguete" antes de "Bem-vindo".
+    iconEl.setAttribute("aria-hidden", "true");
+
+    const titleEl = document.createElement("div");
+    titleEl.className = "cw-wiz-title";
+    titleEl.id = titleId;
+
+    const textEl = document.createElement("div");
+    textEl.className = "cw-wiz-text";
+    textEl.id = textId;
+
+    stage.appendChild(iconEl);
+    stage.appendChild(titleEl);
+    stage.appendChild(textEl);
+
+    const liveEl = document.createElement("div");
+    liveEl.className = "cw-wiz-live";
+    liveEl.setAttribute("aria-live", "polite");
+    liveEl.setAttribute("aria-atomic", "true");
+
+    const dotsEl = document.createElement("div");
+    dotsEl.className = "cw-wiz-dots";
+    dotsEl.setAttribute("role", "group");
+    dotsEl.setAttribute("aria-label", wt("dotsGroup"));
+
+    const actionsEl = document.createElement("div");
+    actionsEl.className = "cw-wiz-actions";
+
+    const btnBack = document.createElement("button");
+    btnBack.type = "button";
+    btnBack.className = "cw-wiz-btn cw-wiz-btn-ghost";
+    btnBack.textContent = wt("back");
+
+    const btnSkip = document.createElement("button");
+    btnSkip.type = "button";
+    btnSkip.className = "cw-wiz-skip";
+    btnSkip.textContent = skipLabel || wt("skip");
+    if (!skipLabel) btnSkip.hidden = true;
+
+    const btnNext = document.createElement("button");
+    btnNext.type = "button";
+    btnNext.className = "cw-wiz-btn cw-wiz-btn-primary";
+
+    actionsEl.appendChild(btnBack);
+    actionsEl.appendChild(btnNext);
+
+    // Primeiro no DOM (e portanto primeiro no Tab) porque é o primeiro
+    // elemento na leitura visual do card - canto superior direito.
+    //
+    // A folga no topo é decidida UMA vez, no mount, e não slide a slide: o
+    // "Pular" some no último slide, e alternar o padding junto faria o card
+    // encolher 16px bem no meio do cross-fade. Um vão constante é menos
+    // perceptível do que geometria que muda.
+    if (skipLabel) {
+        card.classList.add("has-skip");
+        card.appendChild(btnSkip);
+    }
+    card.appendChild(stage);
+    card.appendChild(liveEl);
+    card.appendChild(dotsEl);
+    card.appendChild(actionsEl);
+    overlay.appendChild(card);
+
+    // --- DOTS ---
+    const dots = slides.map((_, i) => {
+        const dot = document.createElement("button");
+        dot.type = "button";
+        dot.className = "cw-wiz-dot";
+        dot.setAttribute("aria-label", wt("slideLabel")(i + 1, slides.length));
+        dot.onmouseenter = () => SoundManager.playHover();
+        dot.onclick = () => {
+            if (i === currentSlide) return;
+            SoundManager.playClick();
+            goTo(i);
+        };
+        dotsEl.appendChild(dot);
+        return dot;
+    });
+
+    // --- RENDER ---
+    function paint(index) {
+        const slide = slides[index];
+        iconEl.textContent = slide.icon || "";
+        titleEl.textContent = slide.title || "";
+        textEl.textContent = slide.text || "";
+
+        dots.forEach((dot, i) => {
+            dot.classList.toggle("active", i === index);
+            dot.setAttribute("aria-current", i === index ? "true" : "false");
+        });
+
+        const isLast = index === slides.length - 1;
+        btnNext.textContent = isLast ? labels.final : labels.next;
+        btnBack.hidden = index === 0;
+        // "Pular" some no último slide: não há mais nada a pular, e a única
+        // ação que faz sentido ali é a principal.
+        btnSkip.hidden = !skipLabel || isLast;
+
+        liveEl.textContent = wt("announce")(index + 1, slides.length, slide.title, slide.text);
+    }
+
+    function goTo(index) {
+        if (isClosing || index === currentSlide) return;
+        if (index < 0 || index >= slides.length) return;
+
+        const direction = index > currentSlide ? "swapping-next" : "swapping-prev";
+        currentSlide = index;
+
+        if (prefersReducedMotion()) {
+            paint(index);
+            return;
+        }
+
+        // Fade out -> troca o conteúdo no ponto invisível -> fade in.
+        clearTimeout(swapTimer);
+        stage.classList.add(direction);
+        swapTimer = setTimeout(() => {
+            paint(index);
+            stage.classList.remove("swapping-next", "swapping-prev");
+        }, SWAP_MS);
+    }
+
+    function close({ silent = false } = {}) {
+        if (isClosing) return;
+        isClosing = true;
+        clearTimeout(swapTimer);
+
+        document.removeEventListener("keydown", handleKeydown, true);
+
+        overlay.classList.add("closing");
+        overlay.classList.remove("open");
+        card.style.willChange = "opacity, transform";
+
+        if (!silent) SoundManager.playSuccess();
+
+        setTimeout(() => {
+            overlay.remove();
+            unlockBodyScroll();
+            // Devolve o foco pra onde ele estava, se aquele elemento ainda
+            // existe e ainda é focável.
+            if (previouslyFocused && document.contains(previouslyFocused)) {
+                try { previouslyFocused.focus({ preventScroll: true }); } catch (_) {}
+            }
+            onClose();
+        }, SHELL_MS);
+    }
+
+    // --- TECLADO ---
+    // Captura (`true`) porque este modal cobre a página inteira do CRM, que
+    // tem os próprios handlers globais de tecla; sem capturar, um Enter aqui
+    // pode disparar algo por baixo antes de chegar no wizard.
+    function handleKeydown(e) {
+        if (isClosing) return;
+
+        if (e.key === "Tab") {
+            // Prende o Tab dentro do card. `aria-modal` informa o leitor de
+            // tela, mas não impede o foco de sair - isso é com a gente.
+            const focusables = Array.from(card.querySelectorAll(FOCUSABLE))
+                .filter((el) => !el.hidden && el.offsetParent !== null);
+            if (focusables.length === 0) return;
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+            return;
+        }
+
+        if (e.key === "Enter") {
+            // Enter em cima de um dot deve ativar o dot, não pular pro próximo.
+            if (document.activeElement && document.activeElement.classList.contains("cw-wiz-dot")) return;
+            e.preventDefault();
+            e.stopPropagation();
+            btnNext.click();
+        } else if (e.key === "Escape") {
+            // Esc sempre DISPENSA o modal - nunca avança slide. Quando existe
+            // um "Pular" visível, passa pela confirmação dele; senão, fecha
+            // direto (é o caso do Changelog, onde não há o que confirmar).
+            e.preventDefault();
+            e.stopPropagation();
+            if (!btnSkip.hidden) btnSkip.click();
+            else close();
+        } else if (e.key === "ArrowRight") {
+            e.preventDefault();
+            if (currentSlide < slides.length - 1) { SoundManager.playClick(); goTo(currentSlide + 1); }
+        } else if (e.key === "ArrowLeft") {
+            e.preventDefault();
+            if (currentSlide > 0) { SoundManager.playClick(); goTo(currentSlide - 1); }
+        }
+    }
+
+    // --- LISTENERS ---
+    [btnBack, btnSkip, btnNext].forEach((b) => {
+        b.onmouseenter = () => SoundManager.playHover();
+    });
+
+    btnNext.onclick = () => {
+        SoundManager.playClick();
+        if (currentSlide < slides.length - 1) goTo(currentSlide + 1);
+        else close();
+    };
+
+    btnBack.onclick = () => {
+        SoundManager.playClick();
+        goTo(currentSlide - 1);
+    };
+
+    btnSkip.onclick = async () => {
+        SoundManager.playClick();
+        if (typeof onSkip === "function") {
+            const confirmed = await onSkip();
+            if (!confirmed) return;
+        }
+        close({ silent: true });
+    };
+
+    // --- MONTAGEM ---
+    document.body.appendChild(overlay);
+    lockBodyScroll();
+    paint(0);
+
+    card.style.willChange = "opacity, transform";
+    requestAnimationFrame(() => {
+        overlay.classList.add("open");
+    });
+
+    setTimeout(() => {
+        // will-change só vale enquanto algo se move; deixá-lo permanente
+        // segura uma camada de composição à toa pelo resto da sessão.
+        card.style.removeProperty("will-change");
+        btnNext.focus({ preventScroll: true });
+    }, SHELL_MS);
+
+    document.addEventListener("keydown", handleKeydown, true);
+
+    return { close };
+}


### PR DESCRIPTION
Preparação para trazer a `main` até a `refactor-structure` (471 commits de atraso), mais a revisão dos dois modais que apresentam o app.

## 🔴 Bloqueador encontrado: produção ia herdar o backend de dev

`src/modules/shared/data-service.js` apontava para `AKfycbxkheuq...` — o **mesmo** deployment que o CI republica a cada push na `refactor-structure`. Com um merge cru para a `main`, o `bundle.js` de produção passaria a falar com o backend de desenvolvimento, reimplantado sem aviso a cada push, e o deployment de produção (`AKfycbxFxh1...`, hoje na `main`) ficaria órfão.

Agora os dois IDs convivem num mapa `DEPLOYMENTS` e o esbuild escolhe via `--define:__CW_BUILD_ENV__`, injetado por branch. Sem o define o fallback é `"development"` — que preserva exatamente o comportamento atual desta branch. Validado nos três modos de build (prod → ID de produção, dev → ID de dev, sem define → fallback).

> ⚠️ **A `main` só pode receber o merge depois que o `deploy.yml` com o `--define` estiver em vigor.**

## 🐛 Conteúdo desatualizado nos dois modais

- **Onboarding** ainda anunciava o **Quick Email**, módulo removido e substituído por Email Assistant + Minha Biblioteca — e não citava nada do que entrou depois (Ctrl+K, Biblioteca, BAU Form, estacionamento de casos). Reescrito em 6 slides usando os rótulos reais da paleta de comandos.
- **Changelog**: `APP_VERSION` era `v5.2` e `RELEASE_NOTES.version` era `v5.1` — o modal aparecia com o selo da versão nova sobre o texto da anterior, e `RELEASE_NOTES.title` sequer era renderizado. Ambos vão para **v6.0**, com as notas reescritas, e `checkAndShowChangelog` passa a suprimir o modal (com `warn`) se voltarem a divergir.

## ♻️ Casca compartilhada (`shared/wizard-shell.js`)

Os dois arquivos eram ~90% o mesmo código, e foi essa duplicação que os deixou de fora da auditoria de movimento — eram **os dois últimos módulos sem `prefers-reduced-motion`**. Unificados numa casca só:

- tokens `--cw-*` e as 4 curvas canônicas no lugar de hex e `cubic-bezier` literais; transições com propriedades explícitas, nunca `transition: all`
- `prefers-reduced-motion` em todo o modal
- hover por background/sombra — o `transform: scale(1.05)` no hover era o anti-padrão auto-referencial removido de 7 lugares na Fase 5, e nem sequer estava na lista de `transition`, então não animava
- `will-change` só durante a entrada
- teclado completo: setas, Voltar, `Tab` preso no card (`aria-modal` não prende foco sozinho) e devolução do foco ao fechar — o modal abre sozinho 2,5s após o boot, sem ninguém ter clicado nada
- região `aria-live` anunciando cada slide; ícones marcados como decorativos
- dots viram botões clicáveis e rotulados
- cross-fade na troca de slide, com a duração do `setTimeout` amarrada à do CSS por constante
- altura reservada no texto — o card parava de pular entre slides
- **"Pular" sai do rodapé para o canto superior**: com Voltar + Pular + Próximo a linha estourava a 380px de viewport (294px de conteúdo em 268px úteis)
- `z-index` 2147483646, um abaixo do `confirmDialog` — antes empatavam em 2147483647 e a confirmação só ficava por cima por ordem de DOM

## ✅ Verificação

Playwright, 29 checagens, todas passando: os dois wizards, guarda de descompasso de versão, `prefers-reduced-motion`, foco preso, scroll-lock, e layout em viewport baixa (900x520) e estreita (380x700).

## ⚠️ Falta um commit neste PR

O commit `ci: injeta __CW_BUILD_ENV__ por branch` está pronto localmente mas **não subiu**: alterar `.github/workflows/` exige o escopo OAuth `workflow`, que o token atual não tem. Precisa de `gh auth refresh -h github.com -s workflow` antes do push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)