### PR TITLE
docs: sincroniza a documentação com a migração para o Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ javascript:(function(){    var s = document.createElement('script');    s.src = 
 
 Push a change to `refactor-structure`, wait for CI to finish, then click the Dev bookmarklet again to pick it up.
 
-> **The `?t=` cache-buster is gone, on purpose.** It existed because GitHub Pages served the bundle with a fixed `max-age` and no way to override it, so the only way to guarantee a fresh copy was to make every URL unique — which forced a full ~668 KB download on every single click. Firebase lets us set the header directly: production is served with `Cache-Control: no-cache`, which means *"cache it, but revalidate"*, so a repeat click becomes a `304 Not Modified` instead of a fresh download. The dev site goes further with `no-store`. Adding `?t=` back would defeat both and make loading slower, not safer.
+> **The `?t=` cache-buster is gone, on purpose.** It existed because GitHub Pages served the bundle with a fixed `max-age` we couldn't override, so the only way to guarantee a fresh copy was to make every URL unique. That guaranteed a full download on every click and made the browser cache useless. Firebase lets us set the header directly, so production is served with `Cache-Control: no-cache` — *"cache it, but revalidate"* — and the URL is stable.
+>
+> **Measured caveat, so nobody repeats the mistake:** conditional requests with `If-None-Match` currently come back `200`, not `304` — verified against the live production URL with the correct encoding-specific ETag. So the revalidation is not yet saving the transfer. What removing `?t=` does buy is a stable cache entry instead of a guaranteed miss.
+>
+> Also worth knowing: the bundle is ~660 KB uncompressed but **~134 KB on the wire** with Brotli. Size arguments about this file should use the compressed number.
+>
+> If repeat-click latency ever matters enough, the fix is a short `max-age` (say 300s, which is roughly what GitHub Pages did) rather than putting `?t=` back — that would serve from cache with no network at all, at the cost of a deploy taking that long to reach agents.
 
 ### 5. Backend changes (optional)
 
@@ -157,7 +163,7 @@ Note that `clasp push` only updates the editor's HEAD — the live `/exec` and `
 │       ├── personal-library/        # Cross-device snippet library
 │       ├── shared/                  # Command center, DOM utils, sound, animations, data service
 │       └── timezone/                # Timezone/meeting planner
-├── dist/                            # Build output (gitignored, published to GitHub Pages)
+├── dist/                            # Build output (gitignored, published to Firebase Hosting)
 ├── gas-backend/                     # Google Apps Script backend, synced via clasp
 │   ├── Código.js                    # doGet(e) router — dispatches by `op=`
 │   ├── BAU_API.js / BAU_Dashboard.js / BAU_Alerts.js
@@ -174,7 +180,7 @@ Note that `clasp push` only updates the editor's HEAD — the live `/exec` and `
 
 ### Injection Mechanism
 
-The bookmarklet appends a cache-busting timestamp to the script URL, then — in the production variant — creates a `trustedTypes` policy named `default` to satisfy the CRM's strict Content Security Policy before injecting a `<script>` tag pointing at the GitHub Pages–hosted bundle.
+The bookmarklet — in the production variant — creates a `trustedTypes` policy named `default` to satisfy the CRM's strict Content Security Policy, then injects a `<script>` tag pointing at the Firebase-hosted bundle. The URL is stable; see the note above on why the `?t=` cache-buster was removed.
 
 ### Boot Sequence (`src/app.js`)
 
@@ -245,11 +251,13 @@ There is no automated test suite in this repository today. Verification is manua
 
 Deployment is fully automated by `.github/workflows/deploy.yml`, triggered on every push to `main` or `refactor-structure`, with two independent jobs:
 
-### Frontend → GitHub Pages
+### Frontend → Firebase Hosting
 
-1. Installs `esbuild`.
-2. Builds `dist/bundle.js` (on `main`) or `dist/bundle-dev.js` (on `refactor-structure`).
-3. Publishes `dist/` to the `gh-pages` branch via `peaceiris/actions-gh-pages`, which GitHub Pages serves from.
+1. Installs dependencies with `npm ci` (locked versions, not a loose `npm install`).
+2. Builds `dist/bundle.js` (on `main`) or `dist/bundle-dev.js` (on `refactor-structure`), each with the matching `--define:__CW_BUILD_ENV__`.
+3. Publishes to the matching Firebase site — `cases-wizard.web.app` from `main`, `cases-wizard-dev.web.app` from `refactor-structure` — authenticating via Workload Identity Federation, so no service-account key is stored in the repository.
+
+**During the transition** the same job also publishes to the `gh-pages` branch via `peaceiris/actions-gh-pages`, so agents who have not switched bookmarklets keep receiving updates. The two destinations are independent: a failure in one does not stop the other. That step is removed at cutover, along with disabling GitHub Pages on both `case-wizard` and `techsol_DialIn_AutoCopy`.
 
 ### Backend → Google Apps Script
 
@@ -273,7 +281,7 @@ If you are still on an older bookmarklet pointing at `lucastdcs.github.io`, that
 
 ### Dev bookmarklet shows old code
 
-The cache-buster (`?t=...`) forces a fresh download, but GitHub Pages/CI can lag behind a push. Confirm the `build-and-deploy-frontend` job finished for your commit before re-clicking the bookmarklet.
+The dev site is served with `Cache-Control: no-store`, so the browser should never hold a stale copy — but CI can lag behind a push. Confirm the `build-and-deploy-frontend` job finished for your commit before re-clicking the bookmarklet.
 
 ### "Timeout: A API demorou muito para responder" in console
 

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -19,7 +19,7 @@
 - **No global/enterprise CLAUDE.md** found (`~/.claude/CLAUDE.md`, macOS/Linux managed paths all absent) → no deference note needed, no AI-attribution policy detected anywhere.
 - **No `PLAN.md`/`TODO.md`/`TASKS.md`/`BACKLOG.md` equivalent** found anywhere in the repo (case-insensitive search, depth 3).
 - **No `docs/superpowers/`** — not in use.
-- CI/CD present (`.github/workflows/deploy.yml`): builds + deploys the frontend to GitHub Pages and syncs/deploys the backend to Apps Script on every push to `main` or `refactor-structure`, with production deployment promotion deliberately left manual.
+- CI/CD present (`.github/workflows/deploy.yml`): builds + deploys the frontend to Firebase Hosting (and, during the transition, to GitHub Pages in parallel) and syncs/deploys the backend to Apps Script on every push to `main` or `refactor-structure`. Each branch promotes its own Apps Script deployment; the production gate is the merge to `main`.
 
 ## What groundrules did
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,8 @@ O projeto é uma **Overlay Application** (Aplicação de Sobreposição) injetad
 
 ### 1.1 O Mecanismo de Injeção
 Para contornar a *Content Security Policy (CSP)* estrita do CRM, o bookmarklet de instalação utiliza a API `trustedTypes`.
-* **Política:** Cria uma política chamada `default` que autoriza a execução de scripts vindos do domínio `lucastdcs.github.io`.
-* **Cache Busting:** Anexa um timestamp (`?t=...`) na URL do script para forçar o navegador a baixar a versão mais recente a cada execução.
+* **Política:** Cria uma política chamada `default` que autoriza a execução de scripts vindos do domínio de hospedagem do bundle — hoje `cases-wizard.web.app` (Firebase Hosting). Durante a transição, `lucastdcs.github.io` continua servindo em paralelo para quem ainda não trocou o favorito.
+* **Cache:** O bundle é servido com `Cache-Control` definido no `firebase.json` (`no-cache` em produção, `no-store` em dev) e a URL é estável. O cache-buster `?t=...` foi removido: ele existia porque o GitHub Pages servia com `max-age` fixo e sem controle nosso, e tornava cada clique um URL novo — o que garantia download completo e inutilizava o cache do navegador.
 
 ## 2. Estrutura de Inicialização (`src/app.js`)
 O ponto de entrada é o arquivo `app.js`. Ele orquestra o "boot" da aplicação em uma ordem específica para garantir estabilidade visual e funcional:

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -20,7 +20,7 @@ Give TechSol's CRM support agents (working BAU/LM cases in PT/ES) a single produ
 - **Communication**: JSONP (`jsonpFetch`), not `fetch`, due to CORS/environment restrictions in the target CRM.
 - **KISS**: code must stay simple, readable, and direct — no premature abstraction.
 - **`specs/` is the absolute source of truth**: if legacy code diverges from a rule in `specs/`, the rule wins and the code must be refactored to match, not the other way around.
-- **Network dependency**: the bookmarklet depends on reaching `github.io`; a corporate network block there breaks loading entirely.
+- **Network dependency**: the bookmarklet depends on reaching `web.app` (Firebase Hosting); a corporate network block there breaks loading entirely. This is a smaller risk than the `github.io` dependency it replaced, since `web.app` is a Google domain, but it is still a single external origin the tool cannot work without.
 - **No durable client-side storage beyond `localStorage`**: user preferences (widget position, sound mute) live there and are lost on a browser cache clear.
 
 ## Out of scope for V1 (non-goals)

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -9,8 +9,11 @@ Como o projeto roda injetado em um ambiente de produção de terceiros, **não e
     * `npm run dev` → `dist/bundle-dev.js` (sem minificação, debug).
     * O GitHub Actions roda o build automaticamente a cada push (`.github/workflows/deploy.yml`), não é necessário rodar manualmente antes de commitar.
 3.  **Deploy:**
-    * Commits na branch `main` geram o `dist/bundle.js` (Produção), publicado via GitHub Pages.
-    * Commits na branch `refactor-structure` geram o `dist/bundle-dev.js` (Desenvolvimento) — na prática, essa é a branch usada no dia a dia; `main` só recebe merge quando algo está pronto para produção.
+    * Commits na branch `main` geram o `dist/bundle.js` (Produção), publicado em `cases-wizard.web.app`.
+    * Commits na branch `refactor-structure` geram o `dist/bundle-dev.js` (Desenvolvimento), publicado em `cases-wizard-dev.web.app` — na prática, essa é a branch usada no dia a dia; `main` só recebe merge quando algo está pronto para produção.
+    * Cada ambiente tem seu próprio site no Firebase Hosting, com URL estável, espelhando a separação que o backend já faz entre as implantações do Apps Script.
+    * **Durante a transição**, o mesmo job também publica no GitHub Pages, para que os agentes que ainda não trocaram o favorito continuem recebendo atualizações. Os dois destinos são independentes: um que falhe não impede o outro. Esse passo sai no corte, junto com a desativação do Pages nos repositórios `case-wizard` e `techsol_DialIn_AutoCopy`.
+    * A autenticação do deploy é por Workload Identity Federation: o GitHub emite um token OIDC para o repositório e o Google troca por credencial de curta duração. Não há chave de service account guardada como secret.
 4.  **Teste:**
     * Vá até o CRM.
     * Use o **Bookmarklet de DEV** (veja `README.md`) para injetar a versão de teste.

--- a/docs/decisions/0005-hospedagem-e-integridade-do-bundle.md
+++ b/docs/decisions/0005-hospedagem-e-integridade-do-bundle.md
@@ -1,7 +1,40 @@
 # 0005 — Hospedagem e integridade do bundle
 
 **Date**: 2026-08-24
-**Status**: Proposed
+**Status**: Superseded (2026-08-31) — pela migração para o Firebase Hosting
+
+> **Nota de superação.** O corpo abaixo fica **como foi escrito**, porque registra a
+> análise e as medições que levaram à decisão da época. O que mudou foi a resposta,
+> não o problema.
+>
+> Este ADR propunha manter o bundle no GitHub Pages e verificar sua integridade por
+> um hash servido do Apps Script. Em 31/08/2026, após conversa com um SME, o projeto
+> tomou um caminho diferente: **mover a hospedagem para o Firebase Hosting**, o que
+> ataca a mesma preocupação pela raiz — o controle de escrita passa a ser IAM do
+> Google Cloud em vez de uma conta pessoal do GitHub — em vez de detectar adulteração
+> depois do fato.
+>
+> O que a migração resolve e o que ela **não** resolve:
+>
+> - **Integridade (quem escreve)**: resolvido em boa parte. Deploy por Workload
+>   Identity Federation, sem credencial de longa duração no repositório.
+> - **Rollback**: resolvido. O Hosting guarda histórico de releases.
+> - **Confidencialidade (quem lê)**: **não** resolvido. O Firebase Hosting é público,
+>   igual ao Pages. A discussão de tornar o repositório privado continua aberta.
+> - **`main` sem proteção**: **não** resolvido. A CI continua disparando no push, e a
+>   #350 segue necessária. É fácil supor que a migração cobriu isso; não cobriu.
+>
+> Duas medições deste documento merecem correção, feita aqui e não no corpo:
+>
+> - O bundle é citado como 668 KB. Esse é o tamanho **descomprimido**; na rede, com
+>   Brotli, são ~134 KB. Argumentos de tamanho sobre este arquivo devem usar o número
+>   comprimido. As conclusões sobre servir pelo Apps Script não mudam, porque lá o
+>   que dominava era latência, não banda.
+> - A medição de TTFB do Apps Script (0,49–0,90 s) cobre apenas o **primeiro** dos
+>   dois saltos: o `/exec` responde 302 para um segundo host, e o conteúdo vem só na
+>   requisição seguinte. O custo real é maior que o registrado.
+>
+> A issue #356, que testaria a proposta deste ADR, fica sem objeto na forma original.
 
 > Este documento existe para responder, por escrito e antes de ser perguntado,
 > como se justifica que uma ferramenta interna carregue seu código de um GitHub

--- a/docs/media/CaseWizardDeck.gs
+++ b/docs/media/CaseWizardDeck.gs
@@ -35,7 +35,7 @@ var FEEDBACK_FORM_URL = 'forms.gle/8icwk1TejBTDYsJS6';
 
 // Bookmarklet de produção (sempre a branch main / bundle.js), copiado
 // literalmente do README.md — não editar sem atualizar lá também.
-var INSTALL_BOOKMARKLET = "javascript:(function(){    const cacheBuster = '?t=' + new Date().getTime();    const scriptUrl = 'https://lucastdcs.github.io/case-wizard/bundle.js' + cacheBuster;        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();";
+var INSTALL_BOOKMARKLET = "javascript:(function(){    const scriptUrl = 'https://cases-wizard.web.app/bundle.js';        const policy = trustedTypes.createPolicy('default', {         createHTML: (string) => string,         createScriptURL: string => string,         createScript: string => string,     });    const oldScript = document.getElementById('techsol-app-bundle');    if(oldScript) oldScript.remove();        const script = document.createElement('script');    script.id = 'techsol-app-bundle';    script.src = policy.createScriptURL(scriptUrl);    document.body.appendChild(script);})();";
 
 // ============================================================
 // 2. TEMA — tokens extraídos do próprio projeto (não inventados)
@@ -382,7 +382,7 @@ function addStackSlide_(ctx) {
     ['Frontend', 'Vanilla JS (ES modules) + esbuild — sem framework, CSS-in-JS', COLOR.modBlue],
     ['Backend', 'Google Apps Script (V8) — sem servidor/DB tradicional', COLOR.modGreen],
     ['Dados', 'Google Sheets como banco, JSONP como transporte (sem CORS)', COLOR.modOrange],
-    ['Deploy', 'GitHub Actions → GitHub Pages (front) + clasp (backend)', COLOR.modPurple],
+    ['Deploy', 'GitHub Actions → Firebase Hosting (front) + clasp (backend)', COLOR.modPurple],
   ];
   var margin = 64, gap = 16;
   var cardW = (ctx.pageW - margin * 2 - gap * (cards.length - 1)) / cards.length;
@@ -528,10 +528,10 @@ var SOLUTION_BULLETS = [
 ];
 
 var ARCHITECTURE_BULLETS = [
-  'O bookmarklet injeta um <script> que carrega o bundle (GitHub Pages) direto na página do Connect Cases.',
+  'O bookmarklet injeta um <script> que carrega o bundle (Firebase Hosting) direto na página do Connect Cases.',
   'Frontend fala com o backend via JSONP (não fetch) para não esbarrar em CORS — Google Apps Script responde por trás de um roteador único (op=...).',
   'Google Sheets é o banco de dados; não existe servidor ou banco tradicional.',
-  'Deploy 100% automatizado por GitHub Actions a cada push — front pro GitHub Pages, backend via clasp.',
+  'Deploy 100% automatizado por GitHub Actions a cada push — front pro Firebase Hosting, backend via clasp, sem credencial de longa duração no repositório.',
 ];
 
 var INSTABILITY_BULLETS = [

--- a/docs/media/CaseWizardTechDoc.gs
+++ b/docs/media/CaseWizardTechDoc.gs
@@ -626,8 +626,8 @@ function sec01_(ctx) {
     ['Backend', 'Google Apps Script (runtime V8), publicado como Web App'],
     ['Banco de dados', 'Google Sheets (dez abas nomeadas)'],
     ['Transporte', 'JSONP sobre GET, tanto para leitura quanto para escrita'],
-    ['Hospedagem do bundle', 'GitHub Pages (branch gh-pages)'],
-    ['CI/CD', 'GitHub Actions: esbuild para o front, clasp para o backend'],
+    ['Hospedagem do bundle', 'Firebase Hosting (dois sites: prod e dev). GitHub Pages segue em paralelo até o corte'],
+    ['CI/CD', 'GitHub Actions: esbuild para o front, clasp para o backend. Deploy no Firebase por Workload Identity Federation, sem chave armazenada'],
     ['Autenticação', 'Delegada ao Google Workspace: o Web App é publicado com access DOMAIN'],
   ], COLOR.blue);
 
@@ -690,7 +690,7 @@ function sec03_(ctx) {
     '  |                      |    |         |                                      |',
     '  | GitHub Actions       |    |         |   +--------------------------------+ |',
     '  |   deploy.yml         v    |  HTTPS  |   | bundle.js (Case Wizard)        | |',
-    '  | GitHub Pages -- bundle.js-+-------->|   |  app.js -> modulos -> overlay  | |',
+    '  | Firebase Hosting-bundle.js+-------->|   |  app.js -> modulos -> overlay  | |',
     '  +---------------------------+         |   +---------------+----------------+ |',
     '                                        +-------------------+------------------+',
     '                                                            | JSONP (GET, <script>)',
@@ -712,7 +712,7 @@ function sec03_(ctx) {
 
   h2_(ctx, 'Responsabilidade de cada camada', COLOR.blue);
   table_(ctx, ['Camada', 'Onde vive', 'Responsabilidade', 'O que ela NÃO faz'], [
-    ['Distribuição', '.github/workflows/deploy.yml, branch gh-pages',
+    ['Distribuição', '.github/workflows/deploy.yml, firebase.json, .firebaserc',
      'Transformar o fonte em um artefato único e publicá-lo em uma URL estável.',
      'Não versiona o backend por conta própria: a promoção da implantação de produção é manual.'],
     ['Execução', 'src/**, servido como dist/bundle.js',
@@ -755,9 +755,7 @@ function sec04_(ctx) {
 
   code_(ctx, [
     'javascript:(function(){',
-    "  const cacheBuster = '?t=' + new Date().getTime();",
-    "  const scriptUrl = 'https://lucastdcs.github.io/case-wizard/bundle.js'",
-    '                  + cacheBuster;',
+    "  const scriptUrl = 'https://cases-wizard.web.app/bundle.js';",
     '',
     "  const policy = trustedTypes.createPolicy('default', {",
     '    createHTML:      (string) => string,',
@@ -785,8 +783,8 @@ function sec04_(ctx) {
 
   h2_(ctx, 'Linha a linha', COLOR.yellow);
   table_(ctx, ['Trecho', 'O que faz', 'Por que existe'], [
-    ['cacheBuster', 'Anexa um timestamp à URL do script.',
-     'GitHub Pages e o navegador cacheiam agressivamente. Sem isso, o agente continuaria rodando a versão de ontem depois de um deploy.'],
+    ['URL estável, sem cacheBuster', 'A URL do script não muda entre cliques.',
+     'O timestamp `?t=` existia porque o GitHub Pages servia com max-age fixo e sem controle nosso: a única forma de garantir versão nova era tornar cada URL única, o que garantia download completo e inutilizava o cache. No Firebase o header é definido no firebase.json (no-cache em prod, no-store em dev), então a URL pode ser estável. Nota medida: requisições condicionais com If-None-Match ainda voltam 200, não 304 — a revalidação não está economizando a transferência. O bundle são ~660 KB crus, mas ~134 KB na rede com Brotli.'],
     ["trustedTypes.createPolicy('default', ...)",
      'Registra uma política chamada default com transformações identidade para HTML, URL de script e script.',
      'A CSP do CRM exige Trusted Types. Sem uma política registrada, atribuir uma string a script.src é rejeitado pelo navegador.'],
@@ -2145,11 +2143,14 @@ function sec20_(ctx) {
     '  se ref = main               -> bash scripts/promote-deployment.sh (PROD)',
     '',
     'JOB 2  build-and-deploy-frontend      needs: deploy-backend-gas',
-    '  checkout -> node 18 -> npm install esbuild',
+    '  checkout -> node 20 -> npm ci',
     '  se ref = main               -> bundle.js     --define __CW_BUILD_ENV__="production"',
     '  se ref = refactor-structure -> bundle-dev.js --define __CW_BUILD_ENV__="development"',
-    '  peaceiris/actions-gh-pages  -> publica ./dist na branch gh-pages',
-    '                                 (keep_files: true, os dois bundles coexistem)',
+    '  peaceiris/actions-gh-pages  -> publica ./dist na branch gh-pages (legado, sai no corte)',
+    '  google-github-actions/auth  -> WIF: token OIDC do repo -> credencial curta',
+    '  firebase-tools deploy       -> hosting:prod (main) ou hosting:dev (refactor)',
+    '                                 os dois destinos sao independentes: um que',
+    '                                 falha nao impede o outro de publicar',
   ], 'O needs: é a peça central. Os dois jobs já rodaram em paralelo, e foi essa corrida que produziu o incidente descrito na seção 21.');
 
   callout_(ctx, 'Por que o backend vai primeiro',


### PR DESCRIPTION
Sincroniza a documentação com a migração para o Firebase, e corrige duas afirmações minhas que estavam erradas no repositório.

## Correção de fato

Afirmei, no README e em três PRs, que servir com `Cache-Control: no-cache` faria o clique repetido virar um `304`. **Não faz.** Verifiquei contra a URL de produção, com o ETag específico da codificação:

```
If-None-Match: "12103099...-br"   →   HTTP 200, 657.391 bytes
```

A revalidação não está economizando a transferência. Tirar o `?t=` continua certo, mas pelo motivo menor de haver uma entrada de cache estável em vez de uma falha garantida — não pela economia que descrevi.

No mesmo teste apareceu o segundo erro: o bundle são **~660 KB crus, mas ~134 KB na rede com Brotli**. O número que usei em toda a análise anterior, inclusive na comparação dos braços A e B do ADR 0005, era o descomprimido — inflado por um fator de cinco.

As duas notas ficam registradas onde a afirmação estava, para que a próxima pessoa não repita a conta.

## Descritivos — atualizados

| arquivo | o que mudou |
|---|---|
| `README.md` | hospedagem, seção de deploy, árvore de diretórios, troubleshooting |
| `docs/ARCHITECTURE.md` | domínio da política `trustedTypes` e a seção de cache |
| `docs/WORKFLOW.md` | destino por branch, independência dos dois destinos, WIF |
| `docs/VISION.md` | dependência de rede agora em `web.app` |
| `docs/ADOPTION-LOG.md` | descrição do CI/CD |
| `docs/media/CaseWizardDeck.gs` | bookmarklet embutido, tabela de stack, bullets de arquitetura |
| `docs/media/CaseWizardTechDoc.gs` | tabela de hospedagem, diagrama de camadas, bookmarklet, seção de cache, resumo do workflow |

## Históricos — preservados

Os ADRs **0003, 0004 e 0005** e as seções do TechDoc que narram o rename ficam como estão. Registram decisões tomadas na época e estavam corretas quando escritas; reescrevê-las apagaria o registro.

No **0005**, que propunha verificar integridade por hash, muda apenas o status para `Superseded`, com uma nota que separa:

- **resolvido** pela migração: integridade (quem escreve) e rollback;
- **não resolvido**: confidencialidade — o Firebase Hosting é público igual ao Pages — e a falta de proteção da `main`, que segue necessária na #350.

Esse segundo ponto é fácil de supor coberto pela migração. Não está.

## Verificação

- Os dois `.gs` passam em `node --check` (copiados para `.js`, já que o Node não reconhece a extensão).
- Varredura por `github.io` / `GitHub Pages` / `gh-pages` no `docs/` e no `README`: o que sobrou é ou narrativa histórica nos ADRs, ou menção explícita ao legado durante a transição.

**Não altera comportamento.** A decisão sobre trocar `no-cache` por um `max-age` curto fica separada, de propósito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myp7qcA8fRPELBRHwtfv1P
