### PR TITLE
feat(central): abre o histórico do item e o caminho de volta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Histórico e "voltar para esta versão" na Central** (fase 3). Cada item
+  publicado passou a oferecer o seu histórico: quais versões existiram, quem
+  publicou cada uma e quando. `listContentItemHistory` e `rollbackContentItem`
+  existiam no backend desde o começo e nunca tinham sido chamados pela tela —
+  enquanto isso o modal de remoção prometia que "a versão fica arquivada e pode
+  voltar", sem oferecer caminho para fazê-la voltar. Ver o histórico é leitura,
+  e aparece para quem enxerga o item; republicar uma versão anterior vai ao ar
+  sem passar pela fila, então exige o papel de quem aprova e o mesmo passo de
+  confirmação da publicação direta.
 - **Smoke da Central de Conteúdo** (`npm run smoke:content`). A maior tela do
   projeto era a única sem teste nenhum, e a reorganização da navegação
   (ADR-0007) toca todos os seus renderizadores de uma vez. O smoke carrega o

--- a/PLAN.md
+++ b/PLAN.md
@@ -48,8 +48,8 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       três grupos; home "Hoje" moldada pelo papel; idioma único e persistente no
       lugar dos `select` independentes; rota por hash. **PR irmão:** changelog de
       versão na Central e no TL Dash, a partir de fonte única no repo.
-- [ ] **Fase 3 — ciclo de vida do item.** Gaveta com histórico e "voltar para
-      esta versão" — `listContentItemHistory` e `rollbackContentItem` existem no
+- [~] **Fase 3 — ciclo de vida do item** — em andamento. **Entregue:** histórico
+      e "voltar para esta versão" — `listContentItemHistory` e `rollbackContentItem` existem no
       backend e nunca foram chamados, enquanto o modal de remoção promete que a
       versão "pode voltar"; rascunho de verdade, separado do envio; trava de
       edição visível; diff por palavra e prévia renderizada na revisão.

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -69,12 +69,17 @@
                             : '<span class="pill draft">rascunho</span>';
                     }
 
+                    // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
+                    // passou. Só reverter é que depende de aprovar.
+                    var historico = '<button class="btn btn-ghost btn-sm" '
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'links\')">Histórico</button>';
+
                     var actions = canPropose('links')
-                        ? '<div style="display:flex;gap:8px">' +
+                        ? '<div style="display:flex;gap:8px">' + historico +
                         '<button class="btn btn-ghost btn-sm" onclick="openLinkEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Tirar do ar</button>' +
                         '</div>'
-                        : '';
+                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -317,12 +322,17 @@
                             : '<span class="pill draft">rascunho</span>')
                         : '';
 
+                    // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
+                    // passou. Só reverter é que depende de aprovar.
+                    var historico = '<button class="btn btn-ghost btn-sm" '
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'call_script\')">Histórico</button>';
+
                     var actions = canPropose('call_script')
-                        ? '<div style="display:flex;gap:8px">' +
+                        ? '<div style="display:flex;gap:8px">' + historico +
                         '<button class="btn btn-ghost btn-sm" onclick="openStepEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                         '</div>'
-                        : '';
+                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -522,12 +532,17 @@
                         ? '<span class="pill draft">' + esc(String(it.field).toUpperCase()) + '</span>'
                         : '';
 
+                    // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
+                    // passou. Só reverter é que depende de aprovar.
+                    var historico = '<button class="btn btn-ghost btn-sm" '
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'note_template\')">Histórico</button>';
+
                     var actions = canPropose('note_template')
-                        ? '<div style="display:flex;gap:8px">' +
+                        ? '<div style="display:flex;gap:8px">' + historico +
                         '<button class="btn btn-ghost btn-sm" onclick="openTemplateEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                         '</div>'
-                        : '';
+                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -751,11 +766,16 @@
                         ? nPh + ' campo' + (nPh === 1 ? '' : 's')
                         : Object.keys(v.labels || {}).length + ' rótulos';
 
+                    // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
+                    // passou. Só reverter é que depende de aprovar.
+                    var historico = '<button class="btn btn-ghost btn-sm" '
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'email_template\')">Histórico</button>';
+
                     var actions = canPropose('email_template')
-                        ? '<div style="display:flex;gap:8px">' +
+                        ? '<div style="display:flex;gap:8px">' + historico +
                         '<button class="btn btn-ghost btn-sm" onclick="openEmailEditor(\'' + it.id + '\')">Editar</button>' +
                         '</div>'
-                        : '';
+                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -915,12 +935,17 @@
                         : '<span class="pill draft">rascunho</span>')
                     : '';
 
+                // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
+                // passou. Só reverter é que depende de aprovar.
+                var historico = '<button class="btn btn-ghost btn-sm" '
+                    + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'tips\')">Histórico</button>';
+
                 var actions = canPropose('tips')
-                    ? '<div style="display:flex;gap:8px">' +
+                    ? '<div style="display:flex;gap:8px">' + historico +
                     '<button class="btn btn-ghost btn-sm" onclick="openTipEditor(\'' + it.id + '\')">Editar</button>' +
                     '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                     '</div>'
-                    : '';
+                    : '<div style="display:flex;gap:8px">' + historico + '</div>';
 
                 return '<div class="item-row">' +
                     '<div class="item-main">' +

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -184,6 +184,148 @@
             });
         }
 
+        // Publicação direta declara o ALCANCE antes de acontecer.
+        //
+        // A fricção estava invertida na tela: a ação que muda a produção de todo
+        // mundo disparava num clique, enquanto rejeitar uma proposta — que é
+        // reversível — exigia modal e justificativa. Aqui o passo a mais existe
+        // para que ninguém publique para a operação inteira sem ler para quem.
+        function confirmarPublicacao(quem, oque, aoConfirmar) {
+            // A confirmação é uma CAMADA por cima do editor, não uma troca do
+            // conteúdo do modal. Trocar por innerHTML recriaria os campos: o
+            // texto digitado sobreviveria à ida e volta, mas os handlers ligados
+            // por JS e a referência do botão que disparou a ação apontariam para
+            // nós já descartados.
+            var camada = document.createElement('div');
+            camada.className = 'modal-backdrop';
+            camada.style.zIndex = '300';
+            camada.innerHTML =
+                '<div class="modal" style="max-width:460px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="pub-titulo">' +
+                '<h2 id="pub-titulo">Publicar agora?</h2>' +
+                '<p class="card-sub">Isto vai ao ar imediatamente para <strong>' + esc(quem) +
+                '</strong>. Não passa por revisão.</p>' +
+                '<div class="note warn" style="margin-top:16px">' + esc(oque) + '</div>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" id="pub-nao">Voltar e revisar</button>' +
+                '<button class="btn btn-primary" id="pub-sim">Publicar agora</button>' +
+                '</div></div>';
+
+            document.getElementById('modal-root').appendChild(camada);
+
+            function fechar() {
+                if (camada.parentNode) camada.parentNode.removeChild(camada);
+            }
+
+            // Voltar devolve o editor intacto: confirmar não pode custar o
+            // trabalho de quem desistiu no último passo.
+            camada.querySelector('#pub-nao').onclick = fechar;
+            camada.querySelector('#pub-sim').onclick = function () {
+                fechar();
+                aoConfirmar();
+            };
+            camada.querySelector('#pub-sim').focus();
+        }
+
+        // --- Histórico do item ---
+        //
+        // `listContentItemHistory` e `rollbackContentItem` existem no backend
+        // desde o começo e NUNCA foram chamados pela tela. Enquanto isso, o
+        // modal de remoção promete que "nada é apagado — a versão fica
+        // arquivada e pode voltar", sem oferecer caminho nenhum para fazê-la
+        // voltar. Isto é a porta que faltava.
+        function abrirHistorico(itemId, lineage, module) {
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:680px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="hist-titulo">' +
+                '<h2 id="hist-titulo">Histórico</h2>' +
+                '<div id="hist-corpo"><div class="skeleton"></div><div class="skeleton"></div></div>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Fechar</button>' +
+                '</div></div></div>';
+
+            google.script.run
+                .withSuccessHandler(function (versoes) {
+                    renderHistorico(versoes || [], itemId, module);
+                })
+                .withFailureHandler(function (err) {
+                    var host = document.getElementById('hist-corpo');
+                    if (host) host.innerHTML = '<div class="note warn">' + esc(err.message) + '</div>';
+                })
+                .listContentItemHistory(lineage, module);
+        }
+
+        function dataCurta(iso) {
+            if (!iso) return '';
+            var d = new Date(iso);
+            if (isNaN(d.getTime())) return String(iso);
+            // Intl no idioma da interface, não formato fixo — mesma regra do
+            // resto do produto (specs/ui-ux/design-system.md).
+            return d.toLocaleString(idiomaAtual() === 'ES' ? 'es' : 'pt-BR',
+                { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+        }
+
+        function renderHistorico(versoes, itemId, module) {
+            var host = document.getElementById('hist-corpo');
+            if (!host) return;
+
+            if (!versoes.length) {
+                host.innerHTML = '<div class="state"><span class="material-symbols-rounded" ' +
+                    'aria-hidden="true">history</span><h2>Sem histórico</h2>' +
+                    '<p>Este item ainda está na primeira versão.</p></div>';
+                return;
+            }
+
+            var titulo = document.getElementById('hist-titulo');
+            if (titulo) titulo.textContent = 'Histórico de ' + (versoes[0].label || 'item');
+
+            // Reverter republica sem passar pela fila: é a mesma natureza da
+            // publicação direta, e quem pode fazer é quem aprova.
+            var podeReverter = !!(SESSION && SESSION.canApprove);
+
+            host.innerHTML = versoes.map(function (v) {
+                var noAr = v.status === 'live';
+                var acao = (!noAr && podeReverter)
+                    ? '<button class="btn btn-ghost btn-sm" ' +
+                      'onclick="pedirRollback(\'' + v.id + '\',' + v.version + ',\'' + module + '\')">' +
+                      'Voltar para esta versão</button>'
+                    : '';
+
+                return '<div class="item-row">' +
+                    '<div class="item-main">' +
+                    '<div class="item-name">Versão ' + v.version +
+                    (noAr ? ' <span class="estado">no ar</span>' : '') + '</div>' +
+                    '<div class="item-meta">por ' + esc(v.publishedBy) + ' · ' +
+                    esc(dataCurta(v.publishedAt)) + '</div>' +
+                    '<div class="diff-body" style="margin-top:8px;max-height:120px;overflow:auto">' +
+                    esc(prettyValue(v.value)) + '</div>' +
+                    '</div>' + acao + '</div>';
+            }).join('');
+
+            if (!podeReverter) {
+                host.innerHTML = '<div class="note">Seu papel vê o histórico, mas não republica ' +
+                    'uma versão anterior — isso vai ao ar sem passar por revisão.</div>' + host.innerHTML;
+            }
+        }
+
+        function pedirRollback(archivedItemId, versao, module) {
+            confirmarPublicacao(
+                'todos os agentes',
+                'Republica a versão ' + versao + '. A que está no ar agora vai para o histórico.',
+                function () {
+                    google.script.run
+                        .withSuccessHandler(function () {
+                            closeModal();
+                            toast('Versão ' + versao + ' republicada.');
+                            refreshContentLists();
+                        })
+                        .withFailureHandler(function (err) { toast(err.message, true); })
+                        .rollbackContentItem(archivedItemId);
+                }
+            );
+        }
+
         // --- Hoje ---
         //
         // Responde "o que está acontecendo no conteúdo agora", que é a pergunta

--- a/gas-backend/ContentDashboard_Ops.html
+++ b/gas-backend/ContentDashboard_Ops.html
@@ -157,49 +157,6 @@
             document.getElementById('bc-title').focus();
         }
 
-        // Publicação direta declara o ALCANCE antes de acontecer.
-        //
-        // A fricção estava invertida na tela: a ação que muda a produção de todo
-        // mundo disparava num clique, enquanto rejeitar uma proposta — que é
-        // reversível — exigia modal e justificativa. Aqui o passo a mais existe
-        // para que ninguém publique para a operação inteira sem ler para quem.
-        function confirmarPublicacao(quem, oque, aoConfirmar) {
-            // A confirmação é uma CAMADA por cima do editor, não uma troca do
-            // conteúdo do modal. Trocar por innerHTML recriaria os campos: o
-            // texto digitado sobreviveria à ida e volta, mas os handlers ligados
-            // por JS e a referência do botão que disparou a ação apontariam para
-            // nós já descartados.
-            var camada = document.createElement('div');
-            camada.className = 'modal-backdrop';
-            camada.style.zIndex = '300';
-            camada.innerHTML =
-                '<div class="modal" style="max-width:460px" role="dialog" aria-modal="true"' +
-                ' aria-labelledby="pub-titulo">' +
-                '<h2 id="pub-titulo">Publicar agora?</h2>' +
-                '<p class="card-sub">Isto vai ao ar imediatamente para <strong>' + esc(quem) +
-                '</strong>. Não passa por revisão.</p>' +
-                '<div class="note warn" style="margin-top:16px">' + esc(oque) + '</div>' +
-                '<div class="modal-actions">' +
-                '<button class="btn btn-ghost" id="pub-nao">Voltar e revisar</button>' +
-                '<button class="btn btn-primary" id="pub-sim">Publicar agora</button>' +
-                '</div></div>';
-
-            document.getElementById('modal-root').appendChild(camada);
-
-            function fechar() {
-                if (camada.parentNode) camada.parentNode.removeChild(camada);
-            }
-
-            // Voltar devolve o editor intacto: confirmar não pode custar o
-            // trabalho de quem desistiu no último passo.
-            camada.querySelector('#pub-nao').onclick = fechar;
-            camada.querySelector('#pub-sim').onclick = function () {
-                fechar();
-                aoConfirmar();
-            };
-            camada.querySelector('#pub-sim').focus();
-        }
-
         function alcanceDoSegmento(lang) {
             if (lang === 'PT') return 'todos os agentes PT-BR';
             if (lang === 'ES') return 'todos os agentes ES';

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -587,6 +587,26 @@
             color: var(--danger);
         }
 
+        /* O estado se diz em texto normal, com um ponto na cor semântica —
+           não em pílula maiúscula (specs/ui-ux/design-system.md). As pílulas
+           antigas seguem no resto da tela; superfície nova nasce certa. */
+        .estado {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 12.5px;
+            font-weight: 400;
+            color: var(--text-secondary);
+        }
+
+        .estado::before {
+            content: '';
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: var(--success);
+        }
+
         /* --- Diff --- */
         .diff {
             display: grid;

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -110,6 +110,25 @@ const ITENS = {
     broadcast: [], bau_availability: [], people: [],
 };
 
+// Duas versões do mesmo link: é o mínimo para provar que a versão arquivada
+// aparece e que só ela oferece "voltar para esta versão".
+const HISTORICO = {
+    itm_1: [
+        {
+            id: 'itm_1', module: 'links', key: 'tasks', lang: 'ALL', label: 'Fila de tarefas',
+            version: 2, status: 'live', publishedBy: 'lucaste', publishedAt: '2026-09-01T10:00:00Z',
+            lineage: 'itm_1',
+            value: JSON.stringify({ name: 'Fila de tarefas', url: 'https://go/fila', desc: 'Fila do dia' }),
+        },
+        {
+            id: 'itm_0', module: 'links', key: 'tasks', lang: 'ALL', label: 'Fila de tarefas',
+            version: 1, status: 'archived', publishedBy: 'anaflor', publishedAt: '2026-08-20T09:00:00Z',
+            lineage: 'itm_1',
+            value: JSON.stringify({ name: 'Fila antiga', url: 'https://go/antiga', desc: 'Versão anterior' }),
+        },
+    ],
+};
+
 // ------------------------------------------------------- montagem da página
 async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } = {}) {
     const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
@@ -121,7 +140,8 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
 
     // O dublê precisa existir ANTES do script da página rodar: o boot dispara
     // no DOMContentLoaded.
-    await page.addInitScript(({ sessao, itens, falhar }) => {
+    await page.addInitScript(({ sessao, itens, falhar, historico }) => {
+        const HISTORICO = historico;
         window.__chamadas = [];
 
         const RESPOSTAS = {
@@ -132,6 +152,8 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
                 return [];
             },
             listPendingApprovals: () => [],
+            listContentItemHistory: (lineage) => (HISTORICO[lineage] || []),
+            rollbackContentItem: () => ({ status: 'success', itemId: 'itm_revivido' }),
             listContentAccess: () => [{ ldap: 'lucaste', role: 'ADMIN', active: true, grantedBy: 'system' }],
             listPeople: () => [],
             getNoteFieldCatalog: () => ({ fields: {}, substatus: [] }),
@@ -180,7 +202,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
             value: { script: { get run() { return construir(); } } },
             writable: true,
         });
-    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe });
+    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe, historico: HISTORICO });
 
     await page.goto('file://' + ARQUIVO + hash, { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(300);
@@ -484,6 +506,81 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         const publicou = await page.evaluate(() => window.__chamadas
             .filter(c => c.metodo === 'publishContentDirect').length);
         igual(publicou, 1, 'chamadas de publicação');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------------ histórico do item
+{
+    const page = await abrir({ sessao: 'admin' });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(200);
+
+    await check('todo item publicado oferece o histórico', async () => {
+        verdade(await page.locator('button:has-text("Histórico")').first().isVisible(),
+            'o botão de histórico deveria aparecer na linha do item');
+    });
+
+    await check('o histórico lista as versões, da mais nova para a mais antiga', async () => {
+        await page.locator('button:has-text("Histórico")').first().click();
+        await page.waitForTimeout(300);
+
+        const versoes = await page.evaluate(() => Array.from(
+            document.querySelectorAll('#hist-corpo .item-name')).map(e => e.textContent.trim()));
+        igual(versoes.length, 2, 'versões listadas');
+        verdade(/Versão 2/.test(versoes[0]), 'a mais nova vem primeiro');
+        verdade(/no ar/.test(versoes[0]), 'a versão no ar é identificada');
+        verdade(/Versão 1/.test(versoes[1]), 'a anterior vem depois');
+    });
+
+    await check('só a versão arquivada oferece voltar', async () => {
+        const botoes = await page.locator('#hist-corpo button:has-text("Voltar para esta versão")').count();
+        igual(botoes, 1, 'botões de reverter');
+    });
+
+    await check('reverter declara o alcance antes de acontecer', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#hist-corpo button:has-text("Voltar para esta versão")').click();
+        await page.waitForTimeout(200);
+
+        const reverteu = await page.evaluate(() => window.__chamadas
+            .some(c => c.metodo === 'rollbackContentItem'));
+        igual(reverteu, false, 'reverteu sem confirmar');
+        verdade(await page.locator('#pub-titulo').isVisible(), 'a confirmação deveria aparecer');
+    });
+
+    await check('confirmar republica a versão escolhida', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.click('#pub-sim');
+        await page.waitForTimeout(300);
+
+        const chamadas = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'rollbackContentItem'));
+        igual(chamadas.length, 1, 'chamadas de rollback');
+        igual(chamadas[0].args[0], 'itm_0', 'reverteu para a versão arquivada, não para a que já está no ar');
+    });
+
+    await page.close();
+}
+
+{
+    // Quem não aprova vê por onde o item passou, mas não republica: reverter
+    // vai ao ar sem revisão, e isso é decisão de quem aprova.
+    const page = await abrir({ sessao: 'wfm' });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(200);
+
+    await check('quem não aprova vê o histórico, mas não o botão de reverter', async () => {
+        await page.locator('button:has-text("Histórico")').first().click();
+        await page.waitForTimeout(300);
+
+        const versoes = await page.locator('#hist-corpo .item-name').count();
+        igual(versoes, 2, 'versões listadas');
+        igual(await page.locator('#hist-corpo button:has-text("Voltar para esta versão")').count(), 0,
+            'botões de reverter');
+        verdade(/não republica/.test(await page.locator('#hist-corpo').textContent()),
+            'a tela precisa dizer por que não há o botão');
     });
 
     await page.close();


### PR DESCRIPTION
## O que muda

Primeira entrega da fase 3. Cada item publicado dos cinco módulos de catálogo passa a oferecer o seu histórico — as versões que existiram, quem publicou cada uma, quando, e o valor de cada uma em texto legível — com o caminho de republicar uma versão anterior.

## Por que assim

`listContentItemHistory` e `rollbackContentItem` existem no backend desde o começo e **nunca foram chamados pela tela**. Enquanto isso, o modal de remoção promete — desde sempre — que *"nada é apagado: a versão fica arquivada e pode voltar"*, sem oferecer caminho nenhum para fazê-la voltar. Este PR é a porta que faltava, e não código novo de backend.

**Duas permissões diferentes, de propósito.** Ver o histórico é **leitura**: aparece para qualquer pessoa que já enxerga o item, inclusive quem não propõe naquele módulo. Saber por onde o conteúdo passou não deveria depender de poder mudá-lo.

Republicar uma versão anterior é outra coisa: **vai ao ar sem passar pela fila**, igual à publicação direta. Então exige o papel de quem aprova e usa o mesmo passo de confirmação com declaração de alcance criado na fase 2 — que por isso subiu de `_Ops` para `_Core`, já que agora serve três partes. Quem não aprova vê o histórico com uma linha explicando por que não há o botão, em vez de um botão que falharia no servidor.

**Um detalhe de design.** O estado "no ar" nasceu como texto normal com um ponto na cor semântica, e não como pílula em maiúsculas — que é o que `specs/ui-ux/design-system.md` pede para evitar, e que a revisão de UX registrou como violação existente. As pílulas antigas seguem no resto da tela; o que muda é que **superfície nova nasce certa** em vez de propagar a violação.

## Como verificar

```
npm run smoke:content
```

**De 25 para 31 verificações.** As seis novas:

```
✓ todo item publicado oferece o histórico
✓ o histórico lista as versões, da mais nova para a mais antiga
✓ só a versão arquivada oferece voltar
✓ reverter declara o alcance antes de acontecer
✓ confirmar republica a versão escolhida
✓ quem não aprova vê o histórico, mas não o botão de reverter
```

A quinta merece destaque: ela afirma que o rollback chamou `rollbackContentItem` com o **ID da versão arquivada**, e não com o da que já está no ar. É o erro que passaria despercebido num teste que só verificasse "a chamada aconteceu".

Todas as 8 suítes `test:` e o `build` verdes; `smoke:wizards`, `env-badge`, `broadcast`, `content` e `people` verdes. `smoke:shortcuts` segue com as mesmas 2 falhas anteriores a esta linha de trabalho (conferidas em `ec3e627`).

Tela conferida renderizada: o modal lista as três versões com autor e data, marca a que está no ar e oferece "Voltar para esta versão" só nas arquivadas.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [ ] Testado com o bookmarklet de **dev** contra o CRM real — ver abaixo

## O que ainda precisa de você

O rollback é a única ação desta fase que **muda o que o agente vê**, e ela roda sob `LockService`, que não existe fora do Apps Script. Vale exercitar uma vez em dev: reverter um link para uma versão anterior e conferir que o app do agente passa a servir a versão antiga na chamada seguinte — é o que prova a invalidação de cache da fase 1 junto com o rollback.

## Checklist

- [x] Se mexi em `gas-backend/`: nenhuma rota nova; o contrato em `specs/data-models/api-payloads.md` continua válido. Só a tela passou a chamar duas funções que já existiam.
- [x] Se mexi numa regra de negócio: nenhuma. Quem pode reverter continua sendo quem aprova, decidido no servidor — a tela só deixou de oferecer o que ia falhar.
- [x] Se é uma decisão que alguém vai questionar depois: a separação entre ver (leitura) e reverter (aprovação) está no ADR-0007 e comentada no código.
- [x] Se muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Se bumpei versão: não bumpei — a fase entra em uma release só.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_