### PR TITLE
fix(email-bot): restaura o speed dial da UI antiga como terceira rota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- **O atalho de e-mail voltou a funcionar na interface antiga do Connect
+  Cases.** A migração para o speed dial da UI nova (`#action-bar-speed-dial-container`
+  → `material-button.compose`) removeu o caminho da UI antiga
+  (`material-fab-speed-dial` → `.trigger`) em vez de mantê-lo como alternativa.
+  O clique no envelope solto, que ficou como único plano B, exige o ícone já
+  visível — e na UI antiga ele está escondido atrás do menu fechado, então o
+  agente ficava sem nenhuma rota e via só o toast de erro. As duas interfaces
+  convivem enquanto a atualização do CRM chega em ondas, então a FASE 1 passou a
+  tentar três rotas em cadeia (speed dial novo → envelope direto → speed dial
+  antigo), cada uma checando o próprio markup antes de agir, e o log diz qual
+  delas abriu o compositor.
 
 ### Security
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -12,6 +12,38 @@ Include the minimal code snippet / command when it is the fix.
 
 ---
 
+## Automação de DOM do CRM: o caminho novo entra na frente, o antigo nunca sai
+
+**Why**: o Connect Cases escondeu o botão de e-mail atrás de um speed dial novo
+(`#action-bar-speed-dial-container` → `material-button.compose`) e a FASE 1 do
+`openAndClearEmail` foi reescrita para segui-lo. Só que a reescrita **removeu** o
+caminho da UI antiga (`material-fab-speed-dial` → `.trigger`) em vez de mantê-lo
+atrás do novo. Parecia seguro porque sobrou um plano B — o clique no envelope
+solto na action bar —, mas esse plano B exige o ícone já visível
+(`offsetParent !== null`), e na UI antiga ele está escondido dentro do menu
+fechado. Resultado: agente na UI antiga sem nenhuma rota, com o toast genérico de
+"botão não encontrado" como única pista. O custo foi alto porque a atualização do
+CRM chega **em ondas**: no dia do merge parte da operação já estava na UI nova e
+parte não, o bug foi para produção via `main`, e o modal de novidades da v6.0.1
+tinha acabado de anunciar que o módulo de e-mails estava corrigido — para quem
+estava na UI antiga, a mensagem era o oposto do que a tela fazia.
+
+A forma correta é uma cadeia: cada rota checa o próprio markup antes de agir e
+devolve `false` sem clicar em nada quando não reconhece a tela, e a rota nova só
+entra **na frente** das que já existiam. No CRM antigo a rota nova custa ~0ms
+(seletor por id não casa), então não há preço em mantê-las todas de pé. O log
+deve dizer qual rota abriu — é o que transforma o próximo report de "quebrou" em
+"quebrou na rota X".
+
+**When to apply**: sempre que uma atualização do CRM mudar o markup que o
+Case Wizard clica ou raspa. Antes de apagar um seletor antigo, pergunte "existe
+hoje um agente vendo a tela que este seletor atende?" — enquanto a resposta não
+for um "não" comprovado, o caminho antigo continua como elo da cadeia. Vale
+também para a leitura do `specs/workflow/scraping-rules.md`: a regra da falha
+silenciosa só protege quem tem outra rota para tentar.
+
+---
+
 ## Antes de mexer no TL Dashboard, confira o código contra `specs/`
 
 **Why**: a fila do TL saía do caso mais novo pro mais antigo porque

--- a/src/modules/email-assistant/email-automation-service.js
+++ b/src/modules/email-assistant/email-automation-service.js
@@ -235,8 +235,7 @@ async function openEmailComposer() {
     }
 }
 
-// Caminho antigo, mantido como plano B enquanto as duas interfaces convivem:
-// em algumas telas o envelope ainda fica solto na action bar.
+// Envelope solto na action bar, sem menu nenhum no caminho.
 function clicarBotaoEmailDireto() {
     const icones = Array.from(document.querySelectorAll('i.material-icons-extended'));
     const iconeEmail = icones.find(el => el.innerText.trim() === 'email' && el.offsetParent !== null);
@@ -248,17 +247,68 @@ function clicarBotaoEmailDireto() {
     return true;
 }
 
+// Envelope visível em qualquer ponto da página. Só é chamado depois que o botão
+// direto já falhou, e é isso que torna a busca sem escopo segura aqui: se não
+// havia envelope visível um instante atrás, o que aparecer agora veio do menu
+// que acabamos de abrir.
+function acharEnvelopeVisivel() {
+    return Array.from(document.querySelectorAll('i.material-icons-extended'))
+        .find(el => el.textContent.trim() === 'email' && estaVisivel(el)) || null;
+}
+
+// Speed dial da interface ANTIGA do CRM, que ainda convive com a nova. O markup
+// é outro (material-fab-speed-dial + .trigger, sem o container com id), então
+// nenhum seletor do fluxo novo alcança este caminho - ele precisa existir por
+// conta própria. Foi removido junto com a migração para a UI nova e o resultado
+// foi o agente sem nenhuma rota: o envelope existe, mas escondido atrás do menu
+// fechado, então o clique direto também não o enxerga.
+async function abrirPelaSpeedDialAntiga() {
+    try {
+        const speedDial = document.querySelector('material-fab-speed-dial');
+        const trigger = speedDial && speedDial.querySelector('.trigger');
+        if (!trigger) return false;
+
+        log("Speed dial da UI antiga encontrado. Abrindo o menu...");
+        simularCliqueReal(trigger);
+
+        // Mesma razão do fluxo novo: os 800ms fixos que existiam aqui falhavam
+        // quando o CRM estava lento. Esperamos o envelope aparecer de fato.
+        const iconeEmail = await esperarPor(acharEnvelopeVisivel, { timeout: 3000 });
+        if (!iconeEmail) {
+            log("Menu antigo abriu, mas o envelope não apareceu.", 'warn');
+            return false;
+        }
+
+        const botaoAlvo = iconeEmail.closest('material-button') || iconeEmail.closest('material-fab') || iconeEmail;
+        simularCliqueReal(botaoAlvo);
+        log("Email aberto via speed dial da UI antiga.", 'success');
+        return true;
+    } catch (erro) {
+        // Falha silenciosa: o caminho manual continua disponível pro usuário.
+        log(`Falha no speed dial antigo: ${erro.message}`, 'error');
+        return false;
+    }
+}
+
 // --- CORE: ABRIR E LIMPAR ---
 async function openAndClearEmail() {
     log("🚀 FASE 1: Tentando abrir a janela de email...");
 
-    // O speed dial vem primeiro: é o fluxo da UI nova do CRM. O botão direto fica
-    // como plano B para as telas que ainda não migraram.
+    // Três rotas em cadeia, cada uma checando o próprio markup antes de agir.
+    // As duas versões da interface do CRM convivem entre os agentes (a
+    // atualização chega em ondas), então nenhuma delas pode ser removida quando
+    // a próxima chegar - só acrescentada na frente. No CRM antigo a primeira
+    // falha sem clicar em nada, porque o seletor é por id e não casa.
     let emailAberto = await openEmailComposer();
 
     if (!emailAberto) {
-        log("Speed dial indisponível. Tentando o botão de email direto...", 'warn');
+        log("Speed dial novo indisponível. Tentando o botão de email direto...", 'warn');
         emailAberto = clicarBotaoEmailDireto();
+    }
+
+    if (!emailAberto) {
+        log("Botão direto não visível. Tentando o speed dial da UI antiga...", 'warn');
+        emailAberto = await abrirPelaSpeedDialAntiga();
     }
 
     if (!emailAberto) {


### PR DESCRIPTION
Corrige uma regressão que está **em produção** desde o merge do #358: no Connect Cases antigo, o atalho de e-mail não abre.

## Causa

O #358 não adicionou um fallback — ele **removeu** um caminho. O bloco da UI antiga saiu inteiro:

```js
const speedDial = document.querySelector('material-fab-speed-dial');
const triggerBtn = speedDial.querySelector('.trigger');
simularCliqueReal(triggerBtn);
await esperar(800);
// ... acha o ícone "email" que apareceu e clica
```

O que ficou como plano B — o clique no envelope solto na action bar — **não cobre esse caso**, porque exige o ícone já visível (`offsetParent !== null`). Na UI antiga o envelope está escondido dentro do menu fechado: ele existe no DOM, mas invisível. As duas etapas falham e o agente vê só o toast genérico.

## Behavior diff

| CRM | Envelope | Antes do #358 | Hoje em prod | Com este PR |
|---|---|---|---|---|
| Novo | atrás do "+ Open" | ❌ (bug original) | ✅ | ✅ |
| Antigo | visível na action bar | ✅ | ✅ | ✅ |
| Antigo | atrás do speed dial antigo | ✅ | ❌ **falha** | ✅ |

## A correção

A FASE 1 passa a tentar três rotas em cadeia, cada uma checando o próprio markup antes de agir:

1. **Speed dial novo** — `#action-bar-speed-dial-container` → `material-button.compose`
2. **Envelope direto** — visível na action bar
3. **Speed dial antigo** — `material-fab-speed-dial` → `.trigger`

No CRM antigo a rota 1 custa ~0 ms e não clica em nada: o seletor é por id e simplesmente não casa. A ordem 2 antes de 3 é a do código original (se o envelope está à mão, clica; senão abre o menu).

Duas diferenças em relação ao bloco que foi removido:

- A rota 3 troca os **800 ms fixos** pelo `esperarPor()` que já existe no arquivo — delay fixo é o que falha quando o CRM está lento, mesmo motivo do fluxo novo.
- O **log diz qual das três rotas** abriu o compositor, para o próximo report já vir com a resposta em vez de "quebrou".

A busca pelo envelope depois de abrir o menu antigo é sem escopo, como no original. Isso é seguro **por causa da ordem**: ela só roda depois que a rota 2 falhou, então não havia envelope visível um instante antes — o que aparecer veio do menu que acabamos de abrir. Escopar ao `material-fab-speed-dial` seria mais estrito, mas os mini-fabs do Angular costumam ser renderizados num overlay fora do elemento, e sem acesso à UI antiga prefiro restaurar o que comprovadamente funcionava a inventar um escopo que pode não casar.

## Verificação

- `npx esbuild src/app.js --bundle` compila sem erros.
- `npm run test:emails` passa (round-trip de 8 modelos, 0 falhas).
- **Falta o teste nas duas UIs reais.** Nada no repo exercita esse fluxo — foi exatamente por isso que a regressão passou. Fica registrado como a lição do `docs/LEARNINGS.md` e como candidato a harness (`composer-opener.js` extraído + DOM falso, ou Playwright sobre o `mock-crm.html`), deliberadamente fora deste PR para o hotfix não esperar.

## Docs

- `CHANGELOG.md` — entrada em `[Unreleased] → Fixed`.
- `docs/LEARNINGS.md` — "Automação de DOM do CRM: o caminho novo entra na frente, o antigo nunca sai", com o gatilho concreto: antes de apagar um seletor antigo, perguntar se existe hoje um agente vendo a tela que ele atende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BybFy7vHB9hzpxYmeMBiux
