### PR TITLE
docs(changelog): registra o split de ambiente e a reconstrução dos wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ versions follow [Semantic Versioning](https://semver.org/).
   publicado — os dois rodavam em paralelo, e era essa corrida que permitia um
   frontend novo chamar operações que a implantação ainda não conhecia.
   Ver `docs/decisions/0004-implantacoes-apps-script-por-branch.md`.
+- **O bundle escolhe seu backend em tempo de build.** Contraparte do item acima,
+  no lado do cliente: `data-service.js` carrega os dois IDs num mapa
+  `DEPLOYMENTS` e o `esbuild` decide qual vale, pelo `--define:__CW_BUILD_ENV__`
+  que o `deploy.yml` injeta por branch. Sem o define o fallback é
+  `"development"`, então os scripts locais `npm run build` / `npm run dev`
+  também passam a flag — `build` gera o arquivo com nome de produção, e sem isso
+  seria uma armadilha silenciosa. Ver `RELEASE.md` → *Secrets & configuration*.
+- **`npm run smoke:wizards`** (25 checagens, Playwright sobre o
+  `mock-crm.html`): cobre os dois wizards de slides — cross-fade, foco preso no
+  card, scroll-lock, `prefers-reduced-motion`, conteúdo e casca em espanhol,
+  viewport baixa e estreita, e a guarda de descompasso de versão. Lê o
+  `APP_VERSION` de `src/app.js` em vez de fixar um número, para que um bump que
+  esqueça o `changelog-data.js` deixe o teste vermelho.
 - **Atalhos do Ctrl+K configuráveis por agente.** Cada pessoa escolhe os
   comandos que quer no Ctrl+K: status + substatus + os cenários que quiser (ou
   nenhum), com nome e apelido de busca próprios. Dois caminhos para criar — o
@@ -48,10 +61,35 @@ versions follow [Semantic Versioning](https://semver.org/).
   quem recebe/acessa. Ver `docs/decisions/0001-i18n-pt-es.md`.
 
 ### Changed
+- **Os wizards de Onboarding e de Changelog foram reconstruídos sobre uma casca
+  compartilhada** (`shared/wizard-shell.js`). Os dois arquivos eram ~90% o mesmo
+  código, e foi essa duplicação que os deixou de fora da auditoria de movimento:
+  eram os dois últimos módulos sem `prefers-reduced-motion`. A casca traz os
+  tokens `--cw-*` e as 4 curvas canônicas no lugar de hex e `cubic-bezier`
+  literais, transições com propriedades explícitas, navegação completa por
+  teclado (setas, Voltar, `Tab` preso no card, foco devolvido ao fechar), região
+  `aria-live` anunciando cada slide, dots clicáveis e rotulados, e cross-fade na
+  troca de slide. O "Pular" saiu do rodapé para o canto superior — com Voltar +
+  Pular + Próximo a linha estourava a 380px de viewport.
+- **Conteúdo do Onboarding reescrito** (PT e ES): ainda anunciava o "Quick
+  Email", módulo removido e substituído por Email Assistant + Minha Biblioteca,
+  e não citava Ctrl+K, Minha Biblioteca, BAU Form nem o estacionamento de casos.
+  Passa a usar os mesmos rótulos da paleta de comandos, que é por onde a pessoa
+  vai procurar depois.
 - O seletor PT/ES próprio do Notes e o do Call Script foram removidos: os dois
   módulos agora seguem o idioma único da sessão, trocado em Configurações.
 
 ### Fixed
+- **O modal de novidades mostrava o selo de uma versão sobre o texto de outra.**
+  `APP_VERSION` (`src/app.js`) estava em `v5.2` enquanto `RELEASE_NOTES.version`
+  seguia em `v5.1`: o modal abria anunciando "Atualização v5.2" com as
+  novidades da v5.1, e `RELEASE_NOTES.title` sequer era renderizado. Ambos vão
+  para **v6.0**, com as notas reescritas para o que de fato entrou, e
+  `checkAndShowChangelog` passa a suprimir o modal (com `console.warn`) se os
+  dois voltarem a divergir — melhor não mostrar nada do que mostrar errado.
+- O `confirmDialog` de "pular o tutorial" empatava em `z-index` 2147483647 com o
+  overlay do Onboarding e só ficava por cima por ordem de DOM. A casca dos
+  wizards passa a usar 2147483646, um abaixo, explicitamente.
 - **Atalhos: seis defeitos achados na revisão do próprio código.** Dois cliques
   no "Salvar" criavam dois atalhos idênticos (o id só nascia na escrita; agora
   é carimbado ao abrir o editor, e o botão fica desabilitado com estado


### PR DESCRIPTION
Entradas que faltaram no PR #284, já mergeado. O `CLAUDE.md` pede um item em `[Unreleased]` para qualquer mudança notável, e essas três são.

**Added** — deployments separados por ambiente (o bug que travava o merge para a `main`: produção ia herdar o backend de dev) e o `npm run smoke:wizards`.

**Changed** — os dois wizards reconstruídos sobre `shared/wizard-shell.js`, e o conteúdo do onboarding reescrito em PT e ES: ainda anunciava o "Quick Email", módulo removido e substituído por Email Assistant + Minha Biblioteca.

**Fixed** — o modal de novidades mostrando "Atualização v5.2" sobre o texto da v5.1, e o empate de `z-index` (2147483647) entre o `confirmDialog` e o overlay do onboarding, que só funcionava por ordem de DOM.

Só documentação; nenhum código muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)