### PR TITLE
fix(ci): publica no GitHub Pages antes do Firebase, não depois

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,33 @@ jobs:
         if: github.ref == 'refs/heads/refactor-structure'
         run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --minify --define:__CW_BUILD_ENV__='"development"'
         
+      # --- DESTINO ANTIGO: GITHUB PAGES --------------------------------------
+      #
+      # Vai PRIMEIRO, pela mesma lógica que faz o backend ir antes do frontend:
+      # o caminho de que as pessoas já dependem nunca pode ficar refém do
+      # caminho novo. Este passo esteve depois do Firebase por um commit, e a
+      # primeira falha do deploy novo pulou a publicação legada inteira - os
+      # agentes com o favorito antigo teriam ficado sem a atualização por causa
+      # de um problema numa rota que nenhum deles usa ainda.
+      #
+      # Mantido de propósito durante a transição. Enquanto houver agente com o
+      # favorito antigo, desligar isto congelaria o bundle dele na última
+      # versão publicada - o pior modo de falha, porque a ferramenta continua
+      # abrindo e ninguém percebe que parou de receber correções.
+      #
+      # Remover este passo é o corte, e só depois que todos migrarem. Junto
+      # dele, desativar o GitHub Pages nos DOIS repositórios: `case-wizard` e
+      # `techsol_DialIn_AutoCopy`, cujo bundle.js ainda responde 200 e é o que
+      # o README instalava até recentemente.
+      - name: Deploy to GitHub Pages (legado, remover no corte)
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          cname: ''
+          keep_files: true
+
       # --- DESTINO NOVO: FIREBASE HOSTING ------------------------------------
       #
       # Autentica por Workload Identity Federation. O GitHub emite um token
@@ -77,6 +104,12 @@ jobs:
       #
       # Diferente do CLASPRC_JSON do job de backend, aqui não existe
       # credencial armazenada: nada a vazar, nada a rotacionar.
+      #
+      # A service account precisa de DOIS papéis, e é fácil parar no primeiro:
+      # `firebasehosting.admin` autoriza publicar, mas resolver o projeto passa
+      # pela API de gerenciamento e exige `firebase.viewer`. Só com o primeiro,
+      # o deploy falha com "Failed to get Firebase project", que parece
+      # problema de credencial e é de permissão.
 
       - name: Autenticar no Google Cloud (WIF)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -103,26 +136,6 @@ jobs:
             --project cases-wizard \
             --message "${GITHUB_SHA}" \
             --non-interactive
-
-      # --- DESTINO ANTIGO: GITHUB PAGES --------------------------------------
-      #
-      # Mantido de propósito durante a transição. Enquanto houver agente com o
-      # favorito antigo, desligar isto congelaria o bundle dele na última
-      # versão publicada - o pior modo de falha, porque a ferramenta continua
-      # abrindo e ninguém percebe que parou de receber correções.
-      #
-      # Remover este passo é o corte, e só depois que todos migrarem. Junto
-      # dele, desativar o GitHub Pages nos DOIS repositórios: `case-wizard` e
-      # `techsol_DialIn_AutoCopy`, cujo bundle.js ainda responde 200 e é o que
-      # o README instalava até este commit.
-      - name: Deploy to GitHub Pages (legado, remover no corte)
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: gh-pages
-          cname: ''
-          keep_files: true
 
   # ==========================================
   # JOB 2: BACKEND (Clasp -> Google Apps Script)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Drop image files into [`docs/media/`](docs/media/) and swap the placeholder cell
 - **Data store**: Google Sheets (accessed from Apps Script — see `specs/data-models/db-schema.md`)
 - **Backend transport**: JSONP (not `fetch`) to avoid CORS restrictions against the Apps Script Web App
 - **CI/CD**: GitHub Actions (`.github/workflows/deploy.yml`)
-- **Frontend hosting**: GitHub Pages (serves the built bundle)
+- **Frontend hosting**: Firebase Hosting (serves the built bundle; GitHub Pages still publishes in parallel until every agent has switched bookmarklets)
 - **Visual portfolio generation**: Python 3 + [Playwright](https://playwright.dev/) (optional, dev-only tooling)
 
 ## Prerequisites


### PR DESCRIPTION
O passo legado do GitHub Pages estava **depois** do deploy no Firebase, e a primeira falha do caminho novo pulou a publicação legada inteira. O run [33426077216](https://github.com/lucastdcs/case-wizard/actions/runs/33426077216) promoveu o backend, construiu o bundle e **não publicou frontend em lugar nenhum**.

```
success  Autenticar no Google Cloud (WIF)
failure  Publicar no Firebase Hosting
skipped  Deploy to GitHub Pages (legado)   ← 
```

Durante a transição essa ordem está invertida. O GitHub Pages é o caminho de que os agentes dependem **hoje**; o Firebase é o que ainda está sendo validado. Um problema numa rota que ninguém usa ainda não pode impedir a atualização de quem usa a outra.

É a mesma lógica que já governa o `needs: deploy-backend-gas` neste workflow: o que as pessoas dependem vai primeiro. O job continua falhando se o Firebase falhar — o sinal de erro não se perde. O que muda é que a publicação legada acontece antes de o sinal aparecer.

## Também documenta a causa da falha atual

A service account precisa de **dois** papéis, e é fácil parar no primeiro:

| papel | para quê |
|---|---|
| `roles/firebasehosting.admin` | publicar no Hosting |
| `roles/firebase.viewer` | resolver o projeto pela API de gerenciamento |

Só com o primeiro, o deploy falha com `Failed to get Firebase project`, que **parece problema de credencial e é de permissão** — foi exatamente onde este deploy parou. Ficou registrado no comentário do passo de autenticação para não custar o mesmo debug de novo.

A correção de IAM em si é feita fora do repositório, no projeto do Google Cloud.

## Verificação

- YAML faz parse; o job do frontend tem 8 passos, `needs: deploy-backend-gas` e `permissions: {contents: read, id-token: write}` preservados.
- O passo do Pages aparece **uma vez** e antes do Firebase (checado programaticamente — a primeira tentativa duplicou o passo e a verificação pegou).
- README: corrigida a linha de Tech Stack que ainda dizia GitHub Pages como hospedagem do frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myp7qcA8fRPELBRHwtfv1P
