### PR TITLE
chore: releases, tags, templates e skill de gerenciamento do GitHub

### DIFF
--- a/.claude/skills/github-management/SKILL.md
+++ b/.claude/skills/github-management/SKILL.md
@@ -134,7 +134,20 @@ Os que existem: `v6.1 — Correções da auditoria`, `v6.2 — Fluxo BAU`,
 
 ## Projects (v2)
 
-Precisa do escopo `project`: `gh auth refresh -s project`.
+⚠️ **Exige o escopo `project`, que o token do repositório não tem por padrão.**
+Nem o `gh project`, nem a mutation `createProjectV2` por GraphQL funcionam sem
+ele — os dois devolvem `INSUFFICIENT_SCOPES`. E `gh auth refresh` é interativo,
+então **o agente não consegue resolver isso sozinho**: peça ao usuário para rodar
+
+```bash
+gh auth refresh -h github.com -s project
+```
+
+Confira antes de prometer qualquer coisa com Projects:
+
+```bash
+gh auth status 2>&1 | grep -i scopes
+```
 
 ```bash
 gh project list --owner lucastdcs
@@ -171,6 +184,48 @@ gh release list
 ⚠️ **Tag não faz deploy, e não pode passar a fazer.** O `RELEASE.md` estabelece
 que o merge para a `main` é o único portão de produção. Se alguém pedir para a
 tag disparar deploy, isso quebra a invariante — levante antes de implementar.
+
+---
+
+## Discussions
+
+Habilitado no repo. As 6 categorias padrão existem (`Announcements`, `General`,
+`Ideas`, `Polls`, `Q&A`, `Show and tell`).
+
+**Quando usar Discussion em vez de issue.** Issue tem dono e desfecho; discussion
+tem participantes e convergência. Se a pergunta é "como implementar", é issue. Se
+é "devemos, e por quê", é discussion — principalmente quando envolve cultura,
+prioridade ou risco aceito.
+
+Na prática aqui: o que está marcado `precisa decisão` e não descreve uma tarefa
+costuma render mais como discussion, com a issue linkando para ela.
+
+Não há `gh discussion` no CLI — é GraphQL:
+
+```bash
+# ids necessários
+gh api graphql -f query='{ repository(owner:"lucastdcs", name:"case-wizard") {
+  id discussionCategories(first:20){ nodes { id name } } } }'
+
+# criar
+Q='mutation($r: ID!, $c: ID!, $t: String!, $b: String!) {
+  createDiscussion(input: {repositoryId: $r, categoryId: $c, title: $t, body: $b}) {
+    discussion { number url } } }'
+gh api graphql -F r=<repoId> -F c=<categoriaId> -F t="Título" -F b=@corpo.md -f query="$Q"
+```
+
+`-F b=@arquivo.md` lê o corpo do arquivo — mesma razão do `--body-file` nas
+issues: markdown inline em shell corrompe silenciosamente.
+
+**Escreva discussion como convite, não como laudo.** Traga o que você mediu, dê
+sua posição, e termine perguntando — uma discussion que só afirma não gera
+conversa. Linke a issue correspondente e comente na issue apontando de volta.
+
+**Habilitar, se um dia estiver desligado:**
+
+```bash
+gh api repos/lucastdcs/case-wizard -X PATCH -F has_discussions=true
+```
 
 ---
 

--- a/.claude/skills/github-management/SKILL.md
+++ b/.claude/skills/github-management/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: github-management
+description: Gerenciar o GitHub do Case Wizard — abrir e curar issues, labels, milestones, Projects, Releases, wiki e discussions pelo `gh` CLI. Use quando pedirem para "abrir issue", "criar label", "organizar o backlog", "montar um project", "publicar release", "criar wiki", ou qualquer curadoria do repositório. Também quando alguém descrever um problema ou uma ideia que deveria virar issue em vez de virar código agora.
+metadata:
+  author: lucas
+  version: "1.0.0"
+---
+
+# Gerenciar o GitHub do Case Wizard
+
+Tudo aqui é feito pelo `gh` CLI, no repositório `lucastdcs/case-wizard`.
+
+**Antes de qualquer coisa em lote** (mais de ~3 issues, criar labels, mexer em
+milestone): descreva o que vai criar e espere aprovação. Criar 20 issues erradas
+custa mais tempo para desfazer do que para revisar antes.
+
+---
+
+## Verificar antes de escrever
+
+Duas checagens que evitam a maior parte do retrabalho:
+
+```bash
+gh repo view --json nameWithOwner,defaultBranchRef   # é o repo certo?
+gh auth status                                        # tem os escopos? (repo, workflow, project)
+```
+
+E, para uma issue de bug: **confirme que o bug ainda existe** na branch de
+integração antes de abrir. O checkout local costuma estar atrás.
+
+```bash
+git fetch origin
+git archive origin/refactor-structure | tar -x -C /tmp/atual
+```
+
+Issue de bug já corrigido é ruído que alguém vai gastar tempo investigando.
+
+---
+
+## Issues
+
+### O formato que este projeto usa
+
+Bug — cinco blocos, nesta ordem:
+
+```markdown
+**Sintoma.** O que acontece, do ponto de vista de quem usa.
+
+**Causa.** Com `arquivo:linha`. Se não investigou, omita o bloco.
+
+**Correção proposta.** Se depende de uma escolha de produto, escreva a
+**pergunta** em vez de uma solução fechada, e marque `precisa decisão`.
+
+**Como verificar.** O `npm run test:*` existente, ou o passo manual.
+
+**Evidência.** Log, medição, saída de console. O que provou que é real.
+```
+
+Ideia/melhoria — três blocos: **Contexto** (o que existe hoje, com referências
+ao código), **O que fazer**, **Em aberto**.
+
+### Regras que valem mais que o formato
+
+- **Uma issue, um problema.** Agrupe só o que se corrige no mesmo commit.
+- **Aponte `arquivo:linha`.** É o que separa uma issue que alguém pega de uma
+  que precisa ser reinvestigada do zero.
+- **Registre o que você mediu**, não o que você supõe. Se rodou algo e viu a
+  saída, cole a saída.
+- **Não transcreva o pedido.** Se o usuário descreveu um sintoma, vá ao código
+  e descubra a causa antes de abrir. A issue vale pelo que ela acrescenta.
+- **Referências cruzadas de verdade.** `#301` cria vínculo navegável; "ver a
+  issue de segurança" não.
+
+### Comandos
+
+```bash
+gh issue create -R lucastdcs/case-wizard \
+  --title "..." --body-file corpo.md \
+  --milestone "Backlog" \
+  --label "bug" --label "severidade: alta" --label "área: backend"
+
+gh issue list -R lucastdcs/case-wizard --milestone "Backlog" --limit 30
+gh issue edit 296 --body-file novo.md      # substitui o corpo
+gh issue comment 296 --body "..."          # acrescenta — prefira para correções
+gh issue close 296 --reason completed
+```
+
+**Corpo sempre por `--body-file`.** Markdown com crase, `$` ou aspas dentro de
+`--body` vira escape shell e corrompe silenciosamente.
+
+⚠️ **Em zsh, `$var` não sofre word-splitting.** Um `for pair in "300 d1"; do set -- $pair`
+não divide — `$1` recebe a string inteira. Use função com parâmetros nomeados ou `${=var}`.
+
+---
+
+## Labels
+
+Três eixos, e uma label não deve misturar dois:
+
+| Eixo | Valores |
+|---|---|
+| Severidade | `severidade: crítica` · `alta` · `média` |
+| Área | `área: backend` · `frontend` · `ci-cd` · `docs` · `comando` |
+| Tipo | `tipo: segurança` · `a11y` · `performance` · `pesquisa` · `design` |
+
+Mais as nativas `bug`, `enhancement`, `documentation`, e `precisa decisão` para
+o que está bloqueado numa escolha de produto.
+
+```bash
+gh label create "nome" --color RRGGBB --description "..." --force
+gh label list --limit 40
+```
+
+Antes de criar uma label nova, pergunte se ela é um **quarto eixo** ou só um
+valor novo num eixo existente. Taxonomia que cresce sem critério deixa de filtrar.
+
+---
+
+## Milestones
+
+Milestone é **quando**; label é **o quê**. Não crie milestone para agrupar tema —
+isso é label, ou Project.
+
+```bash
+gh api repos/lucastdcs/case-wizard/milestones -f title="..." -f description="..."
+gh api repos/lucastdcs/case-wizard/milestones --jq '.[] | "#\(.number) \(.title)"'
+```
+
+Os que existem: `v6.1 — Correções da auditoria`, `v6.2 — Fluxo BAU`,
+`v6.3 — Segurança do backend`, `E-mails`, `Comando como centro`,
+`Estudos e decisões`, `Backlog`.
+
+---
+
+## Projects (v2)
+
+Precisa do escopo `project`: `gh auth refresh -s project`.
+
+```bash
+gh project list --owner lucastdcs
+gh project create --owner lucastdcs --title "Roadmap Case Wizard"
+gh project item-add <número> --owner lucastdcs --url <url-da-issue>
+gh project field-list <número> --owner lucastdcs
+```
+
+Use Project quando precisar de **ordem e estado** (backlog → fazendo → revisão),
+que milestone não expressa. Não duplique no Project o que já está em label.
+
+---
+
+## Releases
+
+**O `release.yml` já faz isso.** Uma tag `vX.Y.Z` empurrada dispara o workflow,
+que extrai a seção do `CHANGELOG.md` e publica o Release. Não crie release à mão
+— você contorna as duas guardas (tag × `package.json`, e existência da seção).
+
+Antes de criar a tag, na ordem do `RELEASE.md`:
+
+1. fechar a seção no `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] - data`)
+2. alinhar `package.json`, `APP_VERSION` e `RELEASE_NOTES.version` no mesmo commit
+3. merge para a `main` ← **isto é o que promove produção**
+4. tag na `main` ← isto só publica as notas
+
+```bash
+git checkout main && git pull
+git tag -a v6.0.0 -m "v6.0.0"
+git push origin v6.0.0
+gh release list
+```
+
+⚠️ **Tag não faz deploy, e não pode passar a fazer.** O `RELEASE.md` estabelece
+que o merge para a `main` é o único portão de produção. Se alguém pedir para a
+tag disparar deploy, isso quebra a invariante — levante antes de implementar.
+
+---
+
+## Wiki
+
+A wiki é um repositório git separado (`<repo>.wiki.git`), não versionado junto.
+
+Por isso, **prefira `docs/` no próprio repo** para qualquer coisa que precise
+andar junto com o código: revisão por PR, histórico no mesmo lugar, e o
+`CLAUDE.md` já manda enriquecer doc existente em vez de criar novo. O projeto já
+tem `docs/`, `specs/` e `docs/decisions/` com dono claro.
+
+A wiki serve para o que **não** é versionado com o código: onboarding de pessoa
+nova, notas de reunião, links úteis.
+
+```bash
+git clone https://github.com/lucastdcs/case-wizard.wiki.git
+```
+
+---
+
+## Onde cada coisa mora neste projeto
+
+Antes de criar documento novo, confira se já não existe dono:
+
+| Conteúdo | Lugar |
+|---|---|
+| Como publicar, ambientes, rollback, tags | `RELEASE.md` |
+| O que mudou em cada versão | `CHANGELOG.md` |
+| Decisão arquitetural e o porquê | `docs/decisions/` (ADR) |
+| Regra de negócio, contrato de dados | `specs/` — **é a lei; se o código diverge, o código é que corrige** |
+| Visão geral da arquitetura | `docs/ARCHITECTURE.md` |
+| Convenções para o agente | `CLAUDE.md` |
+| Como contribuir (humano) | `CONTRIBUTING.md` |
+| Aprendizado, armadilha encontrada | `docs/LEARNINGS.md` |
+
+---
+
+## Armadilhas já encontradas
+
+- **Sessão isolada em worktree recusa comando composto.** Rode `gh` a partir do
+  diretório principal, ou saia do worktree (`ExitWorktree`) antes do lote.
+- **`--body-file` só lê caminho existente.** Se o heredoc que criava o arquivo
+  estava no mesmo comando que foi recusado, o arquivo não existe — confira antes.
+- **Placeholder de referência cruzada.** Ao criar issues em lote que se citam,
+  escreva `#<ID>` e resolva depois com `gh issue edit`, quando os números
+  existirem. Não chute número.
+- **O repo foi renomeado** de `techsol_DialIn_AutoCopy` para `case-wizard`. O
+  nome antigo hoje é um **repositório shim** que mantém os bookmarklets vivos —
+  criar o shim **consumiu o nome e encerrou o redirect do git**. Não confie no
+  nome antigo em script nenhum; ver `docs/decisions/0003-rename-repo-to-case-wizard.md`.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,58 @@
+name: Bug
+description: Algo que não funciona como deveria
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Preencha o que souber. Nem todo campo se aplica a todo bug — o único
+        realmente obrigatório é o sintoma.
+
+  - type: textarea
+    id: sintoma
+    attributes:
+      label: Sintoma
+      description: O que acontece, do ponto de vista de quem usa. Sem teoria ainda.
+      placeholder: O selo "Admin" aparece na pílula para todos os usuários, não só para quem está na lista.
+    validations:
+      required: true
+
+  - type: textarea
+    id: causa
+    attributes:
+      label: Causa
+      description: |
+        Se você já investigou, aponte `arquivo:linha`. Se ainda não, deixe em branco —
+        é melhor abrir a issue sem isso do que não abrir.
+      placeholder: |
+        `.cw-pill > *:not(.cw-main-logo)` (command-center.js:310, especificidade 0,2,0)
+        vence `.cw-admin-badge` (:586, 0,1,0) e força opacity: 1.
+
+  - type: textarea
+    id: correcao
+    attributes:
+      label: Correção proposta
+      description: Se houver uma decisão a tomar antes de implementar, escreva a pergunta aqui em vez de uma solução fechada.
+
+  - type: textarea
+    id: verificacao
+    attributes:
+      label: Como verificar
+      description: Como saber que foi resolvido. Um `npm run test:*` existente, ou o passo manual.
+
+  - type: textarea
+    id: evidencia
+    attributes:
+      label: Evidência
+      description: Log, medição, print, saída de console. O que te convenceu de que o bug é real.
+      render: shell
+
+  - type: dropdown
+    id: ambiente
+    attributes:
+      label: Onde aconteceu
+      options:
+        - Produção (bundle.js)
+        - Desenvolvimento (bundle-dev.js)
+        - Os dois
+        - Não sei

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Como o projeto funciona
+    url: https://github.com/lucastdcs/case-wizard/blob/refactor-structure/docs/ARCHITECTURE.md
+    about: Visão geral da arquitetura antes de abrir uma issue sobre comportamento.
+  - name: Regras de negócio e contratos
+    url: https://github.com/lucastdcs/case-wizard/blob/refactor-structure/specs/_MASTER_RULEBOOK.md
+    about: Se o código diverge da spec, a spec prevalece — vale checar antes de tratar como bug.
+  - name: Como publicar uma versão
+    url: https://github.com/lucastdcs/case-wizard/blob/refactor-structure/RELEASE.md
+    about: Runbook de deploy, ambientes, tags e rollback.

--- a/.github/ISSUE_TEMPLATE/melhoria.yml
+++ b/.github/ISSUE_TEMPLATE/melhoria.yml
@@ -1,0 +1,33 @@
+name: Melhoria
+description: Uma capacidade nova, ou algo que funciona mas poderia ser melhor
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problema
+    attributes:
+      label: Que problema isso resolve
+      description: |
+        Comece pela dor, não pela solução. Uma melhoria sem um problema atrás
+        costuma ser trabalho que ninguém sente falta depois.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposta
+    attributes:
+      label: Proposta
+      description: O que você faria. Se houver mais de um caminho, liste os dois e diga qual prefere.
+
+  - type: textarea
+    id: alternativas
+    attributes:
+      label: O que foi descartado
+      description: Caminhos considerados e por que não. Evita que a discussão se repita daqui a três meses.
+
+  - type: textarea
+    id: impacto
+    attributes:
+      label: O que isso afeta
+      description: |
+        Contrato de payload (`specs/data-models/`), esquema da planilha, uma
+        spec em `specs/`, o bookmarklet já instalado pelos agentes?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## O que muda
+
+<!-- Uma ou duas frases. O "porquê" vale mais que o "o quê" — o diff já mostra o quê. -->
+
+Resolve #
+
+## Por que assim
+
+<!-- A decisão por trás da mudança, e o que você considerou e descartou.
+     Este é o campo que o seu eu de daqui a seis meses vai querer ler. -->
+
+## Como verificar
+
+<!-- O comando que prova, ou o passo manual. Se rodou testes, cole o resultado. -->
+
+- [ ] `npm run build` passa
+- [ ] Testes relevantes passam (`npm run test:*` / `smoke:*`)
+- [ ] Testado com o bookmarklet de **dev** contra o CRM real, se mexeu em módulo
+
+## Checklist
+
+- [ ] Se mexi em `gas-backend/`: o contrato em `specs/data-models/api-payloads.md` continua válido
+- [ ] Se mexi numa regra de negócio: a spec correspondente em `specs/` foi atualizada junto
+- [ ] Se é uma decisão que alguém vai questionar depois: virou um ADR em `docs/decisions/`
+- [ ] Se muda algo perceptível: entrou em `CHANGELOG.md`, sob `[Unreleased]`
+- [ ] Se bumpei versão: `package.json`, `APP_VERSION` e `RELEASE_NOTES.version` no mesmo commit
+
+<!-- PRs vão para `refactor-structure`, nunca direto para `main`.
+     O merge para a main é o portão de produção — ver RELEASE.md. -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release (notas a partir do CHANGELOG)
+
+# ⚠️ ESTE WORKFLOW NÃO FAZ DEPLOY. NENHUM.
+#
+# O RELEASE.md é explícito: "o merge para a `main` é o portão de produção —
+# nada mais promove produção". Criar uma tag não pode virar um segundo caminho
+# para produção, senão a invariante que o deploy.yml estabeleceu deixa de valer
+# e ninguém consegue mais responder "o que está no ar?" olhando uma coisa só.
+#
+# O que este workflow faz é só registrar o que JÁ foi para produção: pega a
+# seção da versão no CHANGELOG.md e publica um GitHub Release com aquele texto.
+# Quem promove produção continua sendo, exclusivamente, o push na `main`.
+#
+# Ordem correta de uma release:
+#   1. fechar a seção no CHANGELOG.md (mover [Unreleased] → [X.Y.Z] - data)
+#   2. alinhar package.json, APP_VERSION e RELEASE_NOTES.version
+#   3. merge para a main  ← isto é o que promove produção
+#   4. tag vX.Y.Z na main ← isto só publica as notas
+# Ver RELEASE.md → "Tags e GitHub Releases".
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publicar-notas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      # A tag é a fonte da verdade do que está sendo publicado; o package.json
+      # é a fonte da verdade do que o projeto acha que é. Se discordarem, é
+      # porque alguém bumpou um e esqueceu o outro — falhar aqui é mais barato
+      # que publicar um Release com o número errado e ter que apagar depois.
+      - name: Conferir se a tag bate com o package.json
+        run: |
+          VERSAO_TAG="${GITHUB_REF_NAME#v}"
+          VERSAO_PKG="$(node -p "require('./package.json').version")"
+
+          echo "tag:          v${VERSAO_TAG}"
+          echo "package.json: ${VERSAO_PKG}"
+
+          if [[ "$VERSAO_TAG" != "$VERSAO_PKG" ]]; then
+            echo "::error::A tag v${VERSAO_TAG} não bate com a versão ${VERSAO_PKG} do package.json."
+            exit 1
+          fi
+
+      - name: Extrair as notas do CHANGELOG
+        run: |
+          VERSAO="${GITHUB_REF_NAME#v}" bash scripts/extract-changelog.sh > /tmp/notas.md
+          echo "--- notas extraídas ---"
+          cat /tmp/notas.md
+
+      - name: Publicar o GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/notas.md \
+            --verify-tag
+
+      - name: Resumo
+        run: |
+          {
+            echo "## 🏷️ Release ${GITHUB_REF_NAME} publicado"
+            echo ""
+            echo "Notas extraídas de \`CHANGELOG.md\`."
+            echo ""
+            echo "**Nenhum deploy foi feito por este workflow** — produção é promovida"
+            echo "apenas pelo push na \`main\` (ver \`RELEASE.md\`)."
+            echo ""
+            echo "[Ver o release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME})"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,13 @@ Thumbs.db
 # Editores
 .vscode/
 .idea/
+
+# Claude Code — versionado por padrão, com duas exceções.
+# `.claude/settings.json` e `.claude/skills/` são configuração e ferramental de
+# time, e o CLAUDE.md conta com eles no repo. Só ficam de fora:
+#   - worktrees/, que são cópias descartáveis do próprio repositório (já passou
+#     de 119 MB aqui) e nunca deveriam ser versionadas;
+#   - settings.local.json, que é configuração pessoal — o sufixo `.local` é a
+#     convenção do próprio Claude Code para isso.
+.claude/worktrees/
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [6.0.0] - 2026-08-21
+
+### Added
 - **Marca visível de ambiente, no app e nos dashboards.** Em desenvolvimento a
   pílula ganha um anel âmbar (colapsada) e um selo "Dev" (aberta), e os
   dashboards de TL e da Central de Conteúdo mostram um chip âmbar no canto. Em
@@ -152,3 +166,6 @@ versions follow [Semantic Versioning](https://semver.org/).
 ### Added
 - ...
 -->
+
+[Unreleased]: https://github.com/lucastdcs/case-wizard/compare/v6.0.0...HEAD
+[6.0.0]: https://github.com/lucastdcs/case-wizard/releases/tag/v6.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contribuindo com o Case Wizard
+
+Este arquivo é um **roteador**, não um manual. As regras moram nos documentos
+abaixo e são mantidas lá — se algo aqui divergir deles, eles é que valem.
+
+## Antes de escrever código
+
+| Você quer... | Leia |
+|---|---|
+| entender como a coisa funciona | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
+| saber a regra de negócio ou o contrato de dados | [`specs/_MASTER_RULEBOOK.md`](specs/_MASTER_RULEBOOK.md) e o resto de `specs/` |
+| achar o arquivo certo | [`CLAUDE.md`](CLAUDE.md) → *Key files and folders* |
+| saber por que uma decisão foi tomada | [`docs/decisions/`](docs/decisions/) |
+| publicar uma versão | [`RELEASE.md`](RELEASE.md) |
+
+**A `specs/` é a lei.** Se o código diverge de uma spec, o padrão é corrigir o
+código — não a spec. Mudar a spec é uma decisão consciente, e vira um ADR.
+
+## O ciclo
+
+1. Branch a partir de `refactor-structure`.
+2. Commits em [Conventional Commits](https://www.conventionalcommits.org/)
+   (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`), pequenos e atômicos.
+3. `npm run build` e os `npm run test:*` / `smoke:*` relevantes.
+4. Teste de verdade: carregue o **bookmarklet de dev** contra o CRM real e
+   exercite o módulo que você mexeu. Não há suíte que cubra a raspagem do DOM.
+5. PR para **`refactor-structure`**. Nunca direto para a `main` — o merge para a
+   `main` é o portão de produção.
+
+## O que costuma ser esquecido
+
+- **Mexeu em `gas-backend/`?** Confira se o contrato em
+  `specs/data-models/api-payloads.md` continua valendo. Mais de um módulo do
+  frontend depende dele.
+- **Mudou algo perceptível?** Entra no `CHANGELOG.md`, sob `[Unreleased]`.
+- **Bumpou versão?** `package.json`, `APP_VERSION` (`src/app.js`) e
+  `RELEASE_NOTES.version` (`src/modules/changelog/changelog-data.js`) mudam
+  **no mesmo commit**. Se divergirem, o modal de novidades some e um teste fica
+  vermelho.
+- **Novo passo de build?** Ele precisa passar `--define:__CW_BUILD_ENV__`.
+  Sem a flag, o bundle cai no fallback `"development"` em silêncio — e um
+  bundle de produção falando com o backend de dev é difícil de perceber.
+
+## Abrindo uma issue
+
+Use os templates de [bug](.github/ISSUE_TEMPLATE/bug.yml) ou
+[melhoria](.github/ISSUE_TEMPLATE/melhoria.yml). Se você já investigou, aponte
+`arquivo:linha` — é o que separa uma issue que alguém consegue pegar de uma que
+vai precisar ser re-investigada do zero.
+
+Issue sem investigação também é bem-vinda. É melhor um sintoma registrado do
+que um sintoma esquecido.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,6 +96,41 @@ backend is the exact state this ordering exists to prevent.
 
 `APP_VERSION` (`src/app.js`) drives *when* the "what's new" modal fires; `RELEASE_NOTES.version` (`src/modules/changelog/changelog-data.js`) drives *what it says*. **Bump both in the same commit.** If they diverge, `checkAndShowChangelog` suppresses the modal and logs a warning rather than showing the new version's badge over the old version's content.
 
+## Tags & GitHub Releases
+
+A tag is **bookkeeping, not a deploy**. `deploy.yml` triggers on `push.branches`
+only, so pushing a tag does not match it and promotes nothing; `release.yml`
+triggers on `push.tags: v*` and only publishes release notes. The merge into
+`main` stays the single production gate.
+
+Order — the tag comes **last**, on a commit that is already in production:
+
+```bash
+# 1. Close the section in CHANGELOG.md: move what is under [Unreleased] into
+#    "## [X.Y.Z] - YYYY-MM-DD", leave a fresh empty [Unreleased] above it, and
+#    add the two link refs at the bottom.
+# 2. Align the three version sources in the same commit:
+#    package.json "version", APP_VERSION (src/app.js), RELEASE_NOTES.version
+#    (src/modules/changelog/changelog-data.js). See "App version" above.
+# 3. Merge into main and push — this is what promotes production.
+git checkout main && git merge refactor-structure && git push origin main
+
+# 4. Tag that commit and push the tag — this only publishes the notes.
+git tag -a v6.0.0 -m "v6.0.0"
+git push origin v6.0.0
+```
+
+`release.yml` then refuses to publish if the tag disagrees with
+`package.json`, and `scripts/extract-changelog.sh` refuses if the CHANGELOG has
+no section for that version — a Release published with empty notes is worse than
+a red workflow, because the red one tells you, and the empty one just sits there
+looking deliberate.
+
+**Versioning.** `package.json` is the SemVer source of truth and the number the
+tag must match. `APP_VERSION` and `RELEASE_NOTES.version` use the shorter `vX.Y`
+form because they drive the in-app "what's new" modal, not the release — but
+they must still describe the same release.
+
 ## Rollback
 
 - **Frontend (GitHub Pages)**: revert the offending commit on the relevant branch and push again — CI rebuilds and republishes `dist/`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "case-wizard",
-  "version": "1.0.0",
+  "version": "6.0.0",
   "description": "TechSol Operations Assistant - Productivity Suite",
   "main": "src/app.js",
   "scripts": {

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Extrai de CHANGELOG.md a seção de UMA versão, para virar o corpo do GitHub
+# Release. Chamado por .github/workflows/release.yml quando uma tag `v*` é
+# empurrada.
+#
+# Espera uma variável de ambiente:
+#   VERSAO   a versão sem o "v" (ex: "6.0.0"), normalmente ${GITHUB_REF_NAME#v}
+#
+# Escreve a seção no stdout. Precisa ser rodado a partir da raiz do repositório.
+#
+# O workflow chama isto como `bash scripts/extract-changelog.sh`, e não
+# `./scripts/...`, pelo mesmo motivo documentado em promote-deployment.sh: o
+# repositório costuma ser clonado num volume Windows montado, onde o bit de
+# execução não persiste.
+#
+# Por que falhar em vez de seguir com o corpo vazio: um Release publicado sem
+# notas é pior que um workflow vermelho. O vermelho avisa; o Release vazio fica
+# lá parecendo intencional, e é exatamente o que acontece quando alguém cria a
+# tag antes de fechar a seção no CHANGELOG. Esse é o erro que este script
+# existe para pegar.
+
+set -euo pipefail
+
+if [[ -z "${VERSAO:-}" ]]; then
+  echo "ERRO: a variável VERSAO não foi definida." >&2
+  exit 1
+fi
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "ERRO: CHANGELOG.md não encontrado. Rode a partir da raiz do repositório." >&2
+  exit 1
+fi
+
+# Pega tudo entre "## [VERSAO]" e o próximo cabeçalho "## [", sem incluir
+# nenhum dos dois. O -v é o jeito seguro de passar a versão para o awk sem
+# interpolar no meio do programa.
+SECAO="$(awk -v alvo="## [${VERSAO}]" '
+  index($0, alvo) == 1 { dentro = 1; next }
+  dentro && /^## \[/   { exit }
+  dentro               { print }
+' CHANGELOG.md)"
+
+# Remove linhas em branco do começo e do fim, e as subseções vazias que o
+# template do Keep a Changelog deixa para trás ("### Added" sem nada embaixo).
+SECAO="$(printf '%s\n' "$SECAO" | awk '
+  /^### / { cabecalho = $0; tem_conteudo = 0; next }
+  /^[[:space:]]*$/ { if (cabecalho != "" && !tem_conteudo) next }
+  {
+    if (cabecalho != "" && !tem_conteudo) { print ""; print cabecalho; tem_conteudo = 1 }
+    print
+  }
+')"
+
+SECAO="$(printf '%s\n' "$SECAO" | sed -e '/./,$!d' | tac | sed -e '/./,$!d' | tac)"
+
+if [[ -z "${SECAO// /}" ]]; then
+  echo "ERRO: não achei conteúdo para a versão ${VERSAO} em CHANGELOG.md." >&2
+  echo "" >&2
+  echo "Antes de criar a tag v${VERSAO}, mova o que está em '## [Unreleased]'" >&2
+  echo "para uma seção '## [${VERSAO}] - AAAA-MM-DD'. Ver RELEASE.md." >&2
+  echo "" >&2
+  echo "Seções encontradas no CHANGELOG:" >&2
+  grep -n '^## \[' CHANGELOG.md >&2 || true
+  exit 1
+fi
+
+printf '%s\n' "$SECAO"


### PR DESCRIPTION
Fecha a última milha do processo de publicação: o repo já tinha `CHANGELOG.md` e `RELEASE.md` maduros, mas **nenhuma tag, nenhum release e nenhum template**.

## Versão unificada

`package.json` estava em `1.0.0`, nunca bumpado, enquanto `APP_VERSION` e `RELEASE_NOTES.version` já andavam juntos em `v6.0`. Agora o `package.json` é a fonte SemVer (`6.0.0`) e a tag tem com o que ser conferida.

## 6.0.0 fechada no CHANGELOG

O que estava sob `[Unreleased]` vira `## [6.0.0] - 2026-08-21`, com um `[Unreleased]` novo e vazio acima e os links de comparação no rodapé.

## `release.yml` — e por que ele **não** faz deploy

Dispara em push de tag `v*`, extrai a seção da versão no CHANGELOG e publica o GitHub Release com aquele texto. Só isso.

O `RELEASE.md` diz, em negrito, que *"o merge para a `main` é o portão de produção — nada mais promove produção"*. Uma tag que fizesse deploy criaria um segundo caminho para produção e essa invariante deixaria de valer. **Verificado** que o `deploy.yml` dispara em `push.branches`, então uma tag não o aciona.

Duas guardas, porque as duas falhas são silenciosas se ninguém checar:
- a tag tem que bater com a versão do `package.json`
- o CHANGELOG tem que ter a seção daquela versão

`scripts/extract-changelog.sh` falha alto em vez de devolver corpo vazio — um Release sem notas fica parecendo intencional, um workflow vermelho avisa. Segue a convenção do `promote-deployment.sh`.

## Templates

Issue de **bug** e de **melhoria**, e template de PR. O de bug segue a estrutura usada nas 23 issues da auditoria: sintoma → causa com `arquivo:linha` → correção proposta → como verificar → evidência. Causa e evidência são opcionais de propósito — issue sem investigação é melhor que sintoma esquecido.

## ⚠️ Dois pontos para você decidir

1. **`CONTRIBUTING.md`.** O `CLAUDE.md` pede para não criar doc novo sem necessidade. Escrevi ele deliberadamente fino — roteia para `ARCHITECTURE.md`, `specs/`, `CLAUDE.md` e `RELEASE.md` em vez de repetir as regras. A justificativa é de **público**, não de conteúdo: o `CLAUDE.md` é escrito para o agente, e um humano que chega pelo GitHub não vai abri-lo. Se discordar, é só remover o arquivo — o resto da PR não depende dele.

2. **A tag `v6.0.0` não foi criada.** De propósito: ela precisa apontar para um commit que já esteja na `main`, e estas mudanças ainda estão na `refactor-structure`. Depois do merge daqui e do merge para a `main`, o comando é:
   ```bash
   git checkout main && git pull
   git tag -a v6.0.0 -m "v6.0.0"
   git push origin v6.0.0
   ```
   O `release.yml` cuida do resto.

## Verificação

- `npm run build` → 652 KB, sem erro
- 7 suítes passando: `test:content` (55), `test:call-script` (71 passos), `test:emails` (8 modelos PT+ES), `test:note-templates` (27 cenários), `test:shortcuts`, `test:prefs`, `test:deployment-env`
- `scripts/extract-changelog.sh` testado nos dois caminhos: extrai 135 linhas para `6.0.0`, e falha com mensagem útil para uma versão inexistente
- YAML dos 4 arquivos novos validado

## Contexto

Sai da auditoria pré-apresentação. As 23 issues estão em #292–#314, distribuídas nos milestones `v6.1`, `v6.2`, `v6.3` e `Backlog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)