### PR TITLE
fix(emails): roteamento de decisão do TL + toque liquid glass

### DIFF
--- a/gas-backend/BAU_Dashboard.js
+++ b/gas-backend/BAU_Dashboard.js
@@ -103,12 +103,31 @@ function updateBAUCaseStatus(id, newStatus) {
         // O status já foi gravado na planilha (linha acima) antes de chegar aqui -
         // uma falha no envio do email não pode mais derrubar a ação inteira pro
         // cliente (google.script.run reportaria falha mesmo com o status já salvo).
+        //
+        // O tipo de e-mail é escolhido por processedAction, não por newStatus:
+        // newStatus só tem dois valores possíveis ('CREATED'/'DISCARDED'), que o
+        // front-end recicla pras quatro decisões do TL (ver botões em
+        // TLDashboard.html) — 'DISCARDED' tanto confirma um descarte quanto
+        // rejeita uma criação, e 'CREATED' tanto aprova uma criação quanto nega
+        // um descarte. processedAction já desfaz essa ambiguidade (é o mesmo
+        // valor usado na trilha de auditoria), então usá-lo aqui também evita
+        // mandar "Caso descartado" pra uma rejeição de criação, ou "Caso criado"
+        // pra um caso que só continuou ativo.
         let emailSent = true;
         try {
-          if (newStatus === "CREATED") {
-            sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_BAU_CREATED', tlEmail);
-          } else if (newStatus === "DISCARDED") {
-            sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_DISCARD_DONE', tlEmail);
+          switch (processedAction) {
+            case "APPROVED_CREATION":
+              sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_BAU_CREATED', tlEmail);
+              break;
+            case "REJECTED_CREATION":
+              sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_CREATION_REJECTED', tlEmail);
+              break;
+            case "CONFIRMED_DISCARD":
+              sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_DISCARD_DONE', tlEmail);
+              break;
+            case "KEPT_ACTIVE":
+              sendDynamicTechSolEmail(agentEmail, emailData, id, 'AGENT_DISCARD_DENIED', tlEmail);
+              break;
           }
         } catch (e) {
           emailSent = false;

--- a/gas-backend/EmailEngine.js
+++ b/gas-backend/EmailEngine.js
@@ -55,6 +55,14 @@ const EMAIL_I18N = {
     discardDoneMessage: function (adv) { return "O descarte do caso de <strong style=\"font-weight:500;\">" + adv + "</strong> foi aprovado e concluído pela liderança."; },
     discardDoneSubject: function (adv) { return "Caso descartado: " + adv; },
 
+    creationRejectedTitle: "Solicitação recusada",
+    creationRejectedMessage: function (adv) { return "A solicitação para <strong style=\"font-weight:500;\">" + adv + "</strong> foi recusada pela liderança e não será aberta como caso."; },
+    creationRejectedSubject: function (adv) { return "Solicitação recusada: " + adv; },
+
+    discardDeniedTitle: "Descarte negado",
+    discardDeniedMessage: function (adv) { return "A liderança negou o pedido de descarte do caso de <strong style=\"font-weight:500;\">" + adv + "</strong>. O caso permanece ativo."; },
+    discardDeniedSubject: function (adv) { return "Descarte negado: " + adv; },
+
     labelContext: "Motivo",
     labelDomain: "Domínio final",
     labelSchedule: "Agendamento (SLA)",
@@ -95,6 +103,14 @@ const EMAIL_I18N = {
     discardDoneMessage: function (adv) { return "El descarte del caso de <strong style=\"font-weight:500;\">" + adv + "</strong> fue aprobado y concluido por la gerencia."; },
     discardDoneSubject: function (adv) { return "Caso descartado: " + adv; },
 
+    creationRejectedTitle: "Solicitud rechazada",
+    creationRejectedMessage: function (adv) { return "La solicitud para <strong style=\"font-weight:500;\">" + adv + "</strong> fue rechazada por la gerencia y no será abierta como caso."; },
+    creationRejectedSubject: function (adv) { return "Solicitud rechazada: " + adv; },
+
+    discardDeniedTitle: "Descarte denegado",
+    discardDeniedMessage: function (adv) { return "La gerencia denegó la solicitud de descarte del caso de <strong style=\"font-weight:500;\">" + adv + "</strong>. El caso permanece activo."; },
+    discardDeniedSubject: function (adv) { return "Descarte denegado: " + adv; },
+
     labelContext: "Motivo",
     labelDomain: "Dominio final",
     labelSchedule: "Programación (SLA)",
@@ -124,12 +140,21 @@ const EMAIL_TOKENS = {
   link: "#1A73E8",
 
   // Acentos por tipo. Tons de superfície clara, e não os pastéis do antigo
-  // cabeçalho escuro — num cartão branco aqueles ficavam lavados. Vivem no
-  // filete sob o nome do produto, que é o único lugar onde a cor varia por tipo.
+  // cabeçalho escuro — num cartão branco aqueles ficavam lavados. Vivem na base
+  // do chip de identidade, que é o único lugar onde a cor varia por tipo.
   accentBlue: "#1A73E8",
   accentGreen: "#1E8E3E",
   accentAmber: "#E37400",
   accentRed: "#D93025",
+
+  // O chip "Cases Wizard" — o único toque de liquid glass do e-mail. Fica escuro
+  // em qualquer tema (não segue a paleta clara/dm-* do resto do cartão): é
+  // identidade de produto, não conteúdo, e por isso não muda com o tema do
+  // cliente de e-mail.
+  glassBg1: "#26272B",
+  glassBg2: "#313340",
+  glassBorder: "rgba(255,255,255,0.10)",
+  glassText: "#E8EAED",
 
   // Avisos. Só aparecem quando há de fato algo a avisar.
   urgentBg: "#FCE8E6",
@@ -180,12 +205,13 @@ function fillEmailSlot(html, token, value) {
 }
 
 function applyEmailTokens(html) {
-  const resolved = html.replace(/{{t\.([A-Za-z]+)}}/g, function (match, key) {
+  // [A-Za-z0-9]+, não só letras: glassBg1/glassBg2 têm dígito no nome.
+  const resolved = html.replace(/{{t\.([A-Za-z0-9]+)}}/g, function (match, key) {
     return Object.prototype.hasOwnProperty.call(EMAIL_TOKENS, key) ? EMAIL_TOKENS[key] : match;
   });
   // Token inexistente é erro de digitação, não valor vazio: estourar aqui é bem
   // melhor do que entregar "{{t.corDoTexto}}" no meio de um atributo style.
-  const unknown = resolved.match(/{{t\.[A-Za-z]+}}/g);
+  const unknown = resolved.match(/{{t\.[A-Za-z0-9]+}}/g);
   if (unknown) {
     throw new Error("Token de e-mail desconhecido: " + unknown.join(", "));
   }
@@ -372,6 +398,31 @@ function sendDynamicTechSolEmail(destinatario, data, escalacaoId, tipoEmail, aut
       title = L.discardDoneTitle;
       lead = L.discardDoneMessage(data.advName);
       subject = L.discardDoneSubject(data.advName);
+      break;
+
+    // A liderança recusou o pedido de ABERTURA de um caso novo. Distinto de
+    // AGENT_DISCARD_DONE: ali um caso existente é descartado; aqui o caso nunca
+    // chegou a existir. Antes das duas linhas abaixo, updateBAUCaseStatus()
+    // reciclava o valor de status 'DISCARDED' pra essa decisão e o agente
+    // recebia "Caso descartado" para uma solicitação que nunca tinha sido
+    // aberta.
+    case 'AGENT_CREATION_REJECTED':
+      accent = EMAIL_TOKENS.accentRed;
+      title = L.creationRejectedTitle;
+      lead = L.creationRejectedMessage(data.advName);
+      subject = L.creationRejectedSubject(data.advName);
+      break;
+
+    // A liderança negou o pedido de DESCARTE de um caso existente — o caso
+    // continua ativo. Distinto de AGENT_BAU_CREATED: ali um caso passa a
+    // existir agora; aqui um caso que já existia apenas não foi descartado.
+    // Mesma razão do caso acima: updateBAUCaseStatus() reciclava o status
+    // 'CREATED' e o agente recebia "Caso criado" para um caso que já existia.
+    case 'AGENT_DISCARD_DENIED':
+      accent = EMAIL_TOKENS.accentGreen;
+      title = L.discardDeniedTitle;
+      lead = L.discardDeniedMessage(data.advName);
+      subject = L.discardDeniedSubject(data.advName);
       break;
   }
 

--- a/gas-backend/EmailTemplateDynamic.html
+++ b/gas-backend/EmailTemplateDynamic.html
@@ -58,11 +58,20 @@
                         <td style="padding: 32px 32px 8px 32px;">
 
                             <!-- Identidade do produto. O único toque de Cases Wizard no
-                                 e-mail: o nome, e um filete que carrega a cor do tipo —
-                                 o mesmo código de cor do TL Dashboard, sem virar enfeite. -->
-                            <p style="margin: 0 0 8px 0; font-family: {{t.fontSans}}; font-size: {{t.sizeMeta}}; font-weight: 500; color: {{t.textMuted}};" class="dm-muted">Cases Wizard</p>
+                                 e-mail: um chip escuro (a mesma família do dark glass do
+                                 header do app, em header-factory.js — sem backdrop-filter,
+                                 que nenhum cliente de e-mail aplica de verdade) com a cor
+                                 do tipo na base, no lugar de um filete solto. Pequeno de
+                                 propósito: é o único elemento escuro da página. -->
                             <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 0 26px 0;">
-                                <tr><td style="width: 28px; height: 3px; line-height: 3px; font-size: 0; background-color: {{ACCENT}};">&nbsp;</td></tr>
+                                <tr>
+                                    <td style="border-radius: 8px 8px 0 0; background: linear-gradient(135deg, {{t.glassBg1}} 0%, {{t.glassBg2}} 100%); border: 1px solid {{t.glassBorder}}; border-bottom: none; padding: 7px 12px 5px 12px;">
+                                        <span style="font-family: {{t.fontSans}}; font-size: {{t.sizeLabel}}; font-weight: 500; letter-spacing: 0.2px; color: {{t.glassText}};">Cases Wizard</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="height: 2px; line-height: 2px; font-size: 0; background-color: {{ACCENT}}; border-radius: 0 0 8px 8px;">&nbsp;</td>
+                                </tr>
                             </table>
 
                             <h1 style="margin: 0 0 12px 0; font-family: {{t.fontSans}}; font-size: {{t.sizeTitle}}; font-weight: 400; line-height: 1.35; color: {{t.textStrong}};" class="dm-text">{{TITLE}}</h1>


### PR DESCRIPTION
Continuação do #355 (já mergeado). Esse commit tinha ficado órfão na branch antiga — foi empurrado depois que o #355 já havia sido mergeado, então este PR o traz isolado, cherry-picked sobre o `refactor-structure` atual.

## O que corrige

Lucas testou o resultado do #355 e achou dois bugs de conteúdo e uma lacuna de identidade.

**Os dois bugs têm a mesma causa.** `updateBAUCaseStatus()` escolhia o e-mail pelo `newStatus` bruto, que só tem dois valores (`'CREATED'`/`'DISCARDED'`) reciclados pelas quatro decisões do TL (ver os dois botões de ação em `TLDashboard.html`):

- Rejeitar uma solicitação de **criação** manda `newStatus='DISCARDED'` — o mesmo valor de "confirmar descarte". O backend testava `newStatus === "DISCARDED"` e disparava `AGENT_DISCARD_DONE` ("Caso descartado") para uma solicitação que nunca tinha sido aberta como caso.
- Manter um caso **ativo** (negar um pedido de descarte) manda `newStatus='CREATED'` — o mesmo valor de "aprovar criação". O backend disparava `AGENT_BAU_CREATED` ("Caso criado") para um caso que já existia.

`resolveProcessedAction()` já calculava a classificação certa (`APPROVED_CREATION`/`REJECTED_CREATION`/`CONFIRMED_DISCARD`/`KEPT_ACTIVE`), usada até aqui só na trilha de auditoria. O switch de envio de e-mail passa a usar essa classificação em vez do `newStatus` bruto, com dois tipos novos para os desfechos que não tinham mensagem própria: `AGENT_CREATION_REJECTED` ("Solicitação recusada") e `AGENT_DISCARD_DENIED` ("Descarte negado").

**A lacuna de identidade:** depois do passe de sobriedade Material do #355, os e-mails ficaram genéricos demais — "dá a impressão de que são de um serviço externo". Entra um chip escuro no topo ("Cases Wizard", gradiente sutil na família do dark glass do header do app em `header-factory.js`, sem `backdrop-filter` porque nenhum cliente de e-mail aplica blur de verdade), pequeno e não-predominante, com a cor do tipo agora na base do chip em vez do filete solto que existia.

## Bug lateral que a implementação revelou

`applyEmailTokens()` resolvia tokens com uma regex que só aceitava letras no nome (`[A-Za-z]+`). As cores do chip (`glassBg1`/`glassBg2`) têm dígito no nome e nunca resolviam — e a mesma regex era usada para checar "token desconhecido", então o bug não estourava erro nenhum: só vazaria `{{t.glassBg1}}` literal no HTML do e-mail em produção. Corrigido para `[A-Za-z0-9]+`.

## Verificação

Harness de conteúdo (7 tipos × PT/ES + alerta de volume = 15 e-mails) e um segundo harness dedicado que chama `updateBAUCaseStatus()` de ponta a ponta com uma planilha falsa para os 4 desfechos do TL — é o teste que trava a regressão do bug de roteamento. Reexecutados agora contra o `refactor-structure` atual (que recebeu outros merges desde o #355), não só contra a branch antiga.

Refs #316, #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
