### PR TITLE
fix(ci): chama o script de promoção por 'bash', não pelo bit de execução

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,11 +132,11 @@ jobs:
         env:
           AMBIENTE: desenvolvimento
           DEPLOYMENT_ID: "AKfycbyUtczRMulDAyO_1ku39Rb01zarPMw1JvO7aNOdJPYeAgCC7G9mmb-P_EuXP6kvo8l2LA"
-        run: ./scripts/promote-deployment.sh
+        run: bash scripts/promote-deployment.sh
 
       - name: Promover implantação de produção
         if: github.ref == 'refs/heads/main'
         env:
           AMBIENTE: produção
           DEPLOYMENT_ID: "AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg"
-        run: ./scripts/promote-deployment.sh
+        run: bash scripts/promote-deployment.sh

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -12,6 +12,33 @@ Include the minimal code snippet / command when it is the fix.
 
 ---
 
+## Script versionado é chamado pelo interpretador (`bash x.sh`), nunca por `./x.sh`
+
+**Why**: o `scripts/promote-deployment.sh` foi criado, `chmod +x` rodou sem erro,
+`bash -n` passou, o commit entrou — e o deploy da `refactor-structure` morreu com
+`Permission denied` / exit 126 (2026-08-21). O motivo: este repositório vive num
+volume Windows montado (`/mnt/c/...` no WSL), e o drvfs não persiste o bit de
+execução. O `chmod` "funciona" localmente e o git grava `100644` mesmo assim, então
+o erro só aparece no CI, depois do merge — e, por causa do `needs:` entre os jobs,
+derruba o deploy inteiro, não só aquele step.
+
+O sintoma é traiçoeiro porque tudo que se testa localmente passa: a sintaxe, a
+execução via `bash`, o `git add`. O único lugar onde a diferença aparece é
+`git ls-files -s`, que mostra `100644` onde se esperava `100755`.
+
+**When to apply**: ao adicionar **qualquer** arquivo executável ao repositório.
+
+- No workflow/`package.json`, invoque pelo interpretador — `bash scripts/x.sh`,
+  `node scripts/x.mjs` —, que é o que o resto do `scripts/` já faz.
+- Se ainda assim quiser o bit correto no git (para quem clona em Linux), ele
+  precisa ser setado no índice, não no filesystem:
+  ```bash
+  git update-index --chmod=+x scripts/x.sh
+  git ls-files -s scripts/x.sh   # confirme 100755
+  ```
+
+---
+
 ## Texto escrito pelo agente entra no DOM por `textContent`, nunca por `innerHTML`
 
 **Why**: na revisão dos atalhos do Ctrl+K (2026-08-20), o **nome** do atalho

--- a/scripts/promote-deployment.sh
+++ b/scripts/promote-deployment.sh
@@ -14,6 +14,13 @@
 #   AMBIENTE       rótulo humano ("produção" / "desenvolvimento"), só para o log
 #
 # Precisa ser rodado a partir da raiz do repositório.
+#
+# O workflow chama isto como `bash scripts/promote-deployment.sh`, e não
+# `./scripts/...`, de propósito: o repositório costuma ser clonado num volume
+# Windows montado (/mnt/c no WSL), onde o bit de execução não persiste - um
+# `chmod +x` local "funciona" mas o git grava 100644, e o step morre com
+# "Permission denied" (exit 126) só no CI. Invocar pelo interpretador tira o
+# modo do arquivo da equação, do mesmo jeito que os `node scripts/*.mjs` daqui.
 
 set -euo pipefail
 


### PR DESCRIPTION
Conserta o deploy da `refactor-structure`, que morreu no merge do #288 com `Permission denied` (exit 126).

## Causa

`chmod +x` rodou sem erro local e `bash -n` passou, mas este repositório vive num **volume Windows montado** (`/mnt/c` no WSL) e o drvfs não persiste o bit de execução. O git gravou `100644`, e o erro só apareceu no CI, depois do merge.

Como o job do frontend declara `needs: deploy-backend-gas`, isso derrubou o deploy **inteiro** — o frontend foi pulado. Vale notar que essa parte funcionou como projetado: em vez de publicar um frontend contra um backend que não subiu, o pipeline parou.

## Correção

Duas, porque uma só não basta:

- o workflow passa a invocar **`bash scripts/promote-deployment.sh`**, tirando o modo do arquivo da equação — é o que os `node scripts/*.mjs` daqui já fazem por tabela;
- o bit vai para o índice via `git update-index --chmod=+x`, para quem clona em Linux ter o arquivo executável de verdade (o commit registra `mode change 100644 => 100755`).

## `docs/LEARNINGS.md`

Entrada nova. O sintoma engana porque **tudo passa localmente** — sintaxe, execução via `bash`, `git add`. O único lugar onde a diferença aparece é `git ls-files -s`, mostrando `100644` onde se esperava `100755`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)