### PR TITLE
chore: renomeia o repositório para case-wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ Since there's no localhost target, "running" the app means loading the bundle in
 **Production** (bypasses CSP via `trustedTypes`, points at the GitHub Pages–hosted `bundle.js`):
 
 ```javascript
-javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();
+javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/case-wizard/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();
 ```
 
 **Development** (points at `bundle-dev.js`, logs to console):
 
 ```javascript
-javascript:(function(){    var s = document.createElement('script');    s.src = 'https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle-dev.js?t=' + new Date().getTime();    s.onload = function() { console.log('✅ TechSol DEV carregado!'); };    s.onerror = function() { alert('❌ Erro ao carregar TechSol DEV: Arquivo não encontrado ou bloqueado.'); };    document.body.appendChild(s);})();
+javascript:(function(){    var s = document.createElement('script');    s.src = 'https://lucastdcs.github.io/case-wizard/bundle-dev.js?t=' + new Date().getTime();    s.onload = function() { console.log('✅ TechSol DEV carregado!'); };    s.onerror = function() { alert('❌ Erro ao carregar TechSol DEV: Arquivo não encontrado ou bloqueado.'); };    document.body.appendChild(s);})();
 ```
 
 Push a change to `refactor-structure`, wait for CI to finish, then click the Dev bookmarklet again to pick it up (the cache-busting timestamp forces a fresh download each click).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,7 +30,7 @@ Each branch owns one Apps Script deployment and touches only that one.
 | Development | push to `refactor-structure` | GitHub Pages `bundle-dev.js` | dev deployment, promoted by CI on every push |
 | Production | merge + push to `main` | GitHub Pages `bundle.js` | production deployment, promoted by CI on that push only |
 
-URLs: `https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle{,-dev}.js`; Apps Script `.../exec`.
+URLs: `https://lucastdcs.github.io/case-wizard/bundle{,-dev}.js`; Apps Script `.../exec`.
 
 ### Order within a deploy
 
@@ -79,4 +79,5 @@ backend is the exact state this ordering exists to prevent.
 - **`clasp push` ≠ live**: it only updates the Apps Script HEAD (visible in the editor) — the `/exec` and `/dev` URLs stay pinned to whatever was last *promoted*. Easy to assume a push "deployed" when it didn't; see `docs/WORKFLOW.md` and `README.md` → Deployment.
 - **JSONP watchdog**: every backend call times out client-side after 15s (`jsonpFetch` in `data-service.js`) if Apps Script doesn't respond — a slow/erroring deployment surfaces as a generic timeout in the browser console, not a clear backend error.
 - **`github.io` reachability**: the bookmarklet hard-depends on reaching `lucastdcs.github.io`; a corporate network block there is silent failure from the agent's point of view (see `README.md` → Troubleshooting).
+- **The Pages URL contains the repo name**: renaming the repository moves the Pages site and GitHub does *not* redirect the old Pages URL, so every installed bookmarklet would 404 silently. A shim repository under the old name keeps them alive — see `docs/decisions/0003-rename-repo-to-case-wizard.md`. **Do not delete `lucastdcs/techsol_DialIn_AutoCopy`** while pre-rename bookmarklets are still in circulation.
 - <fill in as you learn>

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -9,7 +9,7 @@
 ## What was here (before)
 
 - **Stack**: Node/JavaScript (`package.json`, `esbuild`, `playwright`), Vanilla JS frontend bundled into a browser bookmarklet, Google Apps Script backend (`gas-backend/`, synced via `clasp`), Google Sheets as the data store, no database/ORM in the traditional sense.
-- **Git**: repo with remote `origin` → `github.com/lucastdcs/techsol_DialIn_AutoCopy`. No `.env` files (secrets live in a GitHub Actions secret and hardcoded IDs).
+- **Git**: repo with remote `origin` → `github.com/lucastdcs/case-wizard`. No `.env` files (secrets live in a GitHub Actions secret and hardcoded IDs).
 - **Existing documentation was already substantial**:
   - `README.md` — detailed, project-specific (Portuguese), with screenshots and a demo video.
   - `docs/ARCHITECTURE.md`, `docs/CORE_MODULES.md`, `docs/TL_DASHBOARD_DIAGNOSTIC.md`, `docs/WORKFLOW.md`, `docs/verification/` — an established `docs/` folder.
@@ -24,7 +24,7 @@
 ## What groundrules did
 
 - **Adoption mode: Map in place.** Given `specs/` and `docs/` are pre-existing, actively-maintained conventions with their own internal logic, nothing was moved or reformatted — groundrules only recorded roles and filled genuine gaps.
-- **Project name recorded as "Case Wizard"** (the folder/repo name), chosen over the product-facing "TechSol Operations Assistant" branding and the package.json name `techsol_DialIn_AutoCopy`.
+- **Project name recorded as "Case Wizard"** (the folder/repo name), chosen over the product-facing "TechSol Operations Assistant" branding. The repository and the `package.json` name were later aligned to `case-wizard` to match (see `docs/decisions/0003-rename-repo-to-case-wizard.md`).
 - **Generated** (13 new files, all previously absent): `CLAUDE.md`, `PLAN.md`, `docs/VISION.md`, `docs/LEARNINGS.md`, `docs/GLOSSARY.md`, `docs/ROADMAP.md`, `docs/decisions/README.md` + `0000-template.md`, `docs/media/README.md`, `intake/README.md` + `intake/INTENT.md`, `CHANGELOG.md`, `RELEASE.md`.
 - **`docs/VISION.md` synthesis**: source was `README.md` (overview + features + important notes) and `specs/_MASTER_RULEBOOK.md` (philosophy + stack restrictions), captured verbatim into `intake/INTENT.md` first, then synthesized — because neither `docs/BUSINESS_RULES.md` (an empty stub) nor `specs/_MASTER_RULEBOOK.md` alone (conventions, not vision) was a clean single source.
 - **Declined optional docs, each for a specific reason** (see `.groundrules.json` → `skippedFiles`):

--- a/docs/decisions/0003-rename-repo-to-case-wizard.md
+++ b/docs/decisions/0003-rename-repo-to-case-wizard.md
@@ -1,0 +1,102 @@
+# 0003 — Rename the repository to `case-wizard`
+
+**Date**: 2026-08-20
+**Status**: Accepted
+
+## Context
+
+The repository is named `techsol_DialIn_AutoCopy` — a name left over from an early
+throwaway script that copied a dial-in field. Nothing about it describes what the
+project became: a productivity overlay for the CRM, known to everyone involved as
+**Case Wizard**. The local folder is `Case Wizard`, `docs/ADOPTION-LOG.md` records
+the project name as "Case Wizard", and every localStorage key in the frontend is
+prefixed `cw_`. The repository name was the last holdout.
+
+The reason this was not a trivial rename: **the bookmarklet's script URL contains
+the repository name**. Agents install the tool by saving a bookmark whose `src` is
+`https://lucastdcs.github.io/<repo>/bundle.js`. GitHub redirects a renamed
+repository's web, clone and push URLs indefinitely, but it does **not** redirect the
+GitHub Pages site — the Pages URL simply moves to the new name and the old one stops
+resolving. Every bookmarklet already saved would fail as a silent 404: the injected
+`<script>` never loads and nothing at all happens on screen, which is the hardest
+failure mode to diagnose from a support agent's side.
+
+## Decision
+
+Rename the repository to `case-wizard`, and immediately create a **new, empty
+repository under the old name** (`techsol_DialIn_AutoCopy`) whose `gh-pages` branch
+serves a small shim `bundle.js` / `bundle-dev.js` that loads the real bundle from
+the new URL.
+
+## Alternatives considered
+
+- **Rename with no shim, and re-distribute the bookmarklet**: rejected. It breaks
+  every installed bookmark at once, with no error message, and there is no channel
+  that reliably reaches every agent on the same day.
+- **Keep the old name forever**: rejected. The cost is permanent confusion for
+  anyone new to the project, and it only grows as more docs reference the repo.
+- **Serve the frontend from a custom domain instead**: this would decouple the
+  bookmarklet from the repository name for good, and is the better long-term answer.
+  Rejected *for now* because it needs a domain the team controls plus DNS the
+  corporate environment will resolve — a much larger change than this rename.
+
+## Consequences
+
+### Positive
+- The repository name finally matches the product, the folder, the docs and the
+  `cw_` key prefix.
+- Installed bookmarklets keep working through the shim; re-distribution becomes
+  something that can happen gradually instead of on a deadline.
+- Creating the shim repo also **occupies the old name**, which closes the window in
+  which someone else could claim `lucastdcs/techsol_DialIn_AutoCopy` and thereby
+  break GitHub's redirect of the old repository URL.
+
+### Negative / Tradeoffs
+- One extra repository to keep alive indefinitely. It has no CI and no dependencies,
+  but it must not be deleted while old bookmarklets are still in circulation.
+- The shim adds a second network hop to the load of anyone still on the old URL.
+- Anyone with an existing clone should run `git remote set-url origin
+  https://github.com/lucastdcs/case-wizard.git`. The redirect makes this optional,
+  but only until the redirect is disturbed.
+
+### Neutral
+- GitHub Actions, the `CLASPRC_JSON` secret, `gas-backend/.clasp.json`'s `scriptId`
+  and both Apps Script deployment IDs are all independent of the repository name —
+  nothing there changes.
+- Open pull requests, issues, branches and history survive a rename untouched.
+
+## Notes
+
+Order of operations (the shim must exist before the old URL is relied upon):
+
+1. Merge the docs/`package.json` changes that reference the new name.
+2. GitHub → Settings → rename the repository to `case-wizard`.
+3. `git remote set-url origin https://github.com/lucastdcs/case-wizard.git` in every
+   local clone and worktree.
+4. Confirm Pages is publishing at `https://lucastdcs.github.io/case-wizard/bundle.js`
+   (Settings → Pages; the `gh-pages` branch carries over with the rename).
+5. Create a new empty repo `techsol_DialIn_AutoCopy`, push a `gh-pages` branch
+   containing `bundle.js` and `bundle-dev.js`, each just:
+
+   ```js
+   // Shim: this repository was renamed to case-wizard.
+   // Kept alive so bookmarklets saved before the rename keep working.
+   (function () {
+     var s = document.createElement('script');
+     s.src = 'https://lucastdcs.github.io/case-wizard/bundle.js?t=' + Date.now();
+     document.body.appendChild(s);
+   })();
+   ```
+
+   (`bundle-dev.js` points at `bundle-dev.js` on the new host.) Enable Pages on that
+   repo, serving from `gh-pages`.
+
+   The shim must **not** call `trustedTypes.createPolicy('default', …)` itself. The
+   production bookmarklet already created that policy before the shim runs, and
+   creating a policy named `default` twice throws. Because the default policy is
+   already in place, the shim's plain `s.src = '…'` assignment passes through it.
+6. Verify the old bookmarklet URL still boots the app, then re-distribute the new
+   bookmarklet from `README.md` at a comfortable pace.
+
+Do the rename **after** a production release has settled, never on the same day — a
+rename plus a large deploy at once makes any breakage ambiguous.

--- a/docs/media/CaseWizardDeck.gs
+++ b/docs/media/CaseWizardDeck.gs
@@ -35,7 +35,7 @@ var FEEDBACK_FORM_URL = 'forms.gle/8icwk1TejBTDYsJS6';
 
 // Bookmarklet de produção (sempre a branch main / bundle.js), copiado
 // literalmente do README.md — não editar sem atualizar lá também.
-var INSTALL_BOOKMARKLET = "javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();";
+var INSTALL_BOOKMARKLET = "javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/case-wizard/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();";
 
 // ============================================================
 // 2. TEMA — tokens extraídos do próprio projeto (não inventados)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "techsol_DialIn_AutoCopy",
+  "name": "case-wizard",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "techsol_DialIn_AutoCopy",
+      "name": "case-wizard",
       "version": "1.0.0",
       "dependencies": {
         "esbuild": "^0.27.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "techsol_DialIn_AutoCopy",
+  "name": "case-wizard",
   "version": "1.0.0",
   "description": "TechSol Operations Assistant - Productivity Suite",
   "main": "src/app.js",


### PR DESCRIPTION
Parte versionada do rename `techsol_DialIn_AutoCopy` → `case-wizard`. **Não faz o rename sozinho** — a ordem de execução está na ADR.

## Por que não é um rename trivial

A URL do bookmarklet contém o nome do repo:
`https://lucastdcs.github.io/<repo>/bundle.js`

O GitHub redireciona web/clone/push de um repositório renomeado **para sempre**, mas **não redireciona o GitHub Pages**. Todo bookmarklet já salvo viraria um 404 silencioso — o `<script>` injetado não carrega e nada acontece na tela.

## A saída: repo-shim

Depois do rename, criar um repo **vazio com o nome antigo** cujo `gh-pages` serve um `bundle.js` de 3 linhas apontando para a URL nova. Isso:

1. mantém os bookmarklets instalados funcionando;
2. permite redistribuir o bookmarklet novo sem prazo;
3. **ocupa o nome antigo**, fechando a janela em que alguém poderia reivindicá-lo e quebrar o redirect do repositório.

Detalhe relevante: o shim **não** pode chamar `trustedTypes.createPolicy(default, …)` — o bookmarklet de produção já criou essa policy antes dele rodar, e criar `default` duas vezes lança erro. Como ela já existe, o `s.src = ...` do shim passa por ela.

## O que muda aqui

| Arquivo | Mudança |
|---|---|
| `README.md` | 2 URLs de bookmarklet |
| `RELEASE.md` | 2 URLs + nova entrada em *Known fragilities* |
| `docs/ADOPTION-LOG.md` | referência ao remote e ao nome do `package.json` |
| `package.json` | `"name"` |
| `docs/decisions/0001-…` | ADR nova, com a ordem de execução passo a passo |

## O que **não** muda

Actions, o secret `CLASPRC_JSON`, `gas-backend/.clasp.json` (`scriptId`) e os dois deployment IDs do Apps Script independem do nome do repositório. PRs, issues, branches e histórico sobrevivem intactos.

## ⚠️ Sequenciamento

Fazer o rename **depois** que o release de produção assentar, nunca no mesmo dia — rename + deploy grande juntos tornam qualquer quebra ambígua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)