### PR TITLE
fix(emails): CTA "Ver caso" + raio da pill no chip

### DIFF
--- a/gas-backend/EmailEngine.js
+++ b/gas-backend/EmailEngine.js
@@ -28,7 +28,7 @@ const EMAIL_I18N = {
     defaultSubject: function (adv) { return "Notificação TechSol: " + adv; },
     requestedBy: function (ldap) { return "Solicitado por @" + ldap; },
     footerTrace: function (id) { return "Cases Wizard · automatizado por @lucaste · rastreio " + id; },
-    actionViewCase: "Ver caso no Case Connect",
+    actionViewCase: "Ver caso",
     actionOpenDashboard: "Abrir TL Dashboard",
     sectionDetails: "Detalhes do caso",
 
@@ -76,7 +76,7 @@ const EMAIL_I18N = {
     defaultSubject: function (adv) { return "Notificación TechSol: " + adv; },
     requestedBy: function (ldap) { return "Solicitado por @" + ldap; },
     footerTrace: function (id) { return "Cases Wizard · automatizado por @lucaste · seguimiento " + id; },
-    actionViewCase: "Ver caso en Case Connect",
+    actionViewCase: "Ver caso",
     actionOpenDashboard: "Abrir TL Dashboard",
     sectionDetails: "Detalles del caso",
 
@@ -151,10 +151,23 @@ const EMAIL_TOKENS = {
   // em qualquer tema (não segue a paleta clara/dm-* do resto do cartão): é
   // identidade de produto, não conteúdo, e por isso não muda com o tema do
   // cliente de e-mail.
+  //
+  // As cores não são as mesmas rgba translúcidas da pill flutuante real
+  // (COLORS.glassBg em command-center.js) de propósito: aquela transparência
+  // é calibrada pra sentar sobre backdrop-filter: blur(12px) em cima do CRM,
+  // que muda de conteúdo o tempo todo. Sem blur (nenhum cliente de e-mail
+  // aplica) e sobre um cartão liso, a mesma transparência renderia clara
+  // demais no card branco e quase invisível no card escuro do dark mode.
+  // Um gradiente opaco na mesma família tonal é o que se comporta igual nos
+  // dois temas.
   glassBg1: "#26272B",
   glassBg2: "#313340",
   glassBorder: "rgba(255,255,255,0.10)",
   glassText: "#E8EAED",
+  // O badge do raio, dentro do chip: aqui sim um branco translúcido de
+  // verdade (sem depender de blur) — é a segunda camada que dá a leitura
+  // "opaco por fora, translúcido por dentro" que a pill tem.
+  glassBadgeBg: "rgba(255,255,255,0.08)",
 
   // Avisos. Só aparecem quando há de fato algo a avisar.
   urgentBg: "#FCE8E6",

--- a/gas-backend/EmailTemplateDynamic.html
+++ b/gas-backend/EmailTemplateDynamic.html
@@ -58,15 +58,24 @@
                         <td style="padding: 32px 32px 8px 32px;">
 
                             <!-- Identidade do produto. O único toque de Cases Wizard no
-                                 e-mail: um chip escuro (a mesma família do dark glass do
-                                 header do app, em header-factory.js — sem backdrop-filter,
-                                 que nenhum cliente de e-mail aplica de verdade) com a cor
-                                 do tipo na base, no lugar de um filete solto. Pequeno de
-                                 propósito: é o único elemento escuro da página. -->
+                                 e-mail: um chip escuro (a mesma família do dark glass da
+                                 pill flutuante do app, em command-center.js — sem
+                                 backdrop-filter, que nenhum cliente de e-mail aplica de
+                                 verdade) com o raio da pill dentro de um badge circular, e
+                                 a cor do tipo na base do chip. Pequeno de propósito: é o
+                                 único elemento escuro da página.
+
+                                 O raio da pill é um SVG (path "M13 2L3 14h9l-1 8 10-12h-9
+                                 l1-8z"), mas SVG não renderiza em e-mail — nem inline. O
+                                 emoji ⚡ é o substituto seguro: mesmo glifo, sem depender
+                                 de rede nem de suporte a SVG. -->
                             <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 0 26px 0;">
                                 <tr>
-                                    <td style="border-radius: 8px 8px 0 0; background: linear-gradient(135deg, {{t.glassBg1}} 0%, {{t.glassBg2}} 100%); border: 1px solid {{t.glassBorder}}; border-bottom: none; padding: 7px 12px 5px 12px;">
-                                        <span style="font-family: {{t.fontSans}}; font-size: {{t.sizeLabel}}; font-weight: 500; letter-spacing: 0.2px; color: {{t.glassText}};">Cases Wizard</span>
+                                    <td style="border-radius: 8px 8px 0 0; background: linear-gradient(135deg, {{t.glassBg1}} 0%, {{t.glassBg2}} 100%); border: 1px solid {{t.glassBorder}}; border-bottom: none; padding: 6px 12px 5px 6px;">
+                                        <table cellpadding="0" cellspacing="0" border="0"><tr>
+                                            <td style="width: 20px; height: 20px; border-radius: 50%; background-color: {{t.glassBadgeBg}}; text-align: center; vertical-align: middle; font-size: 11px; line-height: 20px;">⚡</td>
+                                            <td style="padding-left: 7px; font-family: {{t.fontSans}}; font-size: {{t.sizeLabel}}; font-weight: 500; letter-spacing: 0.2px; color: {{t.glassText}}; vertical-align: middle;">Cases Wizard</td>
+                                        </tr></table>
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
Continuação do #362. Dois ajustes que Lucas pediu depois de ver o resultado.

## Botão

`"Ver caso no Case Connect"` / `"Ver caso en Case Connect"` → `"Ver caso"`, nos dois idiomas. O botão já aponta pro Case Connect; o destino não precisa estar escrito duas vezes.

## Raio da pill no chip

O chip "Cases Wizard" ganha o raio da pill flutuante do app — o mesmo ícone que abre o Cases Wizard no CRM (`command-center.js`, path `M13 2L3 14h9l-1 8 10-12h-9l1-8z`), dentro de um badge circular à esquerda do wordmark.

Duas decisões que tomei ao aplicar, sinalizadas para revisão:

- **SVG → emoji ⚡.** O path real da pill não renderiza em e-mail, nem inline — mesmo motivo que já tinha me feito trocar os ícones originais do template por outra coisa. O emoji é o substituto seguro (mesmo glifo, sem depender de rede ou de suporte a SVG), mas reintroduz emoji na área de identidade, que eu tinha eliminado no passe de sobriedade Material anterior. Aqui o papel é diferente — marca do produto, não decoração solta — mas é uma linha que eu mesmo tinha traçado e agora cruzei.
- **Cor opaca em vez da translúcida real da pill** (`rgba(61,61,61,0.77)` em `COLORS.glassBg`). Essa transparência é calibrada para sentar sobre `backdrop-filter: blur(12px)` em cima do CRM. Sem blur (nenhum cliente de e-mail aplica), a mesma transparência ficaria clara demais no card branco e quase some no card escuro do dark mode. Mantive o gradiente opaco já validado como fundo do chip inteiro; o badge do raio, dentro dele, usa um branco translúcido de verdade (`rgba(255,255,255,0.08)`, sem depender de blur) — duas camadas que dão a leitura "opaco por fora, translúcido por dentro" que a pill tem.

## Verificação

Harness de conteúdo (15 e-mails) e o de roteamento (4 desfechos do TL) rodados de novo, limpos. Render em Chromium claro/escuro para os 7 tipos + alerta de volume — badge legível nos dois temas.

Refs #316, #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
