### PR TITLE
docs(media): personaliza conteúdo do gerador de slides

### DIFF
--- a/docs/media/CaseWizardDeck.gs
+++ b/docs/media/CaseWizardDeck.gs
@@ -29,6 +29,14 @@ var CONFIG = {
   DRIVE_FOLDER_ID: 'COLOQUE_O_ID_DA_PASTA_AQUI',
 };
 
+// Mesmo link usado dentro do próprio app (Configurações > "Reportar
+// Bug/Sugestões", src/modules/configs/configs-assistant.js).
+var FEEDBACK_FORM_URL = 'forms.gle/8icwk1TejBTDYsJS6';
+
+// Bookmarklet de produção (sempre a branch main / bundle.js), copiado
+// literalmente do README.md — não editar sem atualizar lá também.
+var INSTALL_BOOKMARKLET = "javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();";
+
 // ============================================================
 // 2. TEMA — tokens extraídos do próprio projeto (não inventados)
 // ============================================================
@@ -73,6 +81,18 @@ var COLOR = {
 // melhorias que vem junto com este arquivo.
 var FONT = 'Roboto';
 
+// Fonte fixa (não-Google) para o bloco de código do slide de instalação
+// — "Courier New" está sempre disponível no Slides, sem o mesmo risco
+// de fallback silencioso de uma Google Font.
+var CODE_FONT = 'Courier New';
+
+function monthYearPtBr_() {
+  var MESES = ['janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
+    'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'];
+  var d = new Date();
+  return MESES[d.getMonth()] + ' de ' + d.getFullYear();
+}
+
 // ============================================================
 // 3. ENTRADA — menu e funções que você roda
 // ============================================================
@@ -103,8 +123,10 @@ function buildPresentation() {
   addBulletSlide_(ctx, 'A solução: um overlay, um clique', SOLUTION_BULLETS, { kicker: 'PROPOSTA' });
   addBulletSlide_(ctx, 'Como funciona por baixo dos panos', ARCHITECTURE_BULLETS, { kicker: 'ARQUITETURA' });
   addStackSlide_(ctx);
+  addBulletSlide_(ctx, 'Um aviso antes de começar', INSTABILITY_BULLETS, { kicker: 'LEIA ANTES' });
 
   addSectionSlide_(ctx, '02', 'Guia do Usuário — Command Center', COLOR.red);
+  addInstallSlide_(ctx);
   addShowcaseSlide_(ctx, {
     kicker: 'COMMAND CENTER', title: 'A pílula flutuante',
     description: 'Um botão só, sempre à mão: clique para abrir e acessar todos os módulos. Ctrl/Cmd+K abre a busca rápida direto.',
@@ -117,15 +139,16 @@ function buildPresentation() {
   addBulletSlide_(ctx, 'Um motor, várias vozes', EMAIL_ENGINE_BULLETS, { kicker: 'COMO FUNCIONA' });
   EMAIL_SLIDES.forEach(function (m) { addShowcaseSlide_(ctx, m); });
 
-  addSectionSlide_(ctx, '04', 'Guia do TL — BAU Dashboard', COLOR.green);
+  addSectionSlide_(ctx, '04', 'Guia do TL — BAU Dashboard', COLOR.green, 'go/cw-bau-tl');
   TL_SLIDES.forEach(function (m) { addShowcaseSlide_(ctx, m); });
 
-  addSectionSlide_(ctx, '05', 'Central de Conteúdo', COLOR.blue);
+  addSectionSlide_(ctx, '05', 'Central de Conteúdo', COLOR.blue, 'go/cw-cc');
   addBulletSlide_(ctx, 'Editar sem depender de deploy', CONTENT_CENTRAL_INTRO_BULLETS, { kicker: 'POR QUE EXISTE' });
   CONTENT_CENTRAL_SLIDES.forEach(function (m) { addShowcaseSlide_(ctx, m); });
 
   addSectionSlide_(ctx, '06', 'Próximos Passos', COLOR.red);
   addBulletSlide_(ctx, 'Roadmap', ROADMAP_BULLETS, { kicker: 'EM ABERTO' });
+  addAboutProjectSlide_(ctx);
   addClosingSlide_(ctx);
 
   if (leftoverBlank) leftoverBlank.remove();
@@ -206,6 +229,16 @@ function addText_(slide, x, y, w, h, text, opts) {
   return box;
 }
 
+function addCodeBlock_(slide, x, y, w, h, text) {
+  addRect_(slide, x, y, w, h, COLOR.dark);
+  var box = slide.insertTextBox(text, x + 16, y + 12, w - 32, h - 24);
+  var style = box.getText().getTextStyle();
+  style.setFontFamily(CODE_FONT);
+  style.setFontSize(9.5);
+  style.setForegroundColor('#E8EAED');
+  return box;
+}
+
 // Insere a imagem encaixada (contain) numa caixa x,y,maxW,maxH,
 // centralizada, preservando proporção — não deforma o print.
 function addImageFit_(slide, fileName, x, y, maxW, maxH) {
@@ -266,13 +299,16 @@ function addCoverSlide_(ctx) {
   var logo = slide.insertImage(getImageBlob_('icon-logo.png'));
   var r = logo.getHeight() / logo.getWidth();
   logo.setWidth(logoSize).setHeight(logoSize * r);
-  logo.setLeft(ctx.pageW / 2 - logoSize / 2).setTop(ctx.pageH * 0.22);
+  logo.setLeft(ctx.pageW / 2 - logoSize / 2).setTop(ctx.pageH * 0.2);
 
-  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.46, ctx.pageW * 0.8, 60,
+  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.44, ctx.pageW * 0.8, 60,
     'Case Wizard', { size: 40, bold: true, color: COLOR.ink, align: SlidesApp.ParagraphAlignment.CENTER });
-  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.58, ctx.pageW * 0.8, 30,
-    'TechSol Operations Assistant — visão geral do projeto e guia de uso',
-    { size: 15, color: COLOR.inkSoft, align: SlidesApp.ParagraphAlignment.CENTER });
+  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.56, ctx.pageW * 0.8, 30,
+    'TechSol Operations Assistant — visão geral do projeto e guia de uso para quem atende no Connect Cases',
+    { size: 14.5, color: COLOR.inkSoft, align: SlidesApp.ParagraphAlignment.CENTER });
+  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.66, ctx.pageW * 0.8, 22,
+    monthYearPtBr_(),
+    { size: 11.5, color: COLOR.inkFaint || COLOR.inkSoft, align: SlidesApp.ParagraphAlignment.CENTER });
 }
 
 function addAgendaSlide_(ctx) {
@@ -300,7 +336,7 @@ function addAgendaSlide_(ctx) {
   addFooter_(ctx, slide);
 }
 
-function addSectionSlide_(ctx, number, title, accent) {
+function addSectionSlide_(ctx, number, title, accent, link) {
   var slide = newSlide_(ctx);
   addRect_(slide, 0, 0, ctx.pageW, ctx.pageH, COLOR.dark);
   addFourColorBar_(slide, 0, ctx.pageH - 10, ctx.pageW, 10);
@@ -314,6 +350,9 @@ function addSectionSlide_(ctx, number, title, accent) {
   addText_(slide, ctx.pageW - 220, 56, 156, 60, number, { size: 48, bold: true, color: accent, align: SlidesApp.ParagraphAlignment.END });
   addText_(slide, 64, ctx.pageH * 0.44, ctx.pageW - 128, 60, title, { size: 32, bold: true, color: '#FFFFFF' });
   addRect_(slide, 64, ctx.pageH * 0.44 + 58, 64, 4, accent);
+  if (link) {
+    addText_(slide, 64, ctx.pageH * 0.44 + 74, ctx.pageW - 128, 20, 'Acesse direto em: ' + link, { size: 12, color: '#C7C9CC' });
+  }
 }
 
 function addBulletSlide_(ctx, title, bullets, opts) {
@@ -358,9 +397,45 @@ function addStackSlide_(ctx) {
   addFooter_(ctx, slide);
 }
 
+function addInstallSlide_(ctx) {
+  var slide = newSlide_(ctx);
+  addRect_(slide, 0, 0, ctx.pageW, ctx.pageH, COLOR.bg);
+  addKicker_(slide, 64, 40, 400, 'ANTES DE TUDO', COLOR.blue);
+  addText_(slide, 64, 58, ctx.pageW - 128, 34, 'Instale o bookmarklet', { size: 22, bold: true });
+
+  var steps = [
+    'Copie o código no bloco abaixo (inteiro, de "javascript:" até o final).',
+    'Na barra de favoritos do navegador, clique com o botão direito → "Adicionar página" (ou "Novo favorito").',
+    'No campo Nome, escreva exatamente: Cases Wizard',
+    'No campo URL, cole o código copiado — no lugar de um endereço normal.',
+    'Salve. Daqui pra frente, sempre que estiver no Connect Cases, clique nesse favorito para abrir o Case Wizard — essa versão aponta sempre para a branch main, a mais atual.',
+  ];
+  var top = ctx.pageH * 0.22;
+  var rowH = 24;
+  steps.forEach(function (s, i) {
+    var y = top + i * rowH;
+    addRect_(slide, 64, y + 3, 16, 16, COLOR.blue);
+    addText_(slide, 64, y + 1, 16, 16, String(i + 1), { size: 9, bold: true, color: '#FFFFFF', align: SlidesApp.ParagraphAlignment.CENTER });
+    addText_(slide, 88, y, ctx.pageW - 152, rowH, s, { size: 11, color: COLOR.ink });
+  });
+
+  var codeY = top + steps.length * rowH + 16;
+  addCodeBlock_(slide, 64, codeY, ctx.pageW - 128, ctx.pageH - codeY - 36, INSTALL_BOOKMARKLET);
+  addFooter_(ctx, slide);
+}
+
+function addAboutProjectSlide_(ctx) {
+  addBulletSlide_(ctx, 'De onde viemos', ABOUT_BULLETS, { kicker: 'SOBRE O PROJETO' });
+}
+
 // O slide-modelo reaproveitado para (quase) toda captura de tela:
 // coluna esquerda com ícone/título/descrição, coluna direita com o
 // print encaixado sobre um fundo levemente colorido pelo accent.
+//
+// A coluna esquerda usa um "cursor" vertical (cursorY) que avança depois
+// de cada elemento pela altura real dele + um respiro fixo — evita que um
+// elemento (ex.: o selo do kicker) fique embaixo do próximo (ex.: o
+// círculo do ícone), que é o que acontecia antes com posições fixas.
 function addShowcaseSlide_(ctx, opts) {
   var slide = newSlide_(ctx);
   addRect_(slide, 0, 0, ctx.pageW, ctx.pageH, COLOR.bg);
@@ -369,22 +444,35 @@ function addShowcaseSlide_(ctx, opts) {
   var leftW = ctx.pageW * 0.34;
   var rightX = margin + leftW + 28;
   var rightW = ctx.pageW - rightX - margin;
-  var contentTop = ctx.pageH * 0.16;
+  var gap = 14;
+  var cursorY = 38;
 
-  if (opts.kicker) addKicker_(slide, margin, 40, leftW, opts.kicker, opts.accent || COLOR.blue);
+  if (opts.kicker) {
+    addKicker_(slide, margin, cursorY, leftW, opts.kicker, opts.accent || COLOR.blue);
+    cursorY += 16 + gap * 0.6;
+  }
+  if (opts.link) {
+    addText_(slide, margin, cursorY, leftW, 14, 'Acesse: ' + opts.link, { size: 9.5, bold: true, color: opts.accent || COLOR.blue });
+    cursorY += 14 + gap * 0.6;
+  }
+  if (opts.icon) {
+    var badgeSize = 50;
+    addIconBadge_(slide, opts.icon, margin + badgeSize / 2, cursorY + badgeSize / 2, badgeSize, opts.accent || COLOR.blue);
+    cursorY += badgeSize + gap;
+  }
 
-  if (opts.icon) addIconBadge_(slide, opts.icon, margin + 28, contentTop + 4, 56, opts.accent || COLOR.blue);
+  addText_(slide, margin, cursorY, leftW, 30, opts.title, { size: 21, bold: true, color: COLOR.ink });
+  cursorY += 30 + 6;
 
-  var titleY = opts.icon ? contentTop + 44 : contentTop;
-  addText_(slide, margin, titleY, leftW, 60, opts.title, { size: 22, bold: true, color: COLOR.ink });
-  addText_(slide, margin, titleY + 46, leftW, 90, opts.description, { size: 12.5, color: COLOR.inkSoft });
+  var descH = 76;
+  addText_(slide, margin, cursorY, leftW, descH, opts.description, { size: 12, color: COLOR.inkSoft });
+  cursorY += descH + 2;
 
   if (opts.bullets && opts.bullets.length) {
-    var by = titleY + 46 + 92;
-    opts.bullets.forEach(function (b, i) {
-      var y = by + i * 26;
-      addRect_(slide, margin, y + 6, 6, 6, opts.accent || COLOR.blue);
-      addText_(slide, margin + 16, y, leftW - 16, 24, b, { size: 10.5, color: COLOR.ink });
+    opts.bullets.forEach(function (b) {
+      addRect_(slide, margin, cursorY + 6, 6, 6, opts.accent || COLOR.blue);
+      addText_(slide, margin + 16, cursorY, leftW - 16, 24, b, { size: 10.5, color: COLOR.ink });
+      cursorY += 24;
     });
   }
 
@@ -402,17 +490,24 @@ function addClosingSlide_(ctx) {
   addRect_(slide, 0, 0, ctx.pageW, ctx.pageH, COLOR.dark);
   addFourColorBar_(slide, 0, ctx.pageH - 10, ctx.pageW, 10);
 
-  var logoSize = 64;
+  var logoSize = 56;
   var img = slide.insertImage(getImageBlob_('icon-logo.png'));
   var r = img.getHeight() / img.getWidth();
   img.setWidth(logoSize).setHeight(logoSize * r);
-  img.setLeft(ctx.pageW / 2 - logoSize / 2).setTop(ctx.pageH * 0.32);
+  img.setLeft(ctx.pageW / 2 - logoSize / 2).setTop(ctx.pageH * 0.09);
 
-  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.52, ctx.pageW * 0.8, 40,
-    'Obrigado!', { size: 30, bold: true, color: '#FFFFFF', align: SlidesApp.ParagraphAlignment.CENTER });
-  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.62, ctx.pageW * 0.8, 24,
-    'Dúvidas e sugestões: Lucas Teixeira / TechSol Team',
-    { size: 13, color: '#9AA0A6', align: SlidesApp.ParagraphAlignment.CENTER });
+  addText_(slide, ctx.pageW * 0.1, ctx.pageH * 0.25, ctx.pageW * 0.8, 40,
+    'Obrigado!', { size: 28, bold: true, color: '#FFFFFF', align: SlidesApp.ParagraphAlignment.CENTER });
+
+  addText_(slide, ctx.pageW * 0.12, ctx.pageH * 0.4, ctx.pageW * 0.76, 24,
+    'Case Wizard é mantido por Lucas Teixeira Di Cesare Santos (lucaste).',
+    { size: 13.5, color: '#E8EAED', align: SlidesApp.ParagraphAlignment.CENTER });
+  addText_(slide, ctx.pageW * 0.12, ctx.pageH * 0.48, ctx.pageW * 0.76, 24,
+    'Encontrou um bug ou tem uma sugestão? ' + FEEDBACK_FORM_URL,
+    { size: 13, color: COLOR.modBlue, align: SlidesApp.ParagraphAlignment.CENTER });
+  addText_(slide, ctx.pageW * 0.14, ctx.pageH * 0.6, ctx.pageW * 0.72, 40,
+    'Agradecimentos especiais a joaovi, por testar o projeto e trazer ideias ao longo do caminho, e a ricardogi e santosrafael, pelo incentivo.',
+    { size: 11.5, color: '#9AA0A6', align: SlidesApp.ParagraphAlignment.CENTER });
 }
 
 // ============================================================
@@ -421,22 +516,29 @@ function addClosingSlide_(ctx) {
 // ============================================================
 
 var PROBLEM_BULLETS = [
-  'Agentes de suporte BAU/LM (PT/ES) fazem tarefas repetitivas dentro do CRM: notas, e-mails, scripts de ligação, fuso horário.',
-  'O CRM corporativo não tem automação nativa para esse fluxo, e trocar de ferramenta quebra o ritmo do atendimento.',
+  'Agentes de suporte BAU/LM (PT/ES) fazem tarefas repetitivas dentro do Connect Cases: notas, e-mails, scripts de ligação, fuso horário.',
+  'O Connect Cases não tem automação nativa para esse fluxo, e trocar de ferramenta quebra o ritmo do atendimento.',
   'Erros de padronização em notas e e-mails geram retrabalho e demoram a escalar para o time BAU.',
 ];
 
 var SOLUTION_BULLETS = [
-  '"TechSol Operations Assistant": um overlay injetado sobre o CRM real via bookmarklet — sem extensão de navegador, sem instalação.',
-  'Um clique no bookmark e a Command Center aparece flutuando sobre a tela do agente.',
+  '"TechSol Operations Assistant": um overlay injetado sobre o Connect Cases via bookmarklet — sem extensão de navegador, sem instalação.',
+  'Um clique no favorito e a Command Center aparece flutuando sobre a tela do agente.',
   'Padroniza o repetitivo (notas, e-mails, scripts) e automatiza a escalação para o time BAU.',
 ];
 
 var ARCHITECTURE_BULLETS = [
-  'O bookmarklet injeta um <script> que carrega o bundle (GitHub Pages) direto na página do CRM.',
+  'O bookmarklet injeta um <script> que carrega o bundle (GitHub Pages) direto na página do Connect Cases.',
   'Frontend fala com o backend via JSONP (não fetch) para não esbarrar em CORS — Google Apps Script responde por trás de um roteador único (op=...).',
   'Google Sheets é o banco de dados; não existe servidor ou banco tradicional.',
   'Deploy 100% automatizado por GitHub Actions a cada push — front pro GitHub Pages, backend via clasp.',
+];
+
+var INSTABILITY_BULLETS = [
+  'O Connect Cases tem instabilidades conhecidas — travamentos, campos que não carregam, timeouts. Isso não é causado pelo Case Wizard, mas como ele roda em cima do Connect Cases, os dois efeitos aparecem juntos na mesma tela.',
+  'Se uma nota ou e-mail não inserir de primeira, tente de novo antes de suspeitar do app — na maioria das vezes é o Connect Cases, não o Case Wizard.',
+  'Por isso o Case Wizard tem redundância própria: notas ficam salvas em rascunho automático (mesmo se a aba fechar ou o Connect Cases travar, o texto não se perde), e o Email Assistant limpa rascunhos "fantasmas" do Gmail antes de preencher um novo.',
+  'Encontrou um bug? Reporte pelo formulário no fim desta apresentação — cada relato ajuda a separar "bug do Case Wizard" de "instabilidade do Connect Cases".',
 ];
 
 var EMAIL_ENGINE_BULLETS = [
@@ -453,9 +555,16 @@ var CONTENT_CENTRAL_INTRO_BULLETS = [
 ];
 
 var ROADMAP_BULLETS = [
+  'Personalização por segmento do agente (Gold/Silver, OCT) chegando em breve — conteúdo e fluxos ajustados automaticamente a quem está atendendo.',
   'Completar a seção "Implementação/Tag Support" do Call Script em ES (aguardando conteúdo real do time).',
   'Revisão do espanhol por um falante nativo — prioridade para os 8 templates de e-mail e os 27 cenários de nota.',
   'Abrir espaço aqui para o que a sua equipe quiser priorizar a seguir.',
+];
+
+var ABOUT_BULLETS = [
+  'O Case Wizard começou a ser desenvolvido em outubro de 2025 e já passou por diversas atualizações até chegar nesta versão — ainda não é um projeto "fechado", e continua evoluindo.',
+  'Uma parte dos agentes já usa o Case Wizard no dia a dia, mesmo com o projeto em constante mudança.',
+  'A empresa já tem um projeto parecido, o "Case Notes 3.0" (de filipepereira) — o Case Wizard não é uma substituição a ele, é uma alternativa. Aliás, foi a inspiração inicial para começar este projeto.',
 ];
 
 var USER_MODULES = [
@@ -467,7 +576,7 @@ var USER_MODULES = [
     bullets: ['Dashboard dos próprios casos escalados', 'Fluxo de edição antes da aprovação do TL', 'Acompanhamento do status em tempo real'] },
   { kicker: 'MÓDULO', title: 'Email Assistant', accent: COLOR.modRed, icon: 'icon-email.png', image: 'modulo-email-assistant.png',
     description: 'Biblioteca de templates de e-mail com placeholders e atalhos "Smart CR".',
-    bullets: ['Detecta e limpa rascunhos "fantasmas" do Gmail', 'Templates ligados ao sub-status da nota', 'Prévia antes de preencher no CRM'] },
+    bullets: ['Detecta e limpa rascunhos "fantasmas" do Gmail', 'Templates ligados ao sub-status da nota', 'Prévia antes de preencher no Connect Cases'] },
   { kicker: 'MÓDULO', title: 'Call Script Assistant', accent: COLOR.modPurple, icon: 'icon-script.png', image: 'modulo-call-script.png',
     description: 'Checklist interativo de ligação — PT/ES/EN, fluxos BAU e LT.',
     bullets: ['Progresso visual passo a passo', 'Captura ao vivo do CID/e-mail do cliente'] },
@@ -479,10 +588,10 @@ var USER_MODULES = [
     bullets: ['Sincroniza entre dispositivos via Google Sheets', 'Estratégia cache-first: nunca trava esperando rede'] },
   { kicker: 'MÓDULO', title: 'Timezone Assistant', accent: COLOR.modTeal, icon: 'icon-timezone.png', image: 'modulo-timezones.png',
     description: 'Horário local ao vivo por país e planejador de horário de reunião.',
-    bullets: ['Evita marcar call no fuso errado do cliente'] },
+    bullets: ['Evita marcar call no fuso errado do cliente', 'Direto na pílula, sem trocar de aba para converter horário'] },
   { kicker: 'MÓDULO', title: 'Configurações', accent: COLOR.modGray, icon: 'icon-configs.png', image: 'modulo-configuracoes.png',
     description: 'Perfil do agente — papel, segmento, idioma — e preferências de som.',
-    bullets: ['Idioma herdado da planilha People, troca manual aqui'] },
+    bullets: ['Idioma herdado da planilha People, troca manual aqui', 'É também onde fica o link de feedback do projeto'] },
   { kicker: 'MÓDULO', title: 'Avisos (Broadcast)', accent: COLOR.modOrange, icon: 'icon-broadcast.png', image: 'modulo-avisos.png',
     description: 'Comunicados globais vindos do backend, com marcação de lido.',
     bullets: ['Suporte a emoji-shortcodes customizados', 'Editável pela Central de Conteúdo'] },


### PR DESCRIPTION
## Summary
- Substitui menções genéricas a "CRM" por "Connect Cases" no texto dos slides.
- Corrige um bug real de layout: o selo do kicker (ex. "MÓDULO") colidia com o círculo do ícone nos slides de showcase — `addShowcaseSlide_` agora usa um cursor vertical que soma a altura real de cada elemento.
- Novo slide de instalação (steps + código do bookmarklet de produção, nomeado "Cases Wizard").
- Novo slide avisando que o Connect Cases é instável e listando os fallbacks do projeto (autosave de notas, limpeza de rascunho fantasma no Gmail).
- Novo slide "De onde viemos": início em out/2025, uso diário já real, relação com o Case Notes 3.0 (filipepereira) como inspiração/alternativa, não substituição.
- Roadmap: adiciona personalização futura por segmento (Gold/Silver, OCT).
- Encerramento: nome completo + LDAP do mantenedor, link do formulário de feedback real, agradecimentos (joaovi, ricardogi, santosrafael).
- Capa: mês/ano calculado em tempo de execução.
- Seções 04/05: links go/cw-bau-tl e go/cw-cc no divisor de seção.
- Pequenos ajustes de texto nos módulos Timezone/Configurações/Email Assistant.

## Test plan
- [ ] `node --check` no arquivo (sintaxe válida, verificado nesta sessão)
- [ ] Rodar `buildPresentation` de novo numa apresentação já montada — idempotente, reconstrói do zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)