### PR TITLE
fix(ci): restaura contents:write e torna os dois destinos independentes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,15 @@ jobs:
     # Workload Identity Federation troca por credencial do Google Cloud. É o
     # que substitui uma chave de service account guardada como secret: nada
     # de longa duração fica no repositório, e o token vale minutos.
+    #
+    # `contents: write` existe por causa do passo legado do GitHub Pages, que
+    # empurra um commit para a branch `gh-pages`. Enquanto não houve bloco
+    # `permissions:` no workflow, o GITHUB_TOKEN vinha com o conjunto
+    # permissivo padrão e isso funcionava por acidente; declarar apenas
+    # `contents: read` derrubou a publicação com 403. Some junto com o passo
+    # do Pages, no corte - a partir dali o job volta a precisar só de leitura.
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
@@ -59,11 +66,13 @@ jobs:
 
       # --- BUILD DE PRODUÇÃO (Apenas na main) ---
       - name: Build Production (bundle.js)
+        id: build_prod
         if: github.ref == 'refs/heads/main'
         run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle.js --minify --define:__CW_BUILD_ENV__='"production"'
 
       # --- BUILD DE DESENVOLVIMENTO (Apenas na refactor) ---
       - name: Build Development (bundle-dev.js)
+        id: build_dev
         if: github.ref == 'refs/heads/refactor-structure'
         run: ./node_modules/.bin/esbuild src/app.js --bundle --outfile=dist/bundle-dev.js --minify --define:__CW_BUILD_ENV__='"development"'
         
@@ -111,7 +120,22 @@ jobs:
       # o deploy falha com "Failed to get Firebase project", que parece
       # problema de credencial e é de permissão.
 
+      # A condição dos dois passos abaixo mantém os destinos INDEPENDENTES.
+      # Passos de um job são sequenciais, então sem ela um destino que falha
+      # pula o outro - e a ordem só decide qual dos dois sequestra o outro. Já
+      # aconteceu nos dois sentidos: o Firebase falhando pulou o Pages, depois
+      # o Pages falhando pulou o Firebase. O job ainda falha se qualquer um
+      # falhar, então nenhum sinal de erro se perde; o que muda é que uma rota
+      # quebrada não impede a publicação da outra.
+      #
+      # A condição olha o BUILD, não só `!cancelled()`. A diferença importa:
+      # com `!cancelled()` sozinho, um build que falhasse ainda dispararia o
+      # deploy, e `firebase deploy` com dist/ vazio APAGA os arquivos do site.
+      # O Pages não corre esse risco porque usa keep_files. Como um dos dois
+      # builds é sempre pulado por branch, a condição aceita qualquer um dos
+      # dois com sucesso.
       - name: Autenticar no Google Cloud (WIF)
+        if: ${{ !cancelled() && (steps.build_prod.outcome == 'success' || steps.build_dev.outcome == 'success') }}
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: cases-wizard
@@ -128,9 +152,21 @@ jobs:
       # nada que constrói ou publica deve ser baixado solto. Ao atualizar,
       # mude aqui de propósito.
       - name: Publicar no Firebase Hosting
+        if: ${{ !cancelled() && (steps.build_prod.outcome == 'success' || steps.build_dev.outcome == 'success') }}
         env:
           TARGET: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+          BUNDLE: ${{ github.ref == 'refs/heads/main' && 'bundle.js' || 'bundle-dev.js' }}
         run: |
+          # Trava contra publicar vazio. `firebase deploy` sincroniza o
+          # diretório: se dist/ chegar sem o bundle, ele não falha - ele apaga
+          # o site e reporta sucesso. Falhar aqui é sempre melhor.
+          if [ ! -s "dist/${BUNDLE}" ]; then
+            echo "::error::dist/${BUNDLE} não existe ou está vazio. Abortando para não esvaziar o site."
+            ls -la dist/ || echo "(dist/ nem existe)"
+            exit 1
+          fi
+          echo "Publicando dist/${BUNDLE} ($(stat -c%s "dist/${BUNDLE}") bytes) em hosting:${TARGET}"
+
           npx --yes firebase-tools@15.28.2 deploy \
             --only "hosting:${TARGET}" \
             --project cases-wizard \


### PR DESCRIPTION
Corrige uma regressão que **eu introduzi** ao declarar `permissions:` no workflow como parte do endurecimento da #351.

Antes não havia bloco `permissions:` nenhum, então o `GITHUB_TOKEN` vinha com o conjunto permissivo padrão e o passo do GitHub Pages funcionava por acidente. Declarar `contents: read` derrubou a publicação:

```
Permission to lucastdcs/case-wizard.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

O `peaceiris/actions-gh-pages` empurra um commit para a branch `gh-pages`, o que exige escrita. O job do frontend volta a ter `contents: write`; o workflow segue em `contents: read`, que é o que o job de backend precisa. Quando o passo do Pages sair, no corte, o job volta a precisar só de leitura — está anotado no comentário.

## A metade estrutural

Trocar a ordem no PR #364 não resolveu o problema de fundo, só mudou quem bloqueia quem. Passos de um job são sequenciais, então um destino que falha pula o outro:

| run | falhou | pulou |
|---|---|---|
| #363 | Firebase | Pages |
| #364 | Pages | Firebase |

Os passos do Firebase passam a ter condição própria. O job continua falhando se qualquer destino falhar — nenhum sinal de erro se perde. O que muda é que uma rota quebrada não impede a publicação da outra.

## Por que a condição olha o build, e não só `!cancelled()`

Essa parte não é cosmética. Com `!cancelled()` sozinho, um build que falhasse ainda dispararia o deploy — e **`firebase deploy` com `dist/` vazio não falha**: ele sincroniza o diretório, apaga o site e reporta sucesso. O Pages não corre esse risco porque usa `keep_files: true`.

A condição virou `!cancelled() && (steps.build_prod.outcome == 'success' || steps.build_dev.outcome == 'success')`, aceitando qualquer um dos dois builds porque um deles é sempre pulado por branch.

Pelo mesmo motivo, o passo de publicação agora verifica que o bundle existe e não está vazio antes de chamar o firebase, e aborta com erro explícito se não estiver. Publicar nada é o único modo de falha deste workflow que **destrói o que já estava no ar**.

## Verificação

Auditoria programática cruzando cada action com a permissão que ela exige:

```
=== build-and-deploy-frontend   {contents: write, id-token: write}
    [ok] actions/checkout              exige contents:read
    [ok] peaceiris/actions-gh-pages    exige contents:write
    [ok] google-github-actions/auth    exige id-token:write

=== deploy-backend-gas          {contents: read}
    [ok] actions/checkout              exige contents:read
```

- `steps.build_prod` / `steps.build_dev` existem e as referências resolvem.
- Condição simulada nas duas branches: o deploy roda em ambas.
- `BUNDLE` acompanha `TARGET` (`main`→`bundle.js`, `refactor-structure`→`bundle-dev.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myp7qcA8fRPELBRHwtfv1P
