### PR TITLE
feat(hosting): publica o bundle no Firebase Hosting com WIF

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,13 @@
+{
+  "projects": {
+    "default": "cases-wizard"
+  },
+  "targets": {
+    "cases-wizard": {
+      "hosting": {
+        "prod": ["cases-wizard"],
+        "dev": ["cases-wizard-dev"]
+      }
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normaliza as quebras de linha.
+#
+# O repositório armazena LF, mas o desenvolvimento acontece em Windows/WSL, onde
+# o editor grava CRLF. Sem esta regra, todo arquivo tocado aparece como modificado
+# no `git status` mesmo sem mudança de conteúdo — chegamos a ter 29 arquivos assim,
+# com 2.880 linhas de diff que somem inteiras sob `--ignore-all-space`.
+#
+# `text=auto eol=lf` faz o git normalizar para LF ao gravar, independentemente do
+# que o editor produziu. Os arquivos binários abaixo ficam de fora, porque
+# normalizar bytes de imagem ou vídeo os corrompe.
+
+* text=auto eol=lf
+
+*.png  binary
+*.webm binary

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,16 @@
-name: Build and Deploy (GH Pages & Apps Script)
+name: Build and Deploy (Firebase, GH Pages & Apps Script)
 
 on:
   push:
     branches:
       - main
       - refactor-structure
+
+# Declarado explicitamente para que o GITHUB_TOKEN não venha com o conjunto
+# permissivo padrão. `id-token: write` é o que permite ao job do frontend
+# pedir o token OIDC do WIF, e por isso fica só nele, não aqui.
+permissions:
+  contents: read
 
 jobs:
   # ==========================================
@@ -19,17 +25,30 @@ jobs:
     # janela - backend novo com frontend antigo continua funcionando, porque
     # operação nova que ninguém chama ainda é inofensiva.
     needs: deploy-backend-gas
+
+    # `id-token: write` deixa o runner pedir ao GitHub o token OIDC que o
+    # Workload Identity Federation troca por credencial do Google Cloud. É o
+    # que substitui uma chave de service account guardada como secret: nada
+    # de longa duração fica no repositório, e o token vale minutos.
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: '18'
+          node-version: '20'
+          cache: 'npm'
 
-      - name: Install esbuild
-        run: npm install esbuild
+      # `npm ci` no lugar de `npm install esbuild`: instala exatamente o que
+      # está no package-lock.json em vez de baixar o compilador solto a cada
+      # build. Fecha a #352.
+      - name: Install dependencies
+        run: npm ci
 
       # `--define:__CW_BUILD_ENV__` é o que faz src/modules/shared/data-service.js
       # escolher entre o deployment de produção e o de desenvolvimento do Apps
@@ -48,7 +67,55 @@ jobs:
         if: github.ref == 'refs/heads/refactor-structure'
         run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --minify --define:__CW_BUILD_ENV__='"development"'
         
-      - name: Deploy to GitHub Pages
+      # --- DESTINO NOVO: FIREBASE HOSTING ------------------------------------
+      #
+      # Autentica por Workload Identity Federation. O GitHub emite um token
+      # OIDC para ESTE repositório - não para uma pessoa - e o Google troca
+      # por credencial de curta duração. A condição travada no provider
+      # (`assertion.repository == 'lucastdcs/case-wizard'`) é o que impede
+      # qualquer outro repositório de assumir a mesma identidade.
+      #
+      # Diferente do CLASPRC_JSON do job de backend, aqui não existe
+      # credencial armazenada: nada a vazar, nada a rotacionar.
+
+      - name: Autenticar no Google Cloud (WIF)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: cases-wizard
+          workload_identity_provider: projects/185063379439/locations/global/workloadIdentityPools/github/providers/github
+          service_account: gh-deployer@cases-wizard.iam.gserviceaccount.com
+
+      # Cada branch publica no SEU site, espelhando a separação que o job de
+      # backend já faz entre as implantações do Apps Script:
+      #
+      #   refactor-structure  ->  cases-wizard-dev.web.app
+      #   main                ->  cases-wizard.web.app
+      #
+      # A versão do firebase-tools é fixa pelo mesmo motivo do `npm ci` acima:
+      # nada que constrói ou publica deve ser baixado solto. Ao atualizar,
+      # mude aqui de propósito.
+      - name: Publicar no Firebase Hosting
+        env:
+          TARGET: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+        run: |
+          npx --yes firebase-tools@15.28.2 deploy \
+            --only "hosting:${TARGET}" \
+            --project cases-wizard \
+            --message "${GITHUB_SHA}" \
+            --non-interactive
+
+      # --- DESTINO ANTIGO: GITHUB PAGES --------------------------------------
+      #
+      # Mantido de propósito durante a transição. Enquanto houver agente com o
+      # favorito antigo, desligar isto congelaria o bundle dele na última
+      # versão publicada - o pior modo de falha, porque a ferramenta continua
+      # abrindo e ninguém percebe que parou de receber correções.
+      #
+      # Remover este passo é o corte, e só depois que todos migrarem. Junto
+      # dele, desativar o GitHub Pages nos DOIS repositórios: `case-wizard` e
+      # `techsol_DialIn_AutoCopy`, cujo bundle.js ainda responde 200 e é o que
+      # o README instalava até este commit.
+      - name: Deploy to GitHub Pages (legado, remover no corte)
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -107,19 +107,21 @@ CI (`.github/workflows/deploy.yml`) builds and publishes automatically on every 
 
 Since there's no localhost target, "running" the app means loading the bundle in the browser via a bookmarklet. Create a browser bookmark with one of the following as its URL, then click it while on the CRM page:
 
-**Production** (bypasses CSP via `trustedTypes`, points at the GitHub Pages–hosted `bundle.js`):
+**Production** (bypasses CSP via `trustedTypes`, points at the Firebase-hosted `bundle.js`):
 
 ```javascript
-javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/case-wizard/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();
+javascript:(function(){    const scriptUrl = 'https://cases-wizard.web.app/bundle.js';        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();
 ```
 
-**Development** (points at `bundle-dev.js`, logs to console):
+**Development** (points at `bundle-dev.js` on the dev site, logs to console):
 
 ```javascript
-javascript:(function(){    var s = document.createElement('script');    s.src = 'https://lucastdcs.github.io/case-wizard/bundle-dev.js?t=' + new Date().getTime();    s.onload = function() { console.log('✅ TechSol DEV carregado!'); };    s.onerror = function() { alert('❌ Erro ao carregar TechSol DEV: Arquivo não encontrado ou bloqueado.'); };    document.body.appendChild(s);})();
+javascript:(function(){    var s = document.createElement('script');    s.src = 'https://cases-wizard-dev.web.app/bundle-dev.js';    s.onload = function() { console.log('✅ TechSol DEV carregado!'); };    s.onerror = function() { alert('❌ Erro ao carregar TechSol DEV: Arquivo não encontrado ou bloqueado.'); };    document.body.appendChild(s);})();
 ```
 
-Push a change to `refactor-structure`, wait for CI to finish, then click the Dev bookmarklet again to pick it up (the cache-busting timestamp forces a fresh download each click).
+Push a change to `refactor-structure`, wait for CI to finish, then click the Dev bookmarklet again to pick it up.
+
+> **The `?t=` cache-buster is gone, on purpose.** It existed because GitHub Pages served the bundle with a fixed `max-age` and no way to override it, so the only way to guarantee a fresh copy was to make every URL unique — which forced a full ~668 KB download on every single click. Firebase lets us set the header directly: production is served with `Cache-Control: no-cache`, which means *"cache it, but revalidate"*, so a repeat click becomes a `304 Not Modified` instead of a fresh download. The dev site goes further with `no-store`. Adding `?t=` back would defeat both and make loading slower, not safer.
 
 ### 5. Backend changes (optional)
 
@@ -264,7 +266,9 @@ In practice, day-to-day work happens on `refactor-structure` (which gets both bu
 
 ### Bookmarklet does nothing / blocked by network
 
-The script depends on reaching `github.io`. If the corporate network blocks that domain, the bundle will never load — check the browser's Network tab for a blocked/failed request to `lucastdcs.github.io`.
+The script depends on reaching `web.app`. If the corporate network blocks that domain, the bundle will never load — check the browser's Network tab for a blocked/failed request to `cases-wizard.web.app` (or `cases-wizard-dev.web.app` for the Dev bookmarklet).
+
+If you are still on an older bookmarklet pointing at `lucastdcs.github.io`, that is the pre-Firebase hosting. It still answers today, but it is being retired — switch to the bookmarklets above.
 
 ### Dev bookmarklet shows old code
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,48 @@
+{
+  "hosting": [
+    {
+      "target": "prod",
+      "public": "dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**",
+        "**/bundle-dev.js"
+      ],
+      "headers": [
+        {
+          "source": "/bundle.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache" },
+            { "key": "Access-Control-Allow-Origin", "value": "*" }
+          ]
+        },
+        {
+          "source": "/bundle.*.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
+            { "key": "Access-Control-Allow-Origin", "value": "*" }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "dev",
+      "public": "dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-store" },
+            { "key": "Access-Control-Allow-Origin", "value": "*" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Migra a hospedagem do bundle do GitHub Pages para o Firebase Hosting, mantendo o Pages publicando em paralelo durante a transição.

Substitui a direção que vinha sendo estudada no ADR 0005 e na #356: em vez de verificar a integridade de um bundle servido de um repositório público, o bundle passa a sair de uma origem sob controle de IAM do Google Cloud.

## Roteamento

Cada branch publica no seu site, espelhando a separação que o job de backend já fazia entre as implantações do Apps Script:

| branch | build | define | site |
|---|---|---|---|
| `main` | `bundle.js` | `production` | `cases-wizard.web.app` |
| `refactor-structure` | `bundle-dev.js` | `development` | `cases-wizard-dev.web.app` |

## Autenticação sem credencial armazenada

O deploy usa Workload Identity Federation. O GitHub emite um token OIDC para **este repositório** — não para uma pessoa — e o Google troca por credencial de curta duração. Não há chave a vazar nem a rotacionar.

A condição travada no provider (`assertion.repository == 'lucastdcs/case-wizard'`) é o que impede outro repositório de assumir a mesma identidade. Sem ela o deploy funcionaria igual, que é justamente o que a torna fácil de esquecer numa revisão.

Isso não substitui o `CLASPRC_JSON` do job de backend, que continua sendo o elo fraco e segue registrado na #351.

## O GitHub Pages continua vivo, de propósito

Remover aquele passo agora congelaria o bundle de todo agente que ainda tem o favorito antigo — o pior modo de falha, porque a ferramenta continua abrindo e ninguém percebe que parou de receber correções.

A remoção é o corte, num PR posterior, e só depois que todos migrarem. **Junto dela é preciso desativar o Pages nos dois repositórios:** `case-wizard` e `techsol_DialIn_AutoCopy` — este segundo ainda responde 200 e era o que o README instalava até recentemente.

## De carona

- **#352** — `npm ci` no lugar de `npm install esbuild`, que ignorava o `package-lock.json` e baixava o compilador solto a cada build.
- **#351 (parcial)** — `permissions:` declarado e actions fixadas em SHA em vez de tag móvel, que era um caminho de execução de código no job que carrega o `CLASPRC_JSON`. O `id-token: write` fica isolado no job do frontend.

## Cache

O `?t=` sai dos favoritos. Ele existia porque o Pages servia com `max-age` fixo e a única forma de garantir cópia nova era tornar cada URL única — o que forçava baixar os 668 KB inteiros a cada clique. Com `Cache-Control: no-cache` o ETag transforma o clique repetido num `304`. Mantê-lo deixaria o carregamento mais lento, não mais seguro.

## Verificação feita

- Roteamento branch → build → define → site traçado a partir dos arquivos, não de memória.
- `--define:__CW_BUILD_ENV__` preservado nos dois builds. Sem ele o bundle cai no fallback silencioso e produção fala com o backend de desenvolvimento.
- `needs: deploy-backend-gas` preservado — o backend continua indo primeiro.
- `npm ci --dry-run` resolve o lockfile sem erro.
- Alvos do `firebase.json` e do `.firebaserc` conferem.

## O que só o merge valida

O passo **"Publicar no Firebase Hosting"** é a única peça que não deu para validar sem executar: se o `firebase-tools` enxerga a credencial que o WIF deixa em `GOOGLE_APPLICATION_CREDENTIALS`. Se falhar, falha ali, com erro de credencial.

Por isso este PR mira `refactor-structure`: o primeiro deploy real acontece no site de dev, sem tocar em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myp7qcA8fRPELBRHwtfv1P
