### PR TITLE
test(central): rede de segurança antes de reorganizar a Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Smoke da Central de Conteúdo** (`npm run smoke:content`). A maior tela do
+  projeto era a única sem teste nenhum, e a reorganização da navegação
+  (ADR-0007) toca todos os seus renderizadores de uma vez. O smoke carrega o
+  `ContentDashboard.html` num navegador de verdade com o `google.script.run`
+  dublado, e trava o que precisa continuar valendo depois do redesenho: acesso,
+  régua de papéis, um painel visível por vez, o regime de publicação dito em
+  cada módulo, uma chamada por proposta salva e falha de rede aparente.
 - **Três ADRs propondo a próxima fase da Central de Conteúdo** (`docs/decisions/`):
   [0007](docs/decisions/0007-arquitetura-da-central-de-conteudo.md) troca as dez
   abas por um trilho agrupado pelo regime de publicação;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ TechSol Operations Assistant — a productivity and automation suite for a corpo
 
 - Install deps: `npm install`
 - Run dev: `npm run dev` — builds `dist/bundle-dev.js`; there is no localhost target, load it into the real CRM via the Dev bookmarklet (see `README.md`)
-- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` · `test:deployment-env` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts`, `smoke:wizards` and `smoke:env-badge` drive the real UI with Playwright over `mock-crm.html`. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
+- Test: `npm run test:content` · `test:call-script` · `test:emails` · `test:note-templates` · `test:shortcuts` · `test:prefs` · `test:deployment-env` — node harnesses that stub the browser/Apps Script globals (there is no runner: each script exits non-zero on failure). `npm run smoke:shortcuts`, `smoke:wizards`, `smoke:env-badge` and `smoke:broadcast` drive the agent UI with Playwright over `mock-crm.html`; `smoke:content` and `smoke:people` drive the Apps Script dashboards, loaded from disk with `google.script.run` doubled. Anything not covered by these is still verified by hand via the Dev bookmarklet on the CRM plus the Apps Script execution log (see `README.md` → Testing)
 - Lint: none configured
 - Build: `npm run build` — builds `dist/bundle.js` (minified, production)
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "smoke:wizards": "node scripts/smoke-wizards.mjs",
     "smoke:env-badge": "node scripts/smoke-env-badge.mjs",
     "smoke:broadcast": "node scripts/smoke-broadcast.mjs",
+    "smoke:content": "node scripts/smoke-content-dashboard.mjs",
     "smoke:people": "node scripts/smoke-people.mjs",
     "seed:note-templates": "node scripts/generate-note-templates-seed.mjs"
   },

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -1,0 +1,354 @@
+// scripts/smoke-content-dashboard.mjs
+//
+// Smoke da Central de Conteúdo (gas-backend/ContentDashboard.html) num
+// navegador de verdade.
+//
+// POR QUE ESTE ARQUIVO EXISTE
+//
+// A Central é a única tela do projeto sem teste nenhum, e é a maior: mais de
+// 2.800 linhas onde estilo, marcação e dez renderizadores convivem no mesmo
+// arquivo. A reorganização da navegação (ADR-0007) toca todos eles de uma vez.
+// Mexer nisso sem rede é a aposta mais cara do plano — então a rede vem antes.
+//
+// O QUE ELE PROTEGE
+//
+// Não a aparência (que vai mudar de propósito), e sim o que precisa continuar
+// verdadeiro DEPOIS do redesenho:
+//   - quem não tem acesso não vê a tela, e quem tem vê o próprio papel;
+//   - cada papel só enxerga o caminho de escrita dos módulos que ele propõe;
+//   - trocar de aba mostra um painel e esconde os outros;
+//   - a aba de Acessos é exclusiva de quem gerencia acesso;
+//   - `people` nunca aparece para quem não propõe (é autorização, não conteúdo);
+//   - salvar uma proposta é UMA chamada ao servidor, não duas;
+//   - falha ao carregar rascunhos aparece na tela em vez de virar "não há nenhum".
+//
+// COMO ELE RODA SEM APPS SCRIPT
+//
+// A tela é servida pelo HtmlService e conversa por `google.script.run`. Aqui o
+// HTML é lido do disco, as duas tags de template viram vazio e o bridge é
+// substituído por um dublê que responde do fixture abaixo. O dublê registra
+// toda chamada, o que permite afirmar quantas viagens uma ação custou — é
+// assim que o teste de "uma chamada, não duas" existe.
+//
+// Uso: npm run smoke:content
+
+import { chromium } from 'playwright';
+import { readFile, writeFile, rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const raiz = resolve(here, '..');
+
+// A página precisa vir de uma URL de verdade, e não de setContent(): os
+// scripts de inicialização do Playwright — que é onde o dublê do
+// google.script.run é instalado — só rodam numa navegação.
+const ARQUIVO = join(tmpdir(), 'cw-content-dashboard-smoke.html');
+
+async function prepararArquivo() {
+    let html = await readFile(resolve(raiz, 'gas-backend/ContentDashboard.html'), 'utf8');
+    // As duas tags são preenchidas pelo renderDashboard() do Código.gs. Fora do
+    // Apps Script elas ficariam literais no DOM.
+    html = html.replace(/<\?!=\s*CW_ENV_BADGE\s*\?>/g, '')
+        .replace(/<\?!=\s*CW_CREDIT\s*\?>/g, '');
+    await writeFile(ARQUIVO, html, 'utf8');
+}
+
+let fail = 0;
+async function check(name, fn) {
+    try { await fn(); console.log('  ✓ ' + name); }
+    catch (e) { console.log('  ✗ ' + name + '\n      ' + e.message); fail++; }
+}
+function igual(atual, esperado, oque) {
+    const a = JSON.stringify(atual), b = JSON.stringify(esperado);
+    if (a !== b) throw new Error(`${oque}: esperado ${b}, veio ${a}`);
+}
+function verdade(cond, oque) {
+    if (!cond) throw new Error(oque);
+}
+
+// ---------------------------------------------------------------- fixture
+//
+// Papéis reais da matriz de CONTENT_ROLES. QA e WFM existem aqui porque são os
+// que provam a régua: cada um propõe um subconjunto diferente, e é isso que a
+// tela tem que refletir sem depender de o servidor recusar depois.
+const SESSOES = {
+    admin: {
+        ldap: 'lucaste', role: 'ADMIN', hasAccess: true,
+        canApprove: true, canManageAccess: true, canSelfApprove: true,
+        proposableModules: ['links', 'call_script', 'email_template', 'note_template',
+            'tips', 'broadcast', 'bau_availability', 'people'],
+    },
+    qa: {
+        ldap: 'qapessoa', role: 'QA', hasAccess: true,
+        canApprove: false, canManageAccess: false, canSelfApprove: false,
+        proposableModules: ['call_script', 'note_template'],
+    },
+    wfm: {
+        ldap: 'wfmpessoa', role: 'WFM', hasAccess: true,
+        canApprove: false, canManageAccess: false, canSelfApprove: false,
+        proposableModules: ['links', 'bau_availability'],
+    },
+    semAcesso: { ldap: 'estranho', role: null, hasAccess: false },
+};
+
+const ITENS = {
+    links: [{
+        id: 'itm_1', module: 'links', key: 'tasks', field: '', lang: 'ALL',
+        label: 'Fila de tarefas', version: 1, status: 'live',
+        publishedBy: 'lucaste', publishedAt: '2026-09-01T10:00:00Z', sortOrder: 0,
+        lineage: 'itm_1',
+        value: JSON.stringify({ name: 'Fila de tarefas', url: 'https://go/fila', desc: 'Fila do dia', desc_es: 'Cola del día' }),
+    }],
+    tips: [{
+        id: 'itm_2', module: 'tips', key: 'geral', field: '', lang: 'PT',
+        label: 'Dica', version: 1, status: 'live', publishedBy: 'lucaste',
+        publishedAt: '2026-09-01T10:00:00Z', sortOrder: 0, lineage: 'itm_2',
+        value: 'Confira o substatus antes de fechar.',
+    }],
+    call_script: [], email_template: [], note_template: [],
+    broadcast: [], bau_availability: [], people: [],
+};
+
+// ------------------------------------------------------- montagem da página
+async function abrir({ sessao = 'admin', falharRascunhosDe = null } = {}) {
+    const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
+    page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
+
+    // As fontes do Google não respondem aqui; cortar evita espera inútil.
+    await page.route('**fonts.googleapis.com/**', (r) => r.abort());
+    await page.route('**fonts.gstatic.com/**', (r) => r.abort());
+
+    // O dublê precisa existir ANTES do script da página rodar: o boot dispara
+    // no DOMContentLoaded.
+    await page.addInitScript(({ sessao, itens, falhar }) => {
+        window.__chamadas = [];
+
+        const RESPOSTAS = {
+            getContentSession: () => sessao,
+            listContentItems: (m) => itens[m] || [],
+            listContentDrafts: (m) => {
+                if (falhar && m === falhar) throw new Error('rede caiu');
+                return [];
+            },
+            listPendingApprovals: () => [],
+            listContentAccess: () => [{ ldap: 'lucaste', role: 'ADMIN', active: true, grantedBy: 'system' }],
+            listPeople: () => [],
+            getNoteFieldCatalog: () => ({ fields: {}, substatus: [] }),
+            saveAndSubmitContentDraft: () => ({ status: 'success', draftId: 'drf_novo' }),
+            publishContentDirect: () => ({ status: 'success', itemId: 'itm_novo', version: 1 }),
+            unpublishContentDirect: () => ({ status: 'success' }),
+            approveContentDraft: () => ({ status: 'success', version: 1, action: 'upsert' }),
+            rejectContentDraft: () => ({ status: 'success' }),
+            requestContentRemoval: () => ({ status: 'success' }),
+            requestPeopleRemoval: () => ({ status: 'success' }),
+            savePeopleChange: () => ({ status: 'success' }),
+            saveContentAccess: () => ({ status: 'success' }),
+        };
+
+        function construir() {
+            let ok = null, erro = null;
+
+            // O encadeamento precisa devolver o PRÓPRIO proxy: devolver o alvo
+            // cru faria a terceira chamada da cadeia
+            // (.withSuccessHandler().withFailureHandler().metodo()) cair num
+            // objeto que não conhece método nenhum.
+            const proxy = new Proxy({}, {
+                get(_base, prop) {
+                    if (prop === 'withSuccessHandler') return function (f) { ok = f; return proxy; };
+                    if (prop === 'withFailureHandler') return function (f) { erro = f; return proxy; };
+                    return function (...args) {
+                        window.__chamadas.push({ metodo: String(prop), args });
+                        // Assíncrono como o bridge real: síncrono esconderia
+                        // corrida de renderização que na tela existe.
+                        setTimeout(() => {
+                            try {
+                                const r = (RESPOSTAS[prop] || (() => null))(...args);
+                                if (ok) ok(r);
+                            } catch (e) {
+                                if (erro) erro({ message: e.message });
+                            }
+                        }, 5);
+                    };
+                },
+            });
+
+            return proxy;
+        }
+
+        Object.defineProperty(window, 'google', {
+            value: { script: { get run() { return construir(); } } },
+            writable: true,
+        });
+    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe });
+
+    await page.goto('file://' + ARQUIVO, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(300);
+    return page;
+}
+
+await prepararArquivo();
+const browser = await chromium.launch({ headless: true });
+
+console.log('\n--- Smoke: Central de Conteúdo ---');
+
+// ------------------------------------------------------------------ acesso
+{
+    const page = await abrir({ sessao: 'semAcesso' });
+
+    await check('sem papel: a tela não aparece, e o motivo sim', async () => {
+        verdade(await page.locator('#denied-state').isVisible(), 'estado de acesso negado deveria estar visível');
+        verdade(!(await page.locator('#app').isVisible()), 'o app não deveria aparecer');
+    });
+
+    await check('sem papel: nenhum conteúdo é carregado', async () => {
+        const chamadas = await page.evaluate(() => window.__chamadas.map(c => c.metodo));
+        igual(chamadas.includes('listContentItems'), false, 'buscou conteúdo sem ter acesso');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'admin' });
+
+    await check('ADMIN: a tela abre e mostra o papel', async () => {
+        verdade(await page.locator('#app').isVisible(), 'o app deveria aparecer');
+        igual((await page.locator('#user-role').textContent()).trim(), 'ADMIN', 'selo de papel');
+        igual((await page.locator('#user-ldap').textContent()).trim(), 'lucaste', 'ldap');
+    });
+
+    await check('ADMIN: enxerga a aba de Acessos', async () => {
+        verdade(await page.locator('#tab-access').isVisible(), 'aba Acessos deveria aparecer para quem gerencia acesso');
+    });
+
+    // A navegação é o que o ADR-0007 vai reescrever. O contrato que precisa
+    // sobreviver não é "existem abas", é "escolher um destino mostra um painel
+    // e esconde os outros".
+    await check('trocar de destino mostra um painel só', async () => {
+        const panes = ['links', 'callscript', 'notes', 'emails', 'tips', 'broadcast', 'bau', 'approvals'];
+        for (const destino of ['tips', 'broadcast', 'links']) {
+            await page.evaluate((d) => switchTab(d), destino);
+            await page.waitForTimeout(120);
+            const visiveis = [];
+            for (const p of panes) {
+                const el = page.locator('#pane-' + p);
+                if (await el.count() && await el.isVisible()) visiveis.push(p);
+            }
+            igual(visiveis, [destino], `ao ir para "${destino}", painéis visíveis`);
+        }
+    });
+
+    await check('o regime de publicação está dito em cada módulo', async () => {
+        await page.evaluate(() => switchTab('broadcast'));
+        await page.waitForTimeout(120);
+        const aviso = (await page.locator('#bc-note').textContent()).toLowerCase();
+        verdade(/na hora|sem passar pela fila/.test(aviso),
+            'o módulo de publicação direta precisa dizer que vai ao ar na hora');
+
+        await page.evaluate(() => switchTab('links'));
+        await page.waitForTimeout(120);
+        const fila = (await page.locator('#links-note').textContent()).toLowerCase();
+        verdade(/aprova/.test(fila), 'o módulo de catálogo precisa dizer que passa por aprovação');
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------------------- papéis
+{
+    const page = await abrir({ sessao: 'qa' });
+
+    await check('QA: não enxerga a aba de Acessos', async () => {
+        verdade(!(await page.locator('#tab-access').isVisible()), 'QA não gerencia acesso');
+    });
+
+    await check('QA: não recebe caminho de escrita em links', async () => {
+        verdade(!(await page.locator('#links-new-btn').isVisible()),
+            'QA não propõe links — o botão não deveria aparecer');
+        const nota = (await page.locator('#links-note').textContent()).toLowerCase();
+        verdade(/não propõe/.test(nota), 'a tela precisa dizer por que não há botão');
+    });
+
+    await check('QA: recebe caminho de escrita no que propõe', async () => {
+        await page.evaluate(() => switchTab('callscript'));
+        await page.waitForTimeout(150);
+        verdade(await page.locator('#cs-new-btn').isVisible(),
+            'QA propõe call_script — o botão deveria aparecer');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'wfm' });
+
+    await check('WFM: publica disponibilidade, mas não aviso', async () => {
+        await page.evaluate(() => switchTab('bau'));
+        await page.waitForTimeout(150);
+        verdade(await page.locator('#bau-editor').isVisible(),
+            'WFM publica disponibilidade — o formulário deveria aparecer');
+
+        await page.evaluate(() => switchTab('broadcast'));
+        await page.waitForTimeout(150);
+        verdade(!(await page.locator('#bc-new-btn').isVisible()),
+            'WFM não publica aviso — o botão não deveria aparecer');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------------- viagens ao servidor
+{
+    const page = await abrir({ sessao: 'admin' });
+
+    await check('salvar uma proposta custa UMA chamada ao servidor', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; openLinkEditor(null); });
+        await page.waitForTimeout(150);
+
+        await page.fill('#lnk-name', 'Link novo');
+        await page.fill('#lnk-url', 'https://go/novo');
+        await page.click('#lnk-save');
+        await page.waitForTimeout(400);
+
+        // Lista explícita: filtrar por padrão pegaria também a releitura que
+        // vem depois do sucesso, que é leitura e não custa escrita nenhuma.
+        const ESCRITAS = ['saveContentDraft', 'submitContentDraft',
+            'saveAndSubmitContentDraft', 'publishContentDirect'];
+        const escritas = await page.evaluate((nomes) => window.__chamadas
+            .filter(c => nomes.includes(c.metodo))
+            .map(c => c.metodo), ESCRITAS);
+
+        // O encadeamento antigo era saveContentDraft -> submitContentDraft.
+        igual(escritas, ['saveAndSubmitContentDraft'], 'chamadas de escrita');
+    });
+
+    await page.close();
+}
+
+// --------------------------------------------------------- falha aparente
+{
+    const page = await abrir({ sessao: 'admin', falharRascunhosDe: 'links' });
+
+    await check('falha ao ler rascunhos aparece na tela', async () => {
+        const texto = (await page.locator('#links-list').textContent()).toLowerCase();
+        verdade(/não foi possível carregar as propostas/.test(texto),
+            'a falha precisa aparecer, não virar silêncio');
+        verdade(/tentar de novo/.test(texto), 'precisa oferecer nova tentativa');
+    });
+
+    await check('a lista do que está no ar continua sendo desenhada', async () => {
+        // Degradar é mostrar menos, não mostrar nada: o conteúdo publicado
+        // carregou normalmente e não pode sumir junto com os rascunhos.
+        const texto = await page.locator('#links-list').textContent();
+        verdade(/Fila de tarefas/.test(texto), 'o item publicado deveria continuar na lista');
+    });
+
+    await page.close();
+}
+
+await browser.close();
+await rm(ARQUIVO, { force: true });
+console.log('\n' + (fail ? '✗' : '✓') + ` smoke da Central: ${fail} falha(s)\n`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## O que muda

Primeiro dos três PRs da fase 2. Adiciona `npm run smoke:content` e **não muda uma linha da tela** — é só a rede que precisa existir antes do redesenho.

> **Base:** este PR sai de `feat/central-fase1-carga-e-correcao` (PR #372), não de `refactor-structure`, porque os dois tocam o mesmo arquivo. Assim o diff mostra só o que é desta etapa. Depois que o #372 entrar, o alvo pode virar `refactor-structure` num clique.

## Por que assim

A Central é a maior tela do projeto — mais de 2.800 linhas onde estilo, marcação e dez renderizadores dividem um arquivo — e a única sem teste nenhum. A reorganização da navegação (ADR-0007) toca todos os renderizadores de uma vez. Fazer isso sem rede é a aposta mais cara do plano, então a rede vem primeiro, sozinha, num PR que dá para revisar sem medo.

**O smoke não trava a aparência.** Ela vai mudar de propósito. O que ele trava é o que precisa continuar verdadeiro *depois* do redesenho — as regras que a tela expressa hoje por acidente de layout e que, se sumirem, somem em silêncio:

- quem não tem papel não vê a tela, e não dispara busca de conteúdo nenhuma;
- cada papel só recebe caminho de escrita nos módulos que propõe — QA não propõe links, WFM publica disponibilidade mas não aviso;
- escolher um destino mostra um painel e esconde os outros;
- a aba de Acessos é de quem gerencia acesso;
- o regime de publicação está dito em cada módulo: fila no catálogo, "na hora" na publicação direta;
- salvar uma proposta custa **uma** chamada ao servidor;
- falha ao ler rascunhos aparece na tela, e não apaga o que já está no ar.

**Como ele roda sem Apps Script.** A tela é servida pelo `HtmlService` e conversa por `google.script.run`. O smoke lê o HTML do disco, troca as duas tags de template (`CW_ENV_BADGE`, `CW_CREDIT`) por vazio e instala um dublê do bridge que responde de um fixture e **registra cada chamada**. É esse registro que permite a asserção de "uma viagem, não duas" — algo que nenhum teste de DOM sozinho conseguiria afirmar.

Duas notas de implementação que custaram tempo e ficaram documentadas no arquivo: o dublê tem de ser instalado por `addInitScript` + `goto` (com `setContent` ele não roda, e a tela chama `boot` no `DOMContentLoaded`), e o encadeamento `withSuccessHandler().withFailureHandler().metodo()` exige que os dois primeiros devolvam o próprio proxy.

## Como verificar

```
npm run smoke:content
```

```
--- Smoke: Central de Conteúdo ---
  ✓ sem papel: a tela não aparece, e o motivo sim
  ✓ sem papel: nenhum conteúdo é carregado
  ✓ ADMIN: a tela abre e mostra o papel
  ✓ ADMIN: enxerga a aba de Acessos
  ✓ trocar de destino mostra um painel só
  ✓ o regime de publicação está dito em cada módulo
  ✓ QA: não enxerga a aba de Acessos
  ✓ QA: não recebe caminho de escrita em links
  ✓ QA: recebe caminho de escrita no que propõe
  ✓ WFM: publica disponibilidade, mas não aviso
  ✓ salvar uma proposta custa UMA chamada ao servidor
  ✓ falha ao ler rascunhos aparece na tela
  ✓ a lista do que está no ar continua sendo desenhada

✓ smoke da Central: 0 falha(s)
```

**Verificado por mutação**, porque teste que não sabe falhar não protege nada. Quebrei a tela de três formas e conferi que o smoke acusa cada uma — restaurando o arquivo depois das três:

| Mutação | O smoke acusa |
|---|---|
| `canPropose()` sempre `true` | `✗ QA: não recebe caminho de escrita em links` e `✗ WFM: publica disponibilidade, mas não aviso` |
| `enviarProposta()` de volta ao `saveContentDraft` | `✗ salvar uma proposta custa UMA chamada ao servidor` |
| `switchTab()` sem esconder os outros painéis | `✗ trocar de destino mostra um painel só` |

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [ ] Testado com o bookmarklet de **dev** contra o CRM real — não se aplica, nada de produção mudou

## Checklist

- [x] Se mexi em `gas-backend/`: não mexi — o `ContentDashboard.html` está byte a byte igual ao da base.
- [x] Se mexi numa regra de negócio: nenhuma. O PR só adiciona `scripts/smoke-content-dashboard.mjs` e o script no `package.json`.
- [x] Se é uma decisão que alguém vai questionar depois: o ADR-0007 já registra o smoke como pré-requisito desta fase.
- [x] Se muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`; o `CLAUDE.md` passou a listar `smoke:content` e `smoke:people` entre os testes.
- [x] Se bumpei versão: não bumpei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_