### PR TITLE
feat(env): marca visível de ambiente no app e nos dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Marca visível de ambiente, no app e nos dashboards.** Em desenvolvimento a
+  pílula ganha um anel âmbar (colapsada) e um selo "Dev" (aberta), e os
+  dashboards de TL e da Central de Conteúdo mostram um chip âmbar no canto. Em
+  produção não aparece nada — a decisão foi não pôr chrome extra na tela de quem
+  está trabalhando. O contrapeso é **Configurações → Diagnóstico**, que mostra o
+  ambiente SEMPRE, inclusive em produção, para que "estou em produção" seja uma
+  confirmação positiva e não a ausência de um selo (ausência também é o que se vê
+  quando algo não renderizou).
+  Junto vai o sufixo da implantação (últimos 6 caracteres do ID): é ele que prova
+  a separação, porque **o sufixo no app tem de bater com o do dashboard**. Os
+  dashboards não confiam numa constante compilada — descobrem a implantação pelo
+  `ScriptApp.getService().getUrl()` da própria requisição, e uma implantação fora
+  do mapa aparece em vermelho como "IMPLANTAÇÃO DESCONHECIDA" em vez de ser
+  tratada como produção.
+  Coberto por `npm run test:deployment-env` (9 casos) e `npm run smoke:env-badge`
+  (11 checagens, os dois builds num navegador real).
 - **Uma implantação do Apps Script por branch, promovida pelo CI.** Até aqui
   existia uma implantação só, republicada a cada push em `refactor-structure` —
   e como o frontend inteiro apontava para ela, um push numa branch de

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ TechSol Operations Assistant — a productivity and automation suite for a corpo
 
 - Install deps: `npm install`
 - Run dev: `npm run dev` — builds `dist/bundle-dev.js`; there is no localhost target, load it into the real CRM via the Dev bookmarklet (see `README.md`)
-- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts` and `npm run smoke:wizards` drive the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
+- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` · `test:deployment-env` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts`, `smoke:wizards` and `smoke:env-badge` drive the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
 - Lint: none configured
 - Build: `npm run build` — builds `dist/bundle.js` (minified, production)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,34 @@ Each branch owns one Apps Script deployment and touches only that one.
 
 URLs: `https://lucastdcs.github.io/case-wizard/bundle{,-dev}.js`; Apps Script `.../exec`.
 
+### Telling the two apart at a glance
+
+Every surface says which deployment it is talking to, so a leak between
+environments is visible instead of inferred:
+
+| Where | Development | Production |
+|---|---|---|
+| Floating pill | amber ring when collapsed, "Dev" badge when open | nothing |
+| Settings → Diagnóstico | `DEV · …xxxxxx` | `PROD · …xxxxxx` |
+| Browser console at boot | `[Case Wizard] backend: development/exec · implantação …xxxxxx` | same, `production` |
+| TL / Content dashboards | amber chip, bottom-left | nothing |
+
+**Production shows no badge on purpose** — no extra chrome for the agent. The
+Settings block and the console line are always present in both environments, so
+"I am in production" stays a positive confirmation rather than the absence of a
+badge (absence is also what a failed render looks like).
+
+The `…xxxxxx` suffix is the last 6 characters of the deployment ID, and it is
+what actually proves the split: **the suffix in the app and the suffix in the
+dashboard must match**. If they differ, the frontend and the backend are on
+different deployments. A dashboard served by a deployment that is in neither map
+renders a red "IMPLANTAÇÃO DESCONHECIDA" chip rather than guessing.
+
+Covered by `npm run test:deployment-env` (the backend mapping, including the
+unknown-deployment case) and `npm run smoke:env-badge` (both builds in a real
+browser — notably that the badge is *absent from the DOM* in production, not
+merely hidden).
+
 ### Order within a deploy
 
 The `build-and-deploy-frontend` job declares `needs: deploy-backend-gas`, so **the

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -618,6 +618,8 @@
 </head>
 
 <body>
+    <?!= CW_ENV_BADGE ?>
+
     <div class="ambient-glow"></div>
 
     <nav class="topnav">

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -16,6 +16,131 @@ const SHEET_USER_PREFS = "User_Prefs";
 // caminho, não na célula. Com 8 atalhos o blob fica na casa de 1 KB.
 const USER_PREFS_MAX_BYTES = 8000;
 
+// ---------------------------------------------------------------------------
+// AMBIENTE DA IMPLANTAÇÃO
+//
+// Produção e desenvolvimento são duas IMPLANTAÇÕES do mesmo projeto Apps
+// Script (ver docs/decisions/0004-implantacoes-apps-script-por-branch.md). O
+// código é idêntico nas duas - o que difere é qual delas atendeu a chamada.
+//
+// `ScriptApp.getService().getUrl()` devolve a URL da implantação que está
+// servindo ESTA requisição, e cada implantação tem a sua. É por isso que o
+// dashboard descobre o ambiente sozinho, em vez de confiar numa constante
+// compilada: uma constante repetiria o que alguém digitou, e o que se quer
+// provar aqui é justamente que o roteamento está certo.
+//
+// Ressalva importante, já registrada em BAU_Alerts.js: em contexto de GATILHO
+// DE TEMPO essa chamada pode devolver a URL de outra implantação. Por isso
+// esta função só é usada no caminho de doGet (requisição web), nunca em
+// gatilho.
+const CW_DEPLOYMENTS = {
+  // Precisa bater com o mapa DEPLOYMENTS de src/modules/shared/data-service.js
+  // e com os DEPLOYMENT_ID do .github/workflows/deploy.yml. Ao rotacionar uma
+  // implantação, os três mudam juntos.
+  production: 'AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg',
+  development: 'AKfycbyUtczRMulDAyO_1ku39Rb01zarPMw1JvO7aNOdJPYeAgCC7G9mmb-P_EuXP6kvo8l2LA',
+};
+
+/**
+ * Descobre em qual implantação este request está rodando.
+ *
+ * @returns {{env: string, isDev: boolean, fingerprint: string}}
+ *   `env` é 'production', 'development' ou 'unknown'. 'unknown' aparece se a
+ *   URL não casar com nenhum dos IDs conhecidos - o caso de uma implantação
+ *   nova que ninguém registrou aqui. Mostrar 'unknown' é melhor que assumir
+ *   produção: um ambiente não identificado é exatamente o que se quer ver.
+ */
+function getDeploymentEnv() {
+  var url = '';
+  try {
+    url = ScriptApp.getService().getUrl() || '';
+  } catch (err) {
+    // Sem contexto de web app (execução manual no editor, por exemplo).
+    return { env: 'unknown', isDev: true, fingerprint: '------' };
+  }
+
+  for (var env in CW_DEPLOYMENTS) {
+    var id = CW_DEPLOYMENTS[env];
+    if (url.indexOf(id) !== -1) {
+      return { env: env, isDev: env !== 'production', fingerprint: id.slice(-6) };
+    }
+  }
+
+  // Extrai o ID da própria URL para que o selo mostre ALGO comparável mesmo
+  // sem casar com o mapa - é essa string que denuncia qual implantação
+  // desconhecida respondeu.
+  var m = url.match(/\/s\/([^\/]+)\//);
+  return {
+    env: 'unknown',
+    isDev: true,
+    fingerprint: m ? m[1].slice(-6) : '------',
+  };
+}
+
+/**
+ * HTML do selo de ambiente, ou string vazia em produção.
+ *
+ * Fica montado aqui, e não repetido dentro de cada dashboard, para que os dois
+ * não possam divergir - mesma razão pela qual os wizards do frontend passaram
+ * a dividir uma casca só.
+ *
+ * Em PRODUÇÃO não devolve nada: a decisão foi não pôr chrome extra na tela de
+ * quem está trabalhando. Quem precisa confirmar produção compara o sufixo em
+ * Configurações → Diagnóstico, no app.
+ *
+ * Chip flutuante no canto inferior esquerdo, de propósito: uma faixa no topo
+ * empurraria o layout dos dois dashboards, e o canto não disputa espaço com a
+ * topnav nem com os cards.
+ */
+function buildEnvBadgeHtml(info) {
+  if (!info.isDev) return '';
+
+  var desconhecido = info.env === 'unknown';
+  // Vermelho para implantação não reconhecida - esse caso merece mais alarme
+  // que "estou em dev", porque significa que alguém publicou de um lugar que
+  // este código não conhece.
+  var fundo = desconhecido ? '#FCE8E6' : '#FEF7E0';
+  var borda = desconhecido ? '#F5C6C1' : '#FEEFC3';
+  var texto = desconhecido ? '#C5221F' : '#B06000';
+  var rotulo = desconhecido ? 'IMPLANTAÇÃO DESCONHECIDA' : 'DESENVOLVIMENTO';
+
+  return '' +
+    '<div id="cw-env-banner" role="status" style="' +
+      'position:fixed; left:16px; bottom:16px; z-index:99999;' +
+      'display:flex; align-items:center; gap:8px;' +
+      'padding:8px 14px; border-radius:100px;' +
+      'background:' + fundo + '; border:1px solid ' + borda + '; color:' + texto + ';' +
+      'font-family:\'Google Sans\', Roboto, sans-serif; font-size:11px; font-weight:700;' +
+      'letter-spacing:0.6px; box-shadow:0 2px 10px rgba(0,0,0,0.12); pointer-events:none;' +
+    '">' +
+      '<span>' + rotulo + '</span>' +
+      '<span style="font-family:ui-monospace, monospace; font-weight:600; opacity:0.85;">' +
+        '…' + info.fingerprint +
+      '</span>' +
+    '</div>';
+}
+
+/**
+ * Serve um dashboard já com o selo de ambiente injetado.
+ *
+ * Usa createTemplateFromFile (e não createHtmlOutputFromFile) só por causa
+ * dessa injeção. Os dois HTML não contêm nenhuma sequência `<?`, então passar
+ * pelo avaliador de template é seguro - se um dia passarem a conter, é aqui
+ * que vai quebrar.
+ */
+function renderDashboard(fileName, title) {
+  var info = getDeploymentEnv();
+  var template = HtmlService.createTemplateFromFile(fileName);
+
+  // Consumido por <?!= CW_ENV_BADGE ?> logo depois do <body> de cada dashboard.
+  template.CW_ENV_BADGE = buildEnvBadgeHtml(info);
+
+  return template.evaluate()
+    .setTitle(title)
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+}
+
 function doGet(e) {
   // Fallback para testes manuais
   if (!e) e = { parameter: { op: 'broadcast' } };
@@ -26,10 +151,7 @@ function doGet(e) {
   const callback = p.callback;
 
   if (e.parameter.page === 'tl') {
-    return HtmlService.createHtmlOutputFromFile('TLDashboard')
-      .setTitle('Cases Wizard | Visão TL')
-      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
-      .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+    return renderDashboard('TLDashboard', 'Cases Wizard | Visão TL');
   }
 
   // Central de Conteúdo - página própria, deliberadamente fora do TLDashboard:
@@ -38,10 +160,7 @@ function doGet(e) {
   // Quem não tem papel em Content_Access vê a tela responder "sem acesso" -
   // o gate real é por ação, no ContentAPI.gs.
   if (e.parameter.page === 'content') {
-    return HtmlService.createHtmlOutputFromFile('ContentDashboard')
-      .setTitle('Cases Wizard | Central de Conteúdo')
-      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
-      .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+    return renderDashboard('ContentDashboard', 'Cases Wizard | Central de Conteúdo');
   }
 
   

--- a/gas-backend/TLDashboard.html
+++ b/gas-backend/TLDashboard.html
@@ -715,6 +715,8 @@
 
 <body>
 
+    <?!= CW_ENV_BADGE ?>
+
     <div class="ambient-glow"></div>
 
     <div id="toast" class="toast" role="status" aria-live="polite">

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "test:note-templates": "node scripts/test-note-templates.mjs",
     "test:shortcuts": "node scripts/test-shortcuts.mjs",
     "test:prefs": "node scripts/test-user-prefs.js",
+    "test:deployment-env": "node scripts/test-deployment-env.js",
     "smoke:shortcuts": "node scripts/smoke-shortcuts.mjs",
     "smoke:wizards": "node scripts/smoke-wizards.mjs",
+    "smoke:env-badge": "node scripts/smoke-env-badge.mjs",
     "seed:note-templates": "node scripts/generate-note-templates-seed.mjs"
   },
   "dependencies": {

--- a/scripts/smoke-env-badge.mjs
+++ b/scripts/smoke-env-badge.mjs
@@ -1,0 +1,209 @@
+// scripts/smoke-env-badge.mjs
+//
+// Smoke da marca de ambiente no bookmarklet, no navegador de verdade.
+//
+// A regra que isto protege é assimétrica e fácil de quebrar sem perceber: em
+// DESENVOLVIMENTO a pílula mostra um selo âmbar; em PRODUÇÃO o elemento não
+// deve nem existir no DOM. Um teste que só verificasse "o selo aparece em dev"
+// passaria feliz com um selo que aparece nos dois — que é justamente o defeito
+// que tornaria a marca inútil.
+//
+// Também confere o bloco Configurações → Diagnóstico, que é o contrapeso da
+// decisão de não marcar produção: lá o ambiente aparece SEMPRE, para que
+// "estou em produção" seja confirmação positiva e não ausência de badge.
+//
+// O sufixo da implantação é comparado com o ID esperado de cada ambiente: é
+// ele que prova a separação, e é ele que o agente compara com o do dashboard.
+//
+// Uso: npm run smoke:env-badge
+
+import { chromium } from 'playwright';
+import { build } from 'esbuild';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const raiz = resolve(here, '..');
+
+// Os IDs saem do próprio data-service.js: fixá-los aqui faria o teste continuar
+// verde depois de uma rotação de implantação que esquecesse algum arquivo.
+const dataService = await readFile(resolve(raiz, 'src/modules/shared/data-service.js'), 'utf8');
+function idDe(env) {
+    const m = dataService.match(new RegExp(`${env}:\\s*"([^"]+)"`));
+    if (!m) throw new Error(`não achei o deployment de ${env} em data-service.js`);
+    return m[1];
+}
+const ESPERADO = {
+    production: idDe('production').slice(-6),
+    development: idDe('development').slice(-6),
+};
+
+async function bundleDe(env) {
+    const out = await build({
+        entryPoints: [resolve(raiz, 'src/app.js')],
+        bundle: true,
+        write: false,
+        logLevel: 'silent',
+        define: { __CW_BUILD_ENV__: JSON.stringify(env) },
+    });
+    return out.outputFiles[0].text;
+}
+
+let fail = 0;
+async function check(name, fn) {
+    try { await fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+function igual(atual, esperado, oque) {
+    if (atual !== esperado) throw new Error(`${oque}: esperado ${JSON.stringify(esperado)}, veio ${JSON.stringify(atual)}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+
+async function abrirApp(env) {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    // A API real não responde daqui; cortar na origem evita 15s de watchdog por
+    // chamada e deixa o app no caminho "sem nuvem", que é o que interessa aqui.
+    await page.route('**script.google.com/**', (route) => route.abort());
+    page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
+
+    const logs = [];
+    page.on('console', (m) => logs.push(m.text()));
+
+    await page.goto('file://' + resolve(raiz, 'mock-crm.html'));
+    await page.evaluate(() => {
+        localStorage.setItem('cw_onboarding_seen_v1', 'true');
+    });
+    await page.addScriptTag({ content: await bundleDe(env) });
+
+    // A pílula só termina de chegar depois da animação de boot.
+    await page.waitForSelector('#cw-btn-configs', { state: 'attached', timeout: 30000 });
+    await page.waitForTimeout(12000);
+
+    const dialog = page.locator('#cw-conf-cancel');
+    if (await dialog.isVisible().catch(() => false)) await dialog.click();
+
+    return { page, logs };
+}
+
+// Configurações é aberto pelo Ctrl+K, e não clicando o ícone: com a pílula
+// colapsada (o estado em que ela passa a maior parte do tempo) os botões
+// existem no DOM mas não são clicáveis. É também o caminho que o agente usa.
+async function abrirConfiguracoes(page) {
+    await page.keyboard.press('Control+k');
+    await page.waitForSelector('.cw-palette-overlay.active', { timeout: 8000 });
+    await page.keyboard.type('config', { delay: 20 });
+    await page.waitForTimeout(400);
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('.cw-env-chip', { timeout: 8000 });
+}
+
+console.log('\n--- Smoke: marca de ambiente (dev vs prod) ---');
+
+// ------------------------------------------------------------ desenvolvimento
+{
+    const { page, logs } = await abrirApp('development');
+
+    await check('dev: a pílula mostra o selo', async () => {
+        igual(await page.locator('#cw-env-tag').count(), 1, 'nós #cw-env-tag');
+        igual((await page.locator('#cw-env-tag').textContent()).trim(), 'Dev', 'rótulo');
+    });
+
+    await check('dev: o selo é âmbar, não vermelho de erro', async () => {
+        const cor = await page.evaluate(() =>
+            getComputedStyle(document.querySelector('#cw-env-tag')).backgroundColor);
+        igual(cor, 'rgb(242, 153, 0)', 'cor de fundo');
+    });
+
+    // O estado que mais importa: a pílula passa a maior parte do tempo
+    // colapsada, e é aí que o selo escrito não cabe. Sem o anel, a marca
+    // desapareceria justamente quando o agente está trabalhando.
+    await check('dev: a pílula COLAPSADA carrega o anel âmbar', async () => {
+        const r = await page.evaluate(() => {
+            const p = document.querySelector('.cw-pill');
+            return {
+                colapsada: p.classList.contains('collapsed'),
+                marcada: p.classList.contains('cw-env-dev'),
+                sombra: getComputedStyle(p).boxShadow,
+            };
+        });
+        if (!r.colapsada) throw new Error('a pílula não estava colapsada neste ponto do teste');
+        if (!r.marcada) throw new Error('classe cw-env-dev ausente');
+        if (!r.sombra.includes('242, 153, 0')) throw new Error('anel âmbar ausente: ' + r.sombra);
+    });
+
+    await check('dev: o title do selo traz o sufixo da implantação de dev', async () => {
+        const t = await page.locator('#cw-env-tag').getAttribute('title');
+        if (!t.includes(ESPERADO.development)) {
+            throw new Error(`title "${t}" não contém …${ESPERADO.development}`);
+        }
+    });
+
+    await check('dev: o console anuncia o ambiente e a implantação', async () => {
+        const linha = logs.find((l) => l.includes('[Case Wizard] backend:'));
+        if (!linha) throw new Error('nenhum log de backend: ' + JSON.stringify(logs.slice(0, 5)));
+        if (!linha.includes('development')) throw new Error('log: ' + linha);
+        if (!linha.includes(ESPERADO.development)) throw new Error('log sem o sufixo: ' + linha);
+    });
+
+    await check('dev: Configurações → Diagnóstico mostra DEV e o sufixo certo', async () => {
+        await abrirConfiguracoes(page);
+        const txt = (await page.locator('.cw-env-chip').textContent()).trim();
+        if (!txt.startsWith('DEV')) throw new Error('chip: ' + txt);
+        if (!txt.includes(ESPERADO.development)) throw new Error('chip sem o sufixo: ' + txt);
+        const cls = await page.locator('.cw-env-chip').getAttribute('class');
+        if (!cls.includes('is-dev')) throw new Error('classe: ' + cls);
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------------------- produção
+{
+    const { page, logs } = await abrirApp('production');
+
+    // A checagem central deste arquivo.
+    await check('prod: o selo NÃO existe no DOM (não basta estar invisível)', async () => {
+        igual(await page.locator('#cw-env-tag').count(), 0, 'nós #cw-env-tag');
+    });
+
+    await check('prod: a pílula não recebe nem a classe nem o anel', async () => {
+        const r = await page.evaluate(() => {
+            const p = document.querySelector('.cw-pill');
+            return { marcada: p.classList.contains('cw-env-dev'), sombra: getComputedStyle(p).boxShadow };
+        });
+        if (r.marcada) throw new Error('classe cw-env-dev presente em produção');
+        if (r.sombra.includes('242, 153, 0')) throw new Error('anel âmbar em produção: ' + r.sombra);
+    });
+
+    await check('prod: o console ainda permite confirmar o ambiente', async () => {
+        const linha = logs.find((l) => l.includes('[Case Wizard] backend:'));
+        if (!linha) throw new Error('nenhum log de backend');
+        if (!linha.includes('production')) throw new Error('log: ' + linha);
+        if (!linha.includes(ESPERADO.production)) throw new Error('log sem o sufixo: ' + linha);
+    });
+
+    // Sem selo na pílula, este bloco é a única confirmação visual de produção -
+    // por isso ele precisa estar lá mesmo (e não só em dev).
+    await check('prod: Configurações → Diagnóstico mostra PROD e o sufixo certo', async () => {
+        await abrirConfiguracoes(page);
+        const txt = (await page.locator('.cw-env-chip').textContent()).trim();
+        if (!txt.startsWith('PROD')) throw new Error('chip: ' + txt);
+        if (!txt.includes(ESPERADO.production)) throw new Error('chip sem o sufixo: ' + txt);
+        const cls = await page.locator('.cw-env-chip').getAttribute('class');
+        if (!cls.includes('is-prod')) throw new Error('classe: ' + cls);
+    });
+
+    await check('prod e dev mostram sufixos DIFERENTES', async () => {
+        if (ESPERADO.production === ESPERADO.development) {
+            throw new Error('os dois ambientes apontam para a mesma implantação — a separação não existe');
+        }
+    });
+
+    await page.close();
+}
+
+await browser.close();
+console.log('\n' + (fail ? '✗' : '✓') + ` smoke: ${fail} falhas\n`);
+process.exit(fail ? 1 : 0);

--- a/scripts/test-deployment-env.js
+++ b/scripts/test-deployment-env.js
@@ -1,0 +1,142 @@
+// scripts/test-deployment-env.js
+//
+// Harness local para o detector de ambiente do backend (getDeploymentEnv e
+// buildEnvBadgeHtml, em gas-backend/Código.js), que não tem como rodar no
+// Apps Script sem uma implantação de verdade. Stub mínimo de ScriptApp.
+//
+// O que estas regras existem para garantir:
+//   - a implantação de produção NÃO mostra selo (decisão de produto: nada de
+//     chrome extra na tela de quem está trabalhando);
+//   - a de desenvolvimento mostra, em âmbar;
+//   - uma implantação que não está no mapa aparece como DESCONHECIDA e em
+//     vermelho — é pior que estar em dev, porque significa que alguém publicou
+//     de um lugar que este código não conhece;
+//   - o sufixo exibido é o mesmo que o frontend mostra em Configurações, que é
+//     o que prova a separação de ambientes;
+//   - sem contexto de web app (execução manual no editor) nada explode.
+//
+// Uso: npm run test:deployment-env
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC = path.join(__dirname, '..', 'gas-backend', 'Código.js');
+
+const PROD = 'AKfycbxkheuq28ENsHMZMH8t9-u4EIrktHC6cBi-87boDre0jJfl1lnSCPBzaEkw6hy3Cx6fAg';
+const DEV = 'AKfycbyUtczRMulDAyO_1ku39Rb01zarPMw1JvO7aNOdJPYeAgCC7G9mmb-P_EuXP6kvo8l2LA';
+const url = (id) => `https://script.google.com/a/macros/google.com/s/${id}/exec`;
+
+// Carrega só as declarações de função do arquivo. Código.js depende de um monte
+// de serviços do Apps Script no corpo do doGet, mas nada disso roda ao apenas
+// avaliar as declarações — e é só getDeploymentEnv/buildEnvBadgeHtml que
+// interessa aqui.
+function carregar(getUrlImpl) {
+    const codigo = fs.readFileSync(SRC, 'utf8');
+    const sandbox = {
+        ScriptApp: { getService: () => ({ getUrl: getUrlImpl }) },
+        SpreadsheetApp: {}, HtmlService: {}, Session: {}, MailApp: {},
+        Logger: { log: () => {} }, console,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(codigo, sandbox);
+    // Declarações de função viram globais do contexto e saem no sandbox; `const`
+    // no topo do script, não - fica no escopo do script. Por isso ler CW_DEPLOYMENTS
+    // exige avaliar uma expressão dentro do contexto, e não acessar sandbox.X.
+    sandbox.__ler = (expr) => vm.runInContext(expr, sandbox);
+    return sandbox;
+}
+
+let falhas = 0;
+function check(nome, fn) {
+    try { fn(); console.log('  ✓ ' + nome); }
+    catch (e) { console.log('  ✗ ' + nome + '\n      ' + e.message); falhas++; }
+}
+function igual(atual, esperado, oque) {
+    if (atual !== esperado) {
+        throw new Error(`${oque}: esperado ${JSON.stringify(esperado)}, veio ${JSON.stringify(atual)}`);
+    }
+}
+
+console.log('\n--- Detector de ambiente da implantação ---');
+
+check('produção é reconhecida e NÃO é dev', () => {
+    const s = carregar(() => url(PROD));
+    const info = s.getDeploymentEnv();
+    igual(info.env, 'production', 'env');
+    igual(info.isDev, false, 'isDev');
+});
+
+check('produção não renderiza selo nenhum', () => {
+    const s = carregar(() => url(PROD));
+    igual(s.buildEnvBadgeHtml(s.getDeploymentEnv()), '', 'html do selo');
+});
+
+check('desenvolvimento é reconhecido', () => {
+    const s = carregar(() => url(DEV));
+    const info = s.getDeploymentEnv();
+    igual(info.env, 'development', 'env');
+    igual(info.isDev, true, 'isDev');
+});
+
+check('selo de desenvolvimento sai em âmbar e diz DESENVOLVIMENTO', () => {
+    const s = carregar(() => url(DEV));
+    const html = s.buildEnvBadgeHtml(s.getDeploymentEnv());
+    if (!html.includes('DESENVOLVIMENTO')) throw new Error('rótulo ausente: ' + html.slice(0, 120));
+    if (!html.includes('#FEF7E0')) throw new Error('não usou o âmbar esperado');
+    if (html.includes('#FCE8E6')) throw new Error('usou a paleta de alerta vermelho em dev');
+});
+
+// É o sufixo que o agente compara com o de Configurações → Diagnóstico. Se
+// esta regra quebrar, a comparação deixa de provar coisa alguma.
+check('o sufixo exibido são os 6 últimos caracteres do ID', () => {
+    const s = carregar(() => url(DEV));
+    igual(s.getDeploymentEnv().fingerprint, DEV.slice(-6), 'fingerprint');
+    const sp = carregar(() => url(PROD));
+    igual(sp.getDeploymentEnv().fingerprint, PROD.slice(-6), 'fingerprint prod');
+});
+
+check('implantação fora do mapa vira DESCONHECIDA, em vermelho', () => {
+    const estranho = 'AKfycbzZZZZnaoRegistradaEmLugarNenhum000000000000000000000';
+    const s = carregar(() => url(estranho));
+    const info = s.getDeploymentEnv();
+    igual(info.env, 'unknown', 'env');
+    igual(info.isDev, true, 'isDev (desconhecido nunca é tratado como produção)');
+    igual(info.fingerprint, estranho.slice(-6), 'fingerprint extraído da própria URL');
+    const html = s.buildEnvBadgeHtml(info);
+    if (!html.includes('IMPLANTAÇÃO DESCONHECIDA')) throw new Error('rótulo errado');
+    if (!html.includes('#FCE8E6')) throw new Error('desconhecida deveria usar a paleta de alerta');
+});
+
+check('sem contexto de web app não explode', () => {
+    const s = carregar(() => { throw new Error('sem serviço'); });
+    const info = s.getDeploymentEnv();
+    igual(info.env, 'unknown', 'env');
+    igual(info.fingerprint, '------', 'fingerprint neutro');
+});
+
+check('getUrl devolvendo vazio também cai em desconhecida', () => {
+    const s = carregar(() => '');
+    igual(s.getDeploymentEnv().env, 'unknown', 'env');
+});
+
+// Os IDs vivem em três arquivos e precisam concordar. Este teste não alcança o
+// deploy.yml, mas alcança os dois que estão no código — e é a divergência que
+// o promote-deployment.sh explicitamente NÃO detecta.
+check('o mapa do backend bate com o do frontend', () => {
+    const front = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'modules', 'shared', 'data-service.js'), 'utf8');
+    const s = carregar(() => url(PROD));
+    const mapa = s.__ler('CW_DEPLOYMENTS');
+    if (!mapa || !mapa.production || !mapa.development) {
+        throw new Error('CW_DEPLOYMENTS não tem as duas chaves esperadas');
+    }
+    for (const [env, id] of Object.entries(mapa)) {
+        if (!front.includes(id)) {
+            throw new Error(`ID de ${env} (…${id.slice(-6)}) não aparece em data-service.js`);
+        }
+    }
+});
+
+console.log('\n' + (falhas ? '✗' : '✓') + ` ${falhas} falhas\n`);
+process.exit(falhas ? 1 : 0);

--- a/src/modules/configs/configs-assistant.js
+++ b/src/modules/configs/configs-assistant.js
@@ -2,7 +2,7 @@
 
 import { stylePopup, showToast } from "../shared/utils.js";
 import { getAgentEmail, captureNameWithMagic } from "../shared/page-data.js";
-import { fetchUserProfile } from "../shared/data-service.js"; // Importação crucial adicionada
+import { fetchUserProfile, getBackendInfo } from "../shared/data-service.js"; // Importação crucial adicionada
 import { createStandardHeader } from "../shared/header-factory.js";
 import { toggleGenieAnimation, isModuleOpen } from "../shared/animations.js";
 import { SoundManager } from "../shared/sound-manager.js";
@@ -25,6 +25,9 @@ const CONFIGS_DICT = {
         langDesc: "Escolha o idioma dos menus, botões e mensagens do Case Wizard.",
         supportSectionTitle: "Suporte & Feedback",
         reportBug: "Reportar Bug/Sugestões",
+        diagSectionTitle: "Diagnóstico",
+        diagLabel: "Ambiente do backend",
+        diagDesc: "Qual implantação do Apps Script este bundle usa. O sufixo tem de bater com o do dashboard.",
         scSectionTitle: "Meus Atalhos (Ctrl+K)",
         scSortLabel: "Ordenar por frequência de uso",
         scSortDesc: "Desligue para definir você mesmo a ordem, arrastando os atalhos.",
@@ -70,6 +73,9 @@ const CONFIGS_DICT = {
         langDesc: "Elige el idioma de los menús, botones y mensajes del Case Wizard.",
         supportSectionTitle: "Soporte y Comentarios",
         reportBug: "Reportar error o sugerencia",
+        diagSectionTitle: "Diagnóstico",
+        diagLabel: "Entorno del backend",
+        diagDesc: "Qué implementación de Apps Script usa este bundle. El sufijo debe coincidir con el del panel.",
         scSectionTitle: "Mis Atajos (Ctrl+K)",
         scSortLabel: "Ordenar por frecuencia de uso",
         scSortDesc: "Desactívalo para definir tú mismo el orden, arrastrando los atajos.",
@@ -429,6 +435,54 @@ export function initConfigsAssistant() {
     `;
     container.appendChild(supportSection);
 
+    // --- SEÇÃO: DIAGNÓSTICO ---
+    // A pílula só marca desenvolvimento; produção fica sem selo, de propósito.
+    // Este bloco é a contrapartida: aqui o ambiente aparece SEMPRE, inclusive
+    // em produção, para que "estou em produção" seja uma confirmação positiva
+    // e não a ausência de um badge — ausência também é o que se vê quando algo
+    // simplesmente não renderizou.
+    //
+    // O sufixo da implantação é o que prova a separação de ambientes: ele tem
+    // de bater com o sufixo mostrado no dashboard. Se divergirem, o frontend e
+    // o backend estão em implantações diferentes.
+    const envInfo = getBackendInfo();
+    const diagSection = document.createElement("div");
+    diagSection.className = "cw-configs-section";
+    diagSection.innerHTML = `
+        <div class="cw-configs-section-title js-diag-section-title"></div>
+        <div class="cw-configs-card">
+            <div class="cw-configs-row">
+                <div>
+                    <div class="cw-configs-label js-diag-label"></div>
+                    <div class="cw-configs-desc js-diag-desc"></div>
+                </div>
+                <div class="cw-env-chip ${envInfo.isDev ? 'is-dev' : 'is-prod'}"></div>
+            </div>
+        </div>
+    `;
+    // textContent, nunca innerHTML: o sufixo vem de uma constante do build,
+    // mas a regra do projeto não abre exceção por origem do dado.
+    diagSection.querySelector(".cw-env-chip").textContent =
+        `${envInfo.isDev ? "DEV" : "PROD"} · …${envInfo.fingerprint}`;
+    container.appendChild(diagSection);
+
+    const diagStyle = document.createElement("style");
+    diagStyle.innerHTML = `
+        .cw-env-chip {
+            font-family: 'Roboto Mono', ui-monospace, monospace;
+            font-size: 11px; font-weight: 700; letter-spacing: 0.4px;
+            padding: 5px 10px; border-radius: 100px; white-space: nowrap;
+            border: 1px solid transparent;
+        }
+        .cw-env-chip.is-prod {
+            background: #E6F4EA; color: #137333; border-color: #CEEAD6;
+        }
+        .cw-env-chip.is-dev {
+            background: #FEF7E0; color: #B06000; border-color: #FEEFC3;
+        }
+    `;
+    diagSection.appendChild(diagStyle);
+
     // --- TEXTOS TRADUZIDOS (aplica na criação e sempre que o idioma mudar) ---
     function applyTexts() {
         if (lastRenderedProfile) renderProfileCard(lastRenderedProfile.ldap, lastRenderedProfile.profile);
@@ -446,6 +500,10 @@ export function initConfigsAssistant() {
 
         supportSection.querySelector(".js-support-section-title").textContent = t('supportSectionTitle');
         supportSection.querySelector(".js-support-link").textContent = t('reportBug');
+
+        diagSection.querySelector(".js-diag-section-title").textContent = t('diagSectionTitle');
+        diagSection.querySelector(".js-diag-label").textContent = t('diagLabel');
+        diagSection.querySelector(".js-diag-desc").textContent = t('diagDesc');
 
         if (headerTitleEl) headerTitleEl.textContent = t('title');
         const helpTitleEl = popup.querySelector('.cw-help-title');

--- a/src/modules/shared/command-center.js
+++ b/src/modules/shared/command-center.js
@@ -1,6 +1,6 @@
 // src/modules/shared/command-center.js
 
-import { DataService } from './data-service.js';
+import { DataService, getBackendInfo } from './data-service.js';
 import { showToast, triggerGoogleAnimation } from './utils.js';
 import { SoundManager } from './sound-manager.js';
 import { ADMINS } from './config.js';
@@ -607,6 +607,57 @@ export function initCommandCenter(actions, splashDone) {
                 transform: translateX(-50%) scale(1);
             }
 
+            /* --- SELO DE AMBIENTE (só desenvolvimento) --- */
+            /* Em produção este elemento nem chega a ser criado: a decisão foi
+               não pôr chrome extra na tela do agente, e um selo permanente
+               dizendo "está tudo normal" é exatamente isso. Quem precisa
+               confirmar produção olha Configurações → Diagnóstico (ou o
+               console), onde a informação está sempre, de graça.
+
+               Aparece em cima, do lado oposto ao streak, e com a pílula
+               ABERTA - na bolinha fechada não há espaço e o agente não está
+               operando nada. Âmbar, não vermelho: é um aviso de contexto
+               ("cuidado, aqui é dev"), não um erro. */
+            .cw-env-badge {
+                position: absolute; top: -8px; left: -6px;
+                background: #F29900; color: #202124;
+                font-size: 9px; font-weight: 800;
+                letter-spacing: 0.6px; text-transform: uppercase;
+                padding: 2px 7px; border-radius: 100px;
+                border: 1px solid rgba(255,255,255,0.25);
+                box-shadow: 0 2px 6px rgba(0,0,0,0.28);
+                white-space: nowrap;
+                pointer-events: none;
+                z-index: 21;
+                opacity: 0;
+                transform: scale(0.6);
+                transition:
+                    opacity 0.3s var(--cw-ease-standard),
+                    transform 0.3s var(--cw-ease-spring);
+            }
+            .cw-pill:not(.collapsed) .cw-env-badge {
+                opacity: 1;
+                transform: scale(1);
+            }
+
+            /* O selo escrito só cabe com a pílula aberta - mas ela passa a
+               maior parte do tempo colapsada numa bolinha de 50px, e uma marca
+               de ambiente que some justamente no estado mais comum não serve
+               pra nada. Então o estado colapsado ganha um anel âmbar.
+               box-shadow, e não border: o anel é desenhado FORA da caixa, logo
+               não é cortado pelo "overflow: hidden" do .collapsed nem empurra
+               o layout interno. A sombra original vem junto na mesma
+               declaração porque box-shadow não se acumula entre regras. */
+            .cw-pill.cw-env-dev.collapsed {
+                box-shadow:
+                    0 12px 32px rgba(0,0,0,0.25),
+                    0 0 0 3px #F29900;
+            }
+            @media (prefers-reduced-motion: reduce) {
+                .cw-env-badge { transition: opacity 0.2s linear !important; transform: none !important; }
+                .cw-pill:not(.collapsed) .cw-env-badge { transform: none !important; }
+            }
+
             /* --- RITMO DO TURNO (contador de casos hoje) --- */
             /* Só aparece com a pílula ABERTA - é um indicador de contexto (tem
                espaço pro número, não corta em overflow:hidden), não uma
@@ -703,6 +754,21 @@ export function initCommandCenter(actions, splashDone) {
   }
 
   // 2. CONSTRUÇÃO DO DOM
+  // Selo de ambiente: existe só fora de produção. Em produção a função devolve
+  // string vazia e o elemento nem entra no DOM - é a diferença entre "não
+  // mostrar" e "mostrar escondido", e importa porque o smoke test verifica a
+  // ausência do nó, não a sua invisibilidade.
+  //
+  // O sufixo da implantação vai no title: quem está caçando um vazamento de
+  // ambiente quer comparar esse sufixo com o do dashboard, mas quem só está
+  // trabalhando não precisa de seis caracteres aleatórios na tela.
+  function envBadgeHtml() {
+    const info = getBackendInfo();
+    if (!info.isDev) return "";
+    const titulo = `Ambiente de desenvolvimento — implantação …${info.fingerprint} (${info.endpoint})`;
+    return `<div id="cw-env-tag" class="cw-env-badge" title="${titulo}">Dev</div>`;
+  }
+
   const ICONS = {
     check: `<svg viewBox="0 0 24 24" fill="none" stroke="#81C995" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
     notes: `<svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>`,
@@ -723,12 +789,16 @@ export function initCommandCenter(actions, splashDone) {
 
   const pill = document.createElement("div");
   pill.id = "cw-floating-trigger";
-  pill.className = "cw-pill side-right collapsed";
+  // A classe de ambiente entra no root da pílula, e não só no selo: é ela que
+  // permite marcar também o estado COLAPSADO (anel âmbar), onde o selo escrito
+  // não teria onde caber.
+  pill.className = "cw-pill side-right collapsed" + (getBackendInfo().isDev ? " cw-env-dev" : "");
 
   pill.innerHTML = `
         <div id="cw-command-center" style="display:none;"></div>
         <div class="cw-main-logo js-cc-quicksearch" title="${cct('quickSearch')}">${ICONS.main}${ICONS.mainSpark}</div>
         <div id="cw-admin-tag" class="cw-admin-badge">Admin</div>
+        ${envBadgeHtml()}
         <div id="cw-streak-badge" class="cw-streak-badge js-cc-casestoday" title="${cct('casesToday')}">🔥 <span id="cw-streak-count">0</span></div>
 
         <div class="cw-grip js-cc-drag" title="${cct('drag')}">

--- a/src/modules/shared/data-service.js
+++ b/src/modules/shared/data-service.js
@@ -52,7 +52,32 @@ const ENDPOINT = isLocalhost ? "dev" : "exec";
 
 const API_URL = `https://script.google.com/a/macros/google.com/s/${SCRIPT_ID}/${ENDPOINT}`;
 
-console.log(`[Case Wizard] backend: ${BUILD_ENV}/${ENDPOINT}`);
+// Os 6 últimos caracteres do ID da implantação. É a "impressão digital" que
+// prova a separação de ambientes: se a pílula, o Configurações e o dashboard
+// mostram o mesmo sufixo, os três estão falando com a mesma implantação; se
+// divergem, achou-se o vazamento. O ID inteiro não vai pra tela - é longo e
+// não acrescenta nada a olho nu.
+const DEPLOYMENT_FINGERPRINT = SCRIPT_ID.slice(-6);
+
+/**
+ * De onde este bundle está falando. Usado pelo selo da pílula e pelo bloco de
+ * diagnóstico em Configurações.
+ *
+ * @returns {{env: string, isDev: boolean, endpoint: string, fingerprint: string}}
+ */
+export function getBackendInfo() {
+    return {
+        env: BUILD_ENV,
+        isDev: BUILD_ENV !== "production",
+        endpoint: ENDPOINT,
+        fingerprint: DEPLOYMENT_FINGERPRINT,
+    };
+}
+
+// Em produção não há selo na tela (decisão de produto: nada de chrome extra
+// pro agente). Este log é, junto com o bloco em Configurações, o caminho
+// determinístico pra confirmar o ambiente sem depender de enxergar um badge.
+console.log(`[Case Wizard] backend: ${BUILD_ENV}/${ENDPOINT} · implantação …${DEPLOYMENT_FINGERPRINT}`);
 
 const CACHE_KEY_BROADCAST = "cw_data_broadcast";
 const CACHE_KEY_TIPS = "cw_data_tips";


### PR DESCRIPTION
Dá para saber, olhando, se você está falando com a implantação de produção ou com a de desenvolvimento — e, mais importante, dá para **provar** que a separação está funcionando.

## Onde aparece

| Superfície | Desenvolvimento | Produção |
|---|---|---|
| Pílula flutuante | anel âmbar (colapsada) · selo "Dev" (aberta) | nada |
| Configurações → Diagnóstico | `DEV · …xxxxxx` | `PROD · …xxxxxx` |
| Console no boot | `backend: development/exec · implantação …xxxxxx` | idem, `production` |
| Dashboards TL / Conteúdo | chip âmbar, canto inferior esquerdo | nada |

**Produção não mostra selo, de propósito** — nada de chrome extra para quem está trabalhando. Mas isso sozinho deixaria *"estou em produção"* indistinguível de *"o selo não renderizou"*. Por isso o bloco em Configurações e a linha de console existem nos **dois** ambientes: é a confirmação positiva.

## Como cada lado descobre o ambiente

- **Frontend**: `BUILD_ENV`, que o esbuild já injeta por branch.
- **Backend**: os dashboards **não** confiam numa constante compilada — descobrem pelo `ScriptApp.getService().getUrl()` da própria requisição, que traz o ID da implantação que atendeu.

Essa distinção é o ponto do PR. Uma constante repetiria o que alguém digitou; o que se quer provar é justamente que o roteamento está certo. (Usado só no caminho de `doGet` — em gatilho de tempo essa chamada é traiçoeira, como o `BAU_Alerts.js` já registrava.)

## O sufixo é o que fecha a prova

Os 6 últimos caracteres do ID da implantação. **O sufixo no app tem de bater com o do dashboard.** Se divergirem, frontend e backend estão em implantações diferentes — e você achou o vazamento.

Implantação fora do mapa vira **"IMPLANTAÇÃO DESCONHECIDA"** em vermelho, nunca é assumida como produção: um ambiente não identificado é exatamente o que se quer enxergar.

## Detalhe que só apareceu olhando o screenshot

A primeira versão só tinha o selo escrito, que exige a pílula aberta — mas ela passa a maior parte do tempo **colapsada**. Uma marca que some justamente no estado mais comum não serve para nada. Daí o anel âmbar no estado colapsado, feito com `box-shadow` (e não `border`) para não ser cortado pelo `overflow: hidden` do `.collapsed`.

## Testes

- **`npm run test:deployment-env`** (9) — o mapeamento URL→ambiente, a implantação desconhecida, o `getUrl()` que falha fora de web app, e uma checagem de que os IDs do backend batem com os do frontend (a divergência que o `promote-deployment.sh` explicitamente *não* detecta).
- **`npm run smoke:env-badge`** (11) — os dois builds num navegador real.

A checagem central é assimétrica de propósito: em produção o selo **não pode nem existir no DOM**. Um teste que só verificasse "aparece em dev" passaria feliz com um selo que aparece nos dois — que é justamente o defeito que tornaria a marca inútil.

Verificado também: `test:content` (55) e `test:prefs` seguem verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)