### PR TITLE
fix(deploy): uma implantação do Apps Script por branch, promovida pelo CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,13 @@ jobs:
   # ==========================================
   build-and-deploy-frontend:
     runs-on: ubuntu-latest
+    # O backend vai PRIMEIRO, sempre. Os dois jobs rodavam em paralelo, e é
+    # essa corrida que abre a janela de erro: um frontend novo publicado
+    # antes do backend chama operações que a implantação ainda não conhece,
+    # e o agente vê só o timeout de 15s do JSONP. Na ordem inversa não há
+    # janela - backend novo com frontend antigo continua funcionando, porque
+    # operação nova que ninguém chama ainda é inofensiva.
+    needs: deploy-backend-gas
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -93,43 +100,43 @@ jobs:
           cd gas-backend
           clasp push -f
 
-      # --- PROMOÇÃO AUTOMÁTICA DA IMPLANTAÇÃO (Apenas na refactor-structure) ---
-      # `clasp push` só atualiza o HEAD do projeto (visível no editor); a URL
-      # de produção (/exec) fica travada numa versão até alguém promover uma
-      # implantação existente pra uma versão nova. Aqui automatizamos essa
-      # promoção só pro deployment de desenvolvimento (o ID abaixo é o mesmo
-      # SCRIPT_ID usado em src/modules/shared/data-service.js nesta branch —
-      # se ele for rotacionado algum dia, atualize os dois em conjunto).
-      # A implantação de produção (usada pela `main`) continua manual, de propósito.
+      # --- PROMOÇÃO DA IMPLANTAÇÃO -------------------------------------------
       #
-      # A descrição da implantação (com data/hora + commit) fica visível em
-      # "Gerenciar implantações" no editor do Apps Script, e o mesmo resumo
-      # também vai pro Job Summary desta execução do Actions — assim dá pra
-      # confirmar "a implantação de dev está na versão de tal commit, feita
-      # às tal hora" sem precisar adivinhar ou disparar uma automação manual
-      # só pra checar.
+      # `clasp push` (acima) só atualiza o HEAD do projeto - o que se vê no
+      # editor. As URLs /exec e /dev continuam presas à versão promovida pela
+      # última vez. Promover é um passo à parte, e é ELE que muda o que os
+      # agentes realmente usam.
+      #
+      # Cada branch promove a SUA implantação, e só a sua:
+      #
+      #   refactor-structure  ->  implantação de desenvolvimento
+      #   main                ->  implantação de produção
+      #
+      # Ou seja: enquanto não houver merge para a `main`, nada que se faça na
+      # branch de desenvolvimento altera a produção. O portão de produção é o
+      # merge, não um comando manual depois dele - antes, o frontend ia
+      # sozinho para produção a cada push na `main` enquanto o backend
+      # esperava alguém lembrar de promovê-lo à mão, e os dois lados
+      # divergiam em silêncio.
+      #
+      # Os IDs abaixo precisam bater com o mapa DEPLOYMENTS de
+      # src/modules/shared/data-service.js. Ao rotacionar um, mude os dois.
+      #
+      # A descrição (data/hora + commit) fica visível em "Gerenciar
+      # implantações" no editor do Apps Script, e o mesmo resumo vai pro Job
+      # Summary desta execução - dá pra confirmar em que commit cada ambiente
+      # está sem precisar abrir o editor.
+
       - name: Promover implantação de desenvolvimento
         if: github.ref == 'refs/heads/refactor-structure'
         env:
+          AMBIENTE: desenvolvimento
+          DEPLOYMENT_ID: "__NOVO_DEPLOYMENT_DEV__"
+        run: ./scripts/promote-deployment.sh
+
+      - name: Promover implantação de produção
+        if: github.ref == 'refs/heads/main'
+        env:
+          AMBIENTE: produção
           DEPLOYMENT_ID: "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg"
-        run: |
-          cd gas-backend
-
-          TIMESTAMP="$(date -u +'%Y-%m-%d %H:%M UTC')"
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          DESCRIPTION="Deploy automático - $TIMESTAMP - commit $SHORT_SHA"
-
-          DEPLOY_OUTPUT="$(clasp deploy -i "$DEPLOYMENT_ID" -d "$DESCRIPTION")"
-          echo "$DEPLOY_OUTPUT"
-
-          {
-            echo "## 🚀 Implantação de desenvolvimento atualizada"
-            echo ""
-            echo "- **Quando:** $TIMESTAMP"
-            echo "- **Commit:** \`$SHORT_SHA\` ($GITHUB_SHA)"
-            echo "- **Deployment ID:** \`$DEPLOYMENT_ID\`"
-            echo ""
-            echo '```'
-            echo "$DEPLOY_OUTPUT"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: ./scripts/promote-deployment.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
         if: github.ref == 'refs/heads/refactor-structure'
         env:
           AMBIENTE: desenvolvimento
-          DEPLOYMENT_ID: "__NOVO_DEPLOYMENT_DEV__"
+          DEPLOYMENT_ID: "AKfycbyUtczRMulDAyO_1ku39Rb01zarPMw1JvO7aNOdJPYeAgCC7G9mmb-P_EuXP6kvo8l2LA"
         run: ./scripts/promote-deployment.sh
 
       - name: Promover implantação de produção

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Uma implantação do Apps Script por branch, promovida pelo CI.** Até aqui
+  existia uma implantação só, republicada a cada push em `refactor-structure` —
+  e como o frontend inteiro apontava para ela, um push numa branch de
+  desenvolvimento republicava o backend que os agentes estavam usando. Agora
+  `refactor-structure` promove a implantação de desenvolvimento (nova) e `main`
+  promove a de produção (a que já estava em uso real), cada branch tocando
+  apenas a sua. **O merge para a `main` passa a ser o portão de produção**, sem
+  passo manual depois dele. O job do frontend declara `needs:
+  deploy-backend-gas`, de modo que o backend é promovido antes de o frontend ser
+  publicado — os dois rodavam em paralelo, e era essa corrida que permitia um
+  frontend novo chamar operações que a implantação ainda não conhecia.
+  Ver `docs/decisions/0004-implantacoes-apps-script-por-branch.md`.
 - **Atalhos do Ctrl+K configuráveis por agente.** Cada pessoa escolhe os
   comandos que quer no Ctrl+K: status + substatus + os cenários que quiser (ou
   nenhum), com nome e apelido de busca próprios. Dois caminhos para criar — o

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,26 +7,43 @@
 
 ```bash
 # Day-to-day (dev): push to refactor-structure.
-# CI builds dist/bundle-dev.js -> GitHub Pages, pushes gas-backend/ -> Apps Script HEAD,
-# AND auto-promotes the pinned dev deployment. Nothing further to do.
+# CI publishes bundle-dev.js and promotes the DEV Apps Script deployment.
+# Production is not touched by this, at all.
 git push origin refactor-structure
 
-# Production: merge refactor-structure into main and push.
-# CI builds dist/bundle.js -> GitHub Pages and pushes the backend HEAD,
-# but does NOT promote the production Apps Script deployment (deliberate).
+# Production: merge refactor-structure into main and push. That push is the
+# release — CI publishes bundle.js and promotes the PRODUCTION deployment.
+# There is no manual step afterwards.
 git checkout main && git merge refactor-structure && git push origin main
-
-# Then, manually, promote the production Apps Script deployment:
-cd gas-backend
-clasp deploy -i <production-deployment-id> -d "Release $(date -u +%F) - $(git rev-parse --short HEAD)"
 ```
+
+**The merge into `main` is the production gate.** Nothing else promotes production:
+no push to `refactor-structure`, no `clasp push` from a laptop, no manual step that
+someone has to remember. If the merge does not happen, production does not move.
 
 ## Environments
 
-| Env | Trigger | Host / target | URL |
+Each branch owns one Apps Script deployment and touches only that one.
+
+| Env | Trigger | Frontend | Apps Script deployment |
 |---|---|---|---|
-| Development | push to `refactor-structure` | GitHub Pages (`bundle-dev.js`) + Apps Script dev deployment (auto-promoted by CI) | `https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle-dev.js`; Apps Script `.../dev` |
-| Production | push to `main` (frontend + backend HEAD) then a manual `clasp deploy` (backend deployment) | GitHub Pages (`bundle.js`) + Apps Script production deployment | `https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle.js`; Apps Script `.../exec` |
+| Development | push to `refactor-structure` | GitHub Pages `bundle-dev.js` | dev deployment, promoted by CI on every push |
+| Production | merge + push to `main` | GitHub Pages `bundle.js` | production deployment, promoted by CI on that push only |
+
+URLs: `https://lucastdcs.github.io/techsol_DialIn_AutoCopy/bundle{,-dev}.js`; Apps Script `.../exec`.
+
+### Order within a deploy
+
+The `build-and-deploy-frontend` job declares `needs: deploy-backend-gas`, so **the
+backend is promoted before the frontend is published**. The two used to run in
+parallel, which is what opens the window where a new frontend calls an operation the
+live deployment does not have yet — the agent sees only the JSONP watchdog timing out
+after 15s. The reverse order has no such window: a new backend under an old frontend
+is harmless, because an operation nobody calls yet does nothing.
+
+A consequence worth knowing: if the backend job fails, the frontend is **not**
+published. That is deliberate — a half-deploy that leaves the frontend ahead of the
+backend is the exact state this ordering exists to prevent.
 
 ## Pre-release checklist
 
@@ -41,8 +58,11 @@ clasp deploy -i <production-deployment-id> -d "Release $(date -u +%F) - $(git re
 - **`scriptId`** (`gas-backend/.clasp.json`, committed) — identifies which Apps Script project `clasp push` targets. Same for both branches/environments; only the *deployment* differs.
 - **`DEPLOYMENTS`** (`src/modules/shared/data-service.js`, committed) — a map with **both** Apps Script deployment IDs, `production` and `development`. Which one the bundle uses is decided at build time, not at runtime.
 - **`__CW_BUILD_ENV__`** (`.github/workflows/deploy.yml`, injected via `esbuild --define`) — `"production"` on `main`, `"development"` on `refactor-structure`. **Any new build step must pass this flag**: without it `data-service.js` falls back to `"development"` silently, and a production bundle would start talking to the dev backend. (That is exactly the state `main` would have inherited from a plain merge before this split existed.) Building locally with no `--define` is the one case where the fallback is correct.
-- **`DEPLOYMENT_ID`** (`.github/workflows/deploy.yml`, hardcoded) — the pinned *development* deployment CI auto-promotes on `refactor-structure`. Must match `DEPLOYMENTS.development` in `data-service.js` — update both together if the deployment is ever rotated.
-- **Production deployment ID** — `DEPLOYMENTS.production` in `data-service.js`. Deliberately **not** promoted by CI; promoted manually via `clasp deploy -i <id>` or the Apps Script UI (Deploy → Manage deployments). Pushing `main` updates the frontend and the backend HEAD, never the live production deployment.
+- **`DEPLOYMENT_ID`** (`.github/workflows/deploy.yml`, hardcoded twice — once per branch) — which deployment that branch promotes. **Each ID must match the matching entry in `DEPLOYMENTS`** in `data-service.js`; rotating one means editing both files. `scripts/promote-deployment.sh` refuses to run on a placeholder ID rather than letting `clasp` fail deep in the log.
+
+> **Which ID is which, and why.** `DEPLOYMENTS.production` is the deployment that had always been in real use — the one CI kept republishing and that every agent works against. It stays production precisely because it is the one that is current; pointing production anywhere else would aim it at a deployment frozen on an old commit. The `development` deployment is the **new** one, created for this split so that pushes to `refactor-structure` stop republishing the backend everyone is using.
+>
+> The first version of this split got that backwards — it treated the ID that `main` happened to reference as production, and that one had not been promoted since March. Worth remembering: "which deployment does this branch name point at" is not the same question as "which deployment is actually live".
 
 ### App version
 

--- a/docs/decisions/0004-implantacoes-apps-script-por-branch.md
+++ b/docs/decisions/0004-implantacoes-apps-script-por-branch.md
@@ -95,13 +95,15 @@ O job do frontend declara `needs: deploy-backend-gas`: o backend é promovido
 
 ## Notes
 
-Ao criar a implantação de desenvolvimento, o ID novo precisa entrar em **dois**
-lugares:
+A implantação de desenvolvimento foi criada em 2026-08-21 e o ID já está nos dois
+lugares que precisam concordar:
 
 - `DEPLOYMENTS.development` em `src/modules/shared/data-service.js`
 - o `DEPLOYMENT_ID` do step "Promover implantação de desenvolvimento" em
   `.github/workflows/deploy.yml`
 
-Enquanto isso não acontecer, os dois arquivos carregam o placeholder
-`__NOVO_DEPLOYMENT_DEV__` e o deploy da branch de desenvolvimento falha de
-propósito, com a mensagem apontando o que fazer.
+Ao rotacionar qualquer uma das duas implantações no futuro, os dois arquivos mudam
+juntos. O `scripts/promote-deployment.sh` recusa rodar com um ID de placeholder
+(`__ALGO__`), mas **não** detecta os dois arquivos apontando para implantações
+diferentes e válidas — esse é o erro que ainda passa silencioso, e a razão de os
+dois pontos estarem listados aqui.

--- a/docs/decisions/0004-implantacoes-apps-script-por-branch.md
+++ b/docs/decisions/0004-implantacoes-apps-script-por-branch.md
@@ -1,0 +1,107 @@
+# 0004 — Uma implantação do Apps Script por branch, promovida pelo CI
+
+**Date**: 2026-08-21
+**Status**: Accepted
+
+## Context
+
+O backend do Case Wizard é um único projeto Apps Script. `clasp push` atualiza o
+**HEAD** desse projeto — o que se vê no editor —, mas as URLs `/exec` e `/dev`
+continuam presas à versão que foi **promovida** por último. Promover é um passo
+separado, e é ele que muda o que os agentes de fato usam.
+
+Até aqui existia **uma implantação só**, e o CI a republicava a cada push em
+`refactor-structure`. Como o frontend inteiro apontava para esse mesmo ID, um push
+numa branch de desenvolvimento republicava o backend de produção. Não havia
+ambiente de desenvolvimento de verdade: havia produção, e pessoas empurrando código
+para dentro dela.
+
+Do lado do frontend, o `RELEASE.md` registrava que a promoção de produção era
+manual "de propósito". Na prática esse portão não protegia nada: o frontend já ia
+sozinho para o GitHub Pages a cada push na `main`, enquanto o backend esperava
+alguém lembrar de promovê-lo à mão. O efeito real era os dois lados divergirem em
+silêncio — foi exatamente o que aconteceu no release da v6.0, em que o frontend
+novo subiu para produção conversando com uma implantação de março.
+
+Os dois jobs do workflow (`build-and-deploy-frontend` e `deploy-backend-gas`)
+também rodavam em paralelo, sem ordem garantida entre si.
+
+## Decision
+
+Cada branch passa a ter a **sua própria implantação** do Apps Script, e o CI
+promove **apenas** a implantação da branch que recebeu o push:
+
+| Branch | Implantação promovida |
+|---|---|
+| `refactor-structure` | desenvolvimento |
+| `main` | produção |
+
+**O merge para a `main` é o portão de produção** — não há passo manual depois
+dele. Enquanto o merge não acontece, nada feito na branch de desenvolvimento
+altera a produção.
+
+A implantação que já estava em uso real vira a de **produção** (ela é a que está
+em dia), e uma implantação **nova** é criada para desenvolvimento.
+
+O job do frontend declara `needs: deploy-backend-gas`: o backend é promovido
+**antes** de o frontend ser publicado.
+
+## Alternatives considered
+
+- **Manter a promoção de produção manual**: rejeitado. Era o estado anterior, e foi
+  o que produziu o skew da v6.0. Um portão que depende de alguém lembrar não é um
+  portão; e o portão de verdade — decidir o que vai para produção — já é o merge.
+- **Eleger como produção a implantação que a `main` referenciava**: foi a primeira
+  tentativa deste split, e estava errada. Aquele ID não era promovido desde março:
+  adotá-lo como produção teria feito produção *regredir* para código antigo.
+- **Dois projetos Apps Script separados** (um por ambiente), em vez de duas
+  implantações do mesmo projeto: seria o isolamento mais forte — planilhas,
+  propriedades e gatilhos separados. Rejeitado por ora pelo custo: exige duplicar o
+  `scriptId`, as credenciais e o Sheet de dados, e migrar o conteúdo. Duas
+  implantações resolvem o problema imediato (pushes de dev mexendo em produção) sem
+  isso. Fica registrado como o caminho natural caso um dia seja preciso isolar
+  *dados*, e não só versão de código.
+- **Publicar o frontend antes do backend, ou em paralelo**: rejeitado. Frontend novo
+  sobre backend antigo chama operações que não existem, e o agente vê só o watchdog
+  do JSONP estourando em 15s. Backend novo sob frontend antigo é inofensivo.
+
+## Consequences
+
+### Positive
+- Pushes em `refactor-structure` deixam de mexer no backend que os agentes usam.
+- Produção só se move quando alguém faz merge — e quando isso acontece, ela se move
+  inteira, frontend e backend, sem depender de memória humana.
+- A ordem backend-antes-de-frontend fecha a janela de erro entre os dois.
+- O estado de cada ambiente fica visível no Job Summary do Actions (data, commit e
+  ID da implantação), sem precisar abrir o editor do Apps Script.
+
+### Negative / Tradeoffs
+- Some o passo em que uma pessoa podia inspecionar o backend antes de promovê-lo.
+  Quem quiser esse portão de volta precisa exercê-lo **antes** do merge, na branch
+  de desenvolvimento — que é onde o código já está rodando de verdade.
+- Se o job do backend falhar, o frontend **não** é publicado. É deliberado, mas
+  significa que uma falha de credencial (`CLASPRC_JSON` expirado) agora bloqueia o
+  deploy inteiro, e não só metade dele.
+- Dois IDs para manter em sincronia entre `data-service.js` e `deploy.yml`. O
+  `scripts/promote-deployment.sh` protege contra o caso do placeholder, mas não
+  contra os dois arquivos apontarem para implantações diferentes e válidas.
+
+### Neutral
+- O `scriptId` (`gas-backend/.clasp.json`) continua único: é o mesmo projeto Apps
+  Script, com a mesma planilha por trás. O que se separa é a *versão publicada*,
+  não os dados.
+- Rollback não muda: continua sendo promover uma versão anterior na implantação
+  afetada (`clasp deploy -i <id> -V <n>` ou pelo editor).
+
+## Notes
+
+Ao criar a implantação de desenvolvimento, o ID novo precisa entrar em **dois**
+lugares:
+
+- `DEPLOYMENTS.development` em `src/modules/shared/data-service.js`
+- o `DEPLOYMENT_ID` do step "Promover implantação de desenvolvimento" em
+  `.github/workflows/deploy.yml`
+
+Enquanto isso não acontecer, os dois arquivos carregam o placeholder
+`__NOVO_DEPLOYMENT_DEV__` e o deploy da branch de desenvolvimento falha de
+propósito, com a mensagem apontando o que fazer.

--- a/scripts/promote-deployment.sh
+++ b/scripts/promote-deployment.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Promove UMA implantação do Apps Script para a versão que está no HEAD do
+# projeto (ou seja, o que o `clasp push -f` do passo anterior acabou de
+# enviar). Chamado por .github/workflows/deploy.yml, uma vez por ambiente.
+#
+# Existe como script, e não inline no YAML, porque os dois ambientes rodam
+# exatamente o mesmo corpo - só mudam o ID e o rótulo. Duplicar isso no
+# workflow é como uma das metades acaba ficando para trás na próxima vez que
+# alguém mexer aqui.
+#
+# Espera duas variáveis de ambiente:
+#   DEPLOYMENT_ID  o ID da implantação a promover
+#   AMBIENTE       rótulo humano ("produção" / "desenvolvimento"), só para o log
+#
+# Precisa ser rodado a partir da raiz do repositório.
+
+set -euo pipefail
+
+: "${DEPLOYMENT_ID:?DEPLOYMENT_ID não definido}"
+: "${AMBIENTE:?AMBIENTE não definido}"
+
+# Guarda contra o placeholder: enquanto a implantação de desenvolvimento não
+# tiver sido criada de verdade, é melhor o deploy falhar aqui, alto e claro,
+# do que o `clasp deploy` receber um ID inválido e o erro se perder no meio
+# do log.
+case "$DEPLOYMENT_ID" in
+    __*__)
+        echo "ERRO: DEPLOYMENT_ID de '$AMBIENTE' ainda é o placeholder ($DEPLOYMENT_ID)." >&2
+        echo "Crie a implantação e substitua o ID no deploy.yml E no mapa" >&2
+        echo "DEPLOYMENTS de src/modules/shared/data-service.js." >&2
+        exit 1
+        ;;
+esac
+
+cd gas-backend
+
+TIMESTAMP="$(date -u +'%Y-%m-%d %H:%M UTC')"
+SHORT_SHA="${GITHUB_SHA:0:7}"
+DESCRIPTION="Deploy automático ($AMBIENTE) - $TIMESTAMP - commit $SHORT_SHA"
+
+DEPLOY_OUTPUT="$(clasp deploy -i "$DEPLOYMENT_ID" -d "$DESCRIPTION")"
+echo "$DEPLOY_OUTPUT"
+
+# Sem GITHUB_STEP_SUMMARY (rodando fora do Actions) o resumo é ignorado.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        echo "## 🚀 Implantação de $AMBIENTE atualizada"
+        echo ""
+        echo "- **Quando:** $TIMESTAMP"
+        echo "- **Commit:** \`$SHORT_SHA\` (${GITHUB_SHA:-?})"
+        echo "- **Deployment ID:** \`$DEPLOYMENT_ID\`"
+        echo ""
+        echo '```'
+        echo "$DEPLOY_OUTPUT"
+        echo '```'
+    } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -38,7 +38,7 @@ const DEPLOYMENTS = {
     // desenvolvimento a toca.
     production:  "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg",
     // Promovida automaticamente a cada push em refactor-structure.
-    development: "__NOVO_DEPLOYMENT_DEV__",
+    development: "AKfycbyUtczRMulDAyO_1ku39Rb01zarPMw1JvO7aNOdJPYeAgCC7G9mmb-P_EuXP6kvo8l2LA",
 };
 
 const BUILD_ENV = typeof __CW_BUILD_ENV__ !== "undefined" ? __CW_BUILD_ENV__ : "development";

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -16,14 +16,29 @@ import { getAgentEmail } from './page-data.js';
 // Live Server, sem passar pelo bundler - o `typeof` cai no fallback
 // "development", que é o comportamento certo pra máquina local.
 //
-// Ao rotacionar um deployment, troque o ID AQUI e, se for o de
-// desenvolvimento, também o DEPLOYMENT_ID do deploy.yml - os dois precisam
-// apontar pro mesmo lugar.
+// QUAL ID É QUAL, e por quê:
+//
+// A implantação abaixo marcada como `production` é a que sempre esteve em
+// uso de fato - a que o CI vinha republicando e contra a qual todo mundo
+// trabalha. Ela continua sendo a de produção justamente por isso: ela já
+// está em dia, e trocar produção para outro lugar significaria apontá-la
+// para uma implantação parada num commit antigo. (Foi o erro da primeira
+// versão deste split: ele elegeu como produção a implantação que a `main`
+// referenciava, e que não era promovida desde março.)
+//
+// A de `development` é NOVA, criada só para este split. Ela existe para que
+// pushes na branch de desenvolvimento parem de mexer no que os agentes
+// usam: antes, um único ID servia aos dois, então cada push republicava o
+// backend de todo mundo.
+//
+// Ao rotacionar um deployment, troque o ID AQUI e também o do
+// .github/workflows/deploy.yml - os dois precisam apontar pro mesmo lugar.
 const DEPLOYMENTS = {
-    // Promovido manualmente (`clasp deploy -i <id>`), nunca pelo CI.
-    production:  "AKfycbxFxh1cVk6r0t_JTA2TBfHBLJe_mOBQFsidwL1jwsUDcBtQYk3afu25SN-FR3vafJChHw",
-    // Promovido automaticamente pelo CI a cada push em refactor-structure.
-    development: "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg",
+    // Promovida SÓ quando um merge chega na `main`. Nenhum push na branch de
+    // desenvolvimento a toca.
+    production:  "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg",
+    // Promovida automaticamente a cada push em refactor-structure.
+    development: "__NOVO_DEPLOYMENT_DEV__",
 };
 
 const BUILD_ENV = typeof __CW_BUILD_ENV__ !== "undefined" ? __CW_BUILD_ENV__ : "development";


### PR DESCRIPTION
## O problema real

Existia **uma implantação só** do Apps Script, republicada a cada push em `refactor-structure`. Como o frontend inteiro apontava para ela, **um push numa branch de desenvolvimento republicava o backend que os agentes estavam usando**. Não havia ambiente de dev: havia produção, e gente empurrando código para dentro dela.

## Qual ID vira o quê — e por que eu tinha errado

A implantação que **sempre esteve em uso de fato** (`AKfycbxkheuq…`) passa a ser a de **produção**, justamente porque é a que está em dia. A de desenvolvimento é **nova**, criada só para este split.

A primeira versão do split (PR #284) fez o contrário: elegeu como produção o ID que a `main` referenciava (`AKfycbxFxh1…`), que **não era promovido desde março**. O resultado foi o release da v6.0 subir com frontend novo conversando com backend de março.

> A lição que fica registrada na ADR: *"qual implantação o nome da branch aponta"* não é a mesma pergunta que *"qual implantação está viva"*.

## Promoção por branch

| Branch | Promove |
|---|---|
| `refactor-structure` | implantação de **desenvolvimento** |
| `main` | implantação de **produção** |

**O merge para a `main` vira o portão de produção** — não há passo manual depois dele. Enquanto o merge não vier, nada feito em desenvolvimento altera a produção.

Isso **reverte** a decisão registrada no `RELEASE.md` de manter a promoção manual "de propósito". Aquele portão não protegia nada: o frontend já ia sozinho para o Pages a cada push na `main`, enquanto o backend esperava alguém lembrar de promovê-lo. O efeito real era os dois lados divergirem em silêncio. O portão de verdade sempre foi o merge.

## Ordem entre os jobs

`build-and-deploy-frontend` agora declara `needs: deploy-backend-gas`. Os dois rodavam **em paralelo**, e era essa corrida que abria a janela em que um frontend novo chama operação que a implantação ainda não tem — e o agente vê só o watchdog do JSONP estourando em 15s. Backend novo sob frontend antigo é inofensivo.

Efeito colateral deliberado: **se o backend falhar, o frontend não é publicado.** Um meio-deploy que deixa o frontend à frente do backend é exatamente o estado que essa ordem existe para impedir.

## `scripts/promote-deployment.sh`

O corpo da promoção virou script em vez de ficar inline duas vezes no YAML — duplicado, uma das metades acabaria ficando para trás. Recusa rodar com ID de placeholder, alto e claro, em vez de deixar o `clasp` falhar no meio do log.

## ⚠️ Pendente: criar a implantação de desenvolvimento

O ID novo precisa entrar em **dois** lugares:

- `DEPLOYMENTS.development` em `src/modules/shared/data-service.js`
- o `DEPLOYMENT_ID` do step *"Promover implantação de desenvolvimento"* em `.github/workflows/deploy.yml`

Até lá os dois carregam `__NOVO_DEPLOYMENT_DEV__` e o deploy da branch de desenvolvimento **falha de propósito**, com a mensagem apontando o que fazer. **Não mergear antes de preencher.**

## Verificação

- YAML validado (o `needs` e os dois `if` de branch conferidos por parser)
- guarda do placeholder testada (sai 1 com mensagem)
- build de produção resolvendo para o ID certo
- `npm run smoke:wizards` verde (25/25)

Ver `docs/decisions/0004-implantacoes-apps-script-por-branch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)