### PR TITLE
feat(central): rascunho vira um estado que dá para alcançar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Rascunho virou um estado alcançável na Central** (fase 3). Todo editor tinha
+  um botão só, que salvava e enviava para revisão no mesmo gesto: não havia como
+  guardar trabalho parcial, a pílula "rascunho" que as listas sabiam desenhar
+  nunca aparecia, e a trava de edição cooperativa nunca chegava a valer porque
+  nada ficava aberto. Agora são dois caminhos — **Salvar rascunho** e **Enviar
+  para revisão** —, a linha do item diz se há rascunho seu, se alguém está
+  editando (e quem), ou se já foi para a fila, e existe
+  `discardContentDraft` para desistir. Sem essa saída o rascunho viraria
+  armadilha: ficaria na lista, contaria na home e reabriria na próxima edição.
 - **Histórico e "voltar para esta versão" na Central** (fase 3). Cada item
   publicado passou a oferecer o seu histórico: quais versões existiram, quem
   publicou cada uma e quando. `listContentItemHistory` e `rollbackContentItem`

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,7 +49,8 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       lugar dos `select` independentes; rota por hash. **PR irmão:** changelog de
       versão na Central e no TL Dash, a partir de fonte única no repo.
 - [~] **Fase 3 — ciclo de vida do item** — em andamento. **Entregue:** histórico
-      e "voltar para esta versão" — `listContentItemHistory` e `rollbackContentItem` existem no
+      e "voltar para esta versão"; rascunho de verdade, separado do envio, com
+      a trava de edição visível e caminho para descartar — `listContentItemHistory` e `rollbackContentItem` existem no
       backend e nunca foram chamados, enquanto o modal de remoção promete que a
       versão "pode voltar"; rascunho de verdade, separado do envio; trava de
       edição visível; diff por palavra e prévia renderizada na revisão.

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -1046,6 +1046,53 @@ function submitContentDraftLocked_(draftId) {
 }
 
 /**
+ * Descarta um rascunho que ainda não foi enviado.
+ *
+ * Existe porque o rascunho passou a ser um estado de verdade na tela: quem
+ * começa uma alteração e muda de ideia precisa de saída. Sem isto o rascunho
+ * fica para sempre — aparece na lista como "rascunho", conta na home de quem o
+ * criou, e a próxima edição daquele item continua abrindo o texto abandonado.
+ *
+ * Só rascunho: uma proposta que JÁ foi enviada se resolve pela revisão
+ * (aprovar ou rejeitar), não sumindo por baixo de quem ia revisar.
+ *
+ * Só quem propôs, ou quem aprova. A regra é a mesma de saveContentDraft(): o
+ * rascunho é de quem o escreveu.
+ */
+function discardContentDraft(draftId) {
+  return withContentWriteLock_(function () {
+    return discardContentDraftLocked_(draftId);
+  });
+}
+
+function discardContentDraftLocked_(draftId) {
+  const draft = findContentRow_(SHEET_CONTENT_DRAFTS, 'Draft_ID', draftId);
+  if (!draft) throw new Error("Rascunho não encontrado.");
+
+  const session = assertContentRole_('propose', String(draft.Module).trim());
+
+  if (String(draft.Status).trim() !== CONTENT_STATUS.DRAFT) {
+    throw new Error(
+      "Só um rascunho pode ser descartado. Uma proposta em revisão se resolve aprovando ou rejeitando."
+    );
+  }
+  if (String(draft.Proposed_By).trim() !== session.ldap && !session.perms.approve) {
+    throw new Error("Este rascunho é de outra pessoa.");
+  }
+
+  getContentSheet_(SHEET_CONTENT_DRAFTS).deleteRow(draft._row);
+
+  logContentEvent_(
+    session.ldap,
+    'draft_discard',
+    String(draft.Module) + '/' + String(draft.Key),
+    String(draft.Label || "")
+  );
+
+  return { status: 'success' };
+}
+
+/**
  * Salva e envia para revisão numa execução só.
  *
  * A tela fazia isso em duas chamadas encadeadas (três nos e-mails, que ainda

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -62,12 +62,14 @@
                 byCat[cat].forEach(function (it) {
                     var v = parseLinkValue(it.value);
                     var d = draftForItem(it.id);
-                    var badge = '';
-                    if (d) {
-                        badge = d.status === 'pending'
-                            ? '<span class="pill pending">em revisão</span>'
-                            : '<span class="pill draft">rascunho</span>';
-                    }
+                    var badge = selosDoRascunho(d);
+
+                    // Descartar só aparece quando existe rascunho não enviado e
+                    // ele é seu: proposta em revisão se resolve pela fila.
+                    var descarte = (d && d.status === 'draft' && !travadoPorOutro(d))
+                        ? '<button class="btn btn-danger btn-sm" onclick="descartarRascunho(\'' +
+                          d.draftId + '\', loadLinks)">Descartar rascunho</button>'
+                        : '';
 
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
@@ -75,11 +77,11 @@
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'links\')">Histórico</button>';
 
                     var actions = canPropose('links')
-                        ? '<div style="display:flex;gap:8px">' + historico +
+                        ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openLinkEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Tirar do ar</button>' +
                         '</div>'
-                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
+                        : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -120,6 +122,89 @@
                 'proposta em revisão que não aparece aqui. ' +
                 '<button class="btn btn-ghost btn-sm" style="margin-left:8px" ' +
                 'onclick="switchTab(\'' + module + '\')">Tentar de novo</button></div>';
+        }
+
+        // Salvar SEM enviar. O rascunho existia no modelo de dados desde o
+        // começo e era inalcançável: todo editor tinha um botão só, que salvava
+        // e submetia no mesmo gesto. Sem isto não havia como guardar trabalho
+        // parcial — fechar o editor descartava tudo — e a trava de edição
+        // cooperativa nunca chegava a valer, porque nada ficava aberto.
+        function salvarRascunho(payload, btn, aoConcluir) {
+            var rotulo = btn.textContent;
+            btn.disabled = true;
+            btn.textContent = 'Salvando…';
+
+            google.script.run
+                .withSuccessHandler(function () {
+                    closeModal();
+                    toast('Rascunho salvo. Ninguém vê até você enviar.');
+                    if (aoConcluir) aoConcluir();
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.textContent = rotulo;
+                    toast(err.message, true);
+                })
+                .saveContentDraft(payload);
+        }
+
+        // Descartar o que foi guardado e não vai virar proposta. Sem esta saída
+        // o rascunho vira armadilha: fica na lista, conta na home e a próxima
+        // edição do item reabre o texto abandonado.
+        function descartarRascunho(draftId, aoConcluir) {
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:440px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="desc-titulo">' +
+                '<h2 id="desc-titulo">Descartar este rascunho?</h2>' +
+                '<p class="card-sub">O texto guardado some. O que está no ar não muda.</p>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Manter</button>' +
+                '<button class="btn btn-danger" id="desc-go">Descartar</button>' +
+                '</div></div></div>';
+
+            document.getElementById('desc-go').onclick = function () {
+                this.disabled = true;
+                google.script.run
+                    .withSuccessHandler(function () {
+                        closeModal();
+                        toast('Rascunho descartado.');
+                        if (aoConcluir) aoConcluir();
+                    })
+                    .withFailureHandler(function (err) { toast(err.message, true); })
+                    .discardContentDraft(draftId);
+            };
+        }
+
+        // Quem está com o item aberto AGORA, se for outra pessoa. A trava é
+        // cooperativa e expira sozinha (CONTENT_LOCK_TTL_MS no servidor); aqui
+        // a janela é a mesma, para a tela não anunciar uma trava que o servidor
+        // já não respeita.
+        var TRAVA_TTL_MS = 10 * 60 * 1000;
+
+        function travadoPorOutro(rascunho) {
+            if (!rascunho || !rascunho.lockedBy || !SESSION) return '';
+            if (rascunho.lockedBy === SESSION.ldap) return '';
+
+            var quando = new Date(rascunho.lockedAt).getTime();
+            if (isNaN(quando) || (Date.now() - quando) > TRAVA_TTL_MS) return '';
+
+            return rascunho.lockedBy;
+        }
+
+        // Rótulo do rascunho na linha do item: o que ele é, e de quem.
+        function selosDoRascunho(rascunho) {
+            if (!rascunho) return '';
+
+            if (rascunho.status === 'pending') {
+                return ' <span class="estado estado-espera">em revisão</span>';
+            }
+
+            var quem = travadoPorOutro(rascunho);
+            if (quem) {
+                return ' <span class="estado estado-espera">' + esc(quem) + ' está editando</span>';
+            }
+            return ' <span class="estado estado-espera">rascunho seu</span>';
         }
 
         function enviarProposta(payload, btn, aoConcluir) {
@@ -180,16 +265,20 @@
                 '<select id="lnk-cat">' + catOptions + '</select>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
-                '<button class="btn btn-primary" id="lnk-save">Salvar e enviar para revisão</button>' +
+                '<button class="btn btn-ghost" id="lnk-draft">Salvar rascunho</button>' +
+                '<button class="btn btn-primary" id="lnk-save">Enviar para revisão</button>' +
                 '</div></div></div>';
 
             document.getElementById('lnk-save').onclick = function () {
                 submitLink(itemId, existingDraft ? existingDraft.draftId : null, this);
             };
+            document.getElementById('lnk-draft').onclick = function () {
+                submitLink(itemId, existingDraft ? existingDraft.draftId : null, this, true);
+            };
             document.getElementById('lnk-name').focus();
         }
 
-        function submitLink(itemId, draftId, btn) {
+        function submitLink(itemId, draftId, btn, apenasRascunho) {
             var name = document.getElementById('lnk-name').value.trim();
             var url = document.getElementById('lnk-url').value.trim();
 
@@ -213,7 +302,7 @@
                 })
             };
 
-            enviarProposta(payload, btn, loadLinks);
+            (apenasRascunho ? salvarRascunho : enviarProposta)(payload, btn, loadLinks);
         }
 
         function askRemoval(itemId) {
@@ -316,10 +405,13 @@
 
                 steps.forEach(function (it, idx) {
                     var d = csDraftForItem(it.id);
-                    var badge = d
-                        ? (d.status === 'pending'
-                            ? '<span class="pill pending">em revisão</span>'
-                            : '<span class="pill draft">rascunho</span>')
+                    var badge = selosDoRascunho(d);
+
+                    // Descartar só aparece quando existe rascunho não enviado e
+                    // ele é seu: proposta em revisão se resolve pela fila.
+                    var descarte = (d && d.status === 'draft' && !travadoPorOutro(d))
+                        ? '<button class="btn btn-danger btn-sm" onclick="descartarRascunho(\'' +
+                          d.draftId + '\', loadCallScript)">Descartar rascunho</button>'
                         : '';
 
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
@@ -328,11 +420,11 @@
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'call_script\')">Histórico</button>';
 
                     var actions = canPropose('call_script')
-                        ? '<div style="display:flex;gap:8px">' + historico +
+                        ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openStepEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                         '</div>'
-                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
+                        : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -378,16 +470,20 @@
                 '<textarea id="cs-text" placeholder="o que o agente deve dizer ou fazer">' + esc(text) + '</textarea>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
-                '<button class="btn btn-primary" id="cs-save">Salvar e enviar para revisão</button>' +
+                '<button class="btn btn-ghost" id="cs-draft">Salvar rascunho</button>' +
+                '<button class="btn btn-primary" id="cs-save">Enviar para revisão</button>' +
                 '</div></div></div>';
 
             document.getElementById('cs-save').onclick = function () {
                 submitStep(itemId, existingDraft ? existingDraft.draftId : null, src, this);
             };
+            document.getElementById('cs-draft').onclick = function () {
+                submitStep(itemId, existingDraft ? existingDraft.draftId : null, src, this, true);
+            };
             document.getElementById('cs-text').focus();
         }
 
-        function submitStep(itemId, draftId, src, btn) {
+        function submitStep(itemId, draftId, src, btn, apenasRascunho) {
             var text = document.getElementById('cs-text').value.trim();
             if (!text) return toast('Escreva o texto do passo.', true);
 
@@ -408,7 +504,7 @@
                 }, 0) + 1;
             }
 
-            enviarProposta({
+            (apenasRascunho ? salvarRascunho : enviarProposta)({
                 draftId: draftId || '',
                 itemId: itemId || '',
                 module: 'call_script',
@@ -523,13 +619,16 @@
                     var v = parseTpl(it.value);
                     var nCampos = Object.keys(v.fields || {}).length;
                     var d = ntDraftForItem(it.id);
-                    var badge = d
-                        ? (d.status === 'pending'
-                            ? '<span class="pill pending">em revisão</span>'
-                            : '<span class="pill draft">rascunho</span>')
-                        : '';
+                    var badge = selosDoRascunho(d);
                     var escopo = (it.field && it.field !== 'all')
                         ? '<span class="pill draft">' + esc(String(it.field).toUpperCase()) + '</span>'
+                        : '';
+
+                    // Descartar só aparece quando existe rascunho não enviado e
+                    // ele é seu: proposta em revisão se resolve pela fila.
+                    var descarte = (d && d.status === 'draft' && !travadoPorOutro(d))
+                        ? '<button class="btn btn-danger btn-sm" onclick="descartarRascunho(\'' +
+                          d.draftId + '\', loadNoteTemplates)">Descartar rascunho</button>'
                         : '';
 
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
@@ -538,11 +637,11 @@
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'note_template\')">Histórico</button>';
 
                     var actions = canPropose('note_template')
-                        ? '<div style="display:flex;gap:8px">' + historico +
+                        ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openTemplateEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                         '</div>'
-                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
+                        : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -610,13 +709,17 @@
                 '<div id="nt-fields" style="margin-top:8px"></div>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
-                '<button class="btn btn-primary" id="nt-save">Salvar e enviar para revisão</button>' +
+                '<button class="btn btn-ghost" id="nt-draft">Salvar rascunho</button>' +
+                '<button class="btn btn-primary" id="nt-save">Enviar para revisão</button>' +
                 '</div></div></div>';
 
             renderTemplateFields(v.fields || {});
 
             document.getElementById('nt-save').onclick = function () {
                 submitTemplate(itemId, existingDraft ? existingDraft.draftId : null, v, this);
+            };
+            document.getElementById('nt-draft').onclick = function () {
+                submitTemplate(itemId, existingDraft ? existingDraft.draftId : null, v, this, true);
             };
             document.getElementById('nt-f-name').focus();
         }
@@ -664,7 +767,7 @@
                 }).join('');
         }
 
-        function submitTemplate(itemId, draftId, original, btn) {
+        function submitTemplate(itemId, draftId, original, btn, apenasRascunho) {
             var nome = document.getElementById('nt-f-name').value.trim();
             if (!nome) return toast('Dê um nome ao modelo.', true);
 
@@ -686,7 +789,7 @@
                 original && original.activeTasks ? { activeTasks: original.activeTasks } : {}
             ));
 
-            enviarProposta({
+            (apenasRascunho ? salvarRascunho : enviarProposta)({
                 draftId: draftId || '',
                 itemId: itemId || '',
                 module: 'note_template',
@@ -755,16 +858,19 @@
                 byCat[cat].forEach(function (it) {
                     var v = parseEmail(it.value);
                     var d = emDraftForItem(it.id);
-                    var badge = d
-                        ? (d.status === 'pending'
-                            ? '<span class="pill pending">em revisão</span>'
-                            : '<span class="pill draft">rascunho</span>')
-                        : '';
+                    var badge = selosDoRascunho(d);
 
                     var nPh = (v.placeholders || []).length;
                     var phInfo = lang === 'PT'
                         ? nPh + ' campo' + (nPh === 1 ? '' : 's')
                         : Object.keys(v.labels || {}).length + ' rótulos';
+
+                    // Descartar só aparece quando existe rascunho não enviado e
+                    // ele é seu: proposta em revisão se resolve pela fila.
+                    var descarte = (d && d.status === 'draft' && !travadoPorOutro(d))
+                        ? '<button class="btn btn-danger btn-sm" onclick="descartarRascunho(\'' +
+                          d.draftId + '\', loadEmails)">Descartar rascunho</button>'
+                        : '';
 
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
@@ -772,10 +878,10 @@
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'email_template\')">Histórico</button>';
 
                     var actions = canPropose('email_template')
-                        ? '<div style="display:flex;gap:8px">' + historico +
+                        ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openEmailEditor(\'' + it.id + '\')">Editar</button>' +
                         '</div>'
-                        : '<div style="display:flex;gap:8px">' + historico + '</div>';
+                        : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
                     html += '<div class="item-row">' +
                         '<div class="item-main">' +
@@ -833,7 +939,8 @@
                 'padding:16px;margin-top:8px;background:#fff;color:#202124;max-height:280px;overflow:auto"></div>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
-                '<button class="btn btn-primary" id="em-save">Salvar e enviar para revisão</button>' +
+                '<button class="btn btn-ghost" id="em-draft">Salvar rascunho</button>' +
+                '<button class="btn btn-primary" id="em-save">Enviar para revisão</button>' +
                 '</div></div></div>';
 
             refreshEmailPreview();
@@ -841,6 +948,9 @@
 
             document.getElementById('em-save').onclick = function () {
                 submitEmail(item, existingDraft ? existingDraft.draftId : null, v, this);
+            };
+            document.getElementById('em-draft').onclick = function () {
+                submitEmail(item, existingDraft ? existingDraft.draftId : null, v, this, true);
             };
         }
 
@@ -854,7 +964,7 @@
             host.innerHTML = body.value;
         }
 
-        function submitEmail(item, draftId, original, btn) {
+        function submitEmail(item, draftId, original, btn, apenasRascunho) {
             var subject = document.getElementById('em-subject').value.trim();
             var template = document.getElementById('em-body').value.trim();
 
@@ -869,7 +979,7 @@
                 ? JSON.stringify({ subject: subject, template: template, labels: original.labels || {} })
                 : JSON.stringify({ subject: subject, template: template, placeholders: original.placeholders || [] });
 
-            enviarProposta({
+            (apenasRascunho ? salvarRascunho : enviarProposta)({
                 draftId: draftId || '',
                 itemId: item.id,
                 module: 'email_template',
@@ -929,10 +1039,11 @@
 
             host.innerHTML = avisoRascunhosOffline('tips') + TP_ITEMS.map(function (it) {
                 var d = tpDraftForItem(it.id);
-                var badge = d
-                    ? (d.status === 'pending'
-                        ? '<span class="pill pending">em revisão</span>'
-                        : '<span class="pill draft">rascunho</span>')
+                var badge = selosDoRascunho(d);
+
+                var descarte = (d && d.status === 'draft' && !travadoPorOutro(d))
+                    ? '<button class="btn btn-danger btn-sm" onclick="descartarRascunho(\'' +
+                      d.draftId + '\', loadTips)">Descartar rascunho</button>'
                     : '';
 
                 // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
@@ -941,11 +1052,11 @@
                     + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'tips\')">Histórico</button>';
 
                 var actions = canPropose('tips')
-                    ? '<div style="display:flex;gap:8px">' + historico +
+                    ? '<div style="display:flex;gap:8px">' + historico + descarte +
                     '<button class="btn btn-ghost btn-sm" onclick="openTipEditor(\'' + it.id + '\')">Editar</button>' +
                     '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
                     '</div>'
-                    : '<div style="display:flex;gap:8px">' + historico + '</div>';
+                    : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
                 return '<div class="item-row">' +
                     '<div class="item-main">' +
@@ -976,16 +1087,20 @@
                 '<textarea id="tp-text" style="min-height:70px">' + esc(src ? src.value : '') + '</textarea>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
-                '<button class="btn btn-primary" id="tp-save">Salvar e enviar para revisão</button>' +
+                '<button class="btn btn-ghost" id="tp-draft">Salvar rascunho</button>' +
+                '<button class="btn btn-primary" id="tp-save">Enviar para revisão</button>' +
                 '</div></div></div>';
 
             document.getElementById('tp-save').onclick = function () {
                 submitTip(itemId, existingDraft ? existingDraft.draftId : null, src, this);
             };
+            document.getElementById('tp-draft').onclick = function () {
+                submitTip(itemId, existingDraft ? existingDraft.draftId : null, src, this, true);
+            };
             document.getElementById('tp-text').focus();
         }
 
-        function submitTip(itemId, draftId, src, btn) {
+        function submitTip(itemId, draftId, src, btn, apenasRascunho) {
             var text = document.getElementById('tp-text').value.trim();
             if (!text) return toast('Escreva o texto da dica.', true);
 
@@ -993,7 +1108,7 @@
                 return Math.max(max, i.sortOrder);
             }, 0) + 1;
 
-            enviarProposta({
+            (apenasRascunho ? salvarRascunho : enviarProposta)({
                 draftId: draftId || '',
                 itemId: itemId || '',
                 module: 'tips',

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -607,6 +607,12 @@
             background: var(--success);
         }
 
+        /* Âmbar para "ainda não está no ar": rascunho, em revisão, alguém
+           editando. Verde continua sendo só o que o agente já vê. */
+        .estado.estado-espera::before {
+            background: var(--warning);
+        }
+
         /* --- Diff --- */
         .diff {
             display: grid;

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -130,7 +130,7 @@ const HISTORICO = {
 };
 
 // ------------------------------------------------------- montagem da página
-async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } = {}) {
+async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null } = {}) {
     const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
     page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
 
@@ -140,7 +140,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
 
     // O dublê precisa existir ANTES do script da página rodar: o boot dispara
     // no DOMContentLoaded.
-    await page.addInitScript(({ sessao, itens, falhar, historico }) => {
+    await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos }) => {
         const HISTORICO = historico;
         window.__chamadas = [];
 
@@ -149,11 +149,13 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
             listContentItems: (m) => itens[m] || [],
             listContentDrafts: (m) => {
                 if (falhar && m === falhar) throw new Error('rede caiu');
-                return [];
+                return (rascunhos && rascunhos[m]) || [];
             },
             listPendingApprovals: () => [],
             listContentItemHistory: (lineage) => (HISTORICO[lineage] || []),
             rollbackContentItem: () => ({ status: 'success', itemId: 'itm_revivido' }),
+            saveContentDraft: () => ({ status: 'success', draftId: 'drf_rascunho' }),
+            discardContentDraft: () => ({ status: 'success' }),
             listContentAccess: () => [{ ldap: 'lucaste', role: 'ADMIN', active: true, grantedBy: 'system' }],
             listPeople: () => [],
             getNoteFieldCatalog: () => ({ fields: {}, substatus: [] }),
@@ -202,7 +204,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '' } =
             value: { script: { get run() { return construir(); } } },
             writable: true,
         });
-    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe, historico: HISTORICO });
+    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe, historico: HISTORICO, rascunhos: draftsDe });
 
     await page.goto('file://' + ARQUIVO + hash, { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(300);
@@ -581,6 +583,148 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
             'botões de reverter');
         verdade(/não republica/.test(await page.locator('#hist-corpo').textContent()),
             'a tela precisa dizer por que não há o botão');
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------- rascunho de verdade
+{
+    const page = await abrir({ sessao: 'admin' });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(200);
+
+    await check('o editor oferece guardar E enviar, não só enviar', async () => {
+        await page.evaluate(() => openLinkEditor(null));
+        await page.waitForTimeout(200);
+        verdade(await page.locator('#lnk-draft').isVisible(), 'faltou "Salvar rascunho"');
+        verdade(await page.locator('#lnk-save').isVisible(), 'faltou "Enviar para revisão"');
+        igual((await page.locator('#lnk-save').textContent()).trim(), 'Enviar para revisão',
+            'rótulo do botão de enviar');
+    });
+
+    await check('guardar rascunho NÃO manda para a fila', async () => {
+        await page.fill('#lnk-name', 'Link guardado');
+        await page.fill('#lnk-url', 'https://go/guardado');
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.click('#lnk-draft');
+        await page.waitForTimeout(300);
+
+        // Lista explícita de ESCRITAS: filtrar por padrão pegaria também a
+        // releitura de rascunhos, que é leitura. Mesmo tropeço de antes.
+        const ESCRITAS = ['saveContentDraft', 'submitContentDraft', 'saveAndSubmitContentDraft'];
+        const escritas = await page.evaluate((nomes) => window.__chamadas
+            .filter(c => nomes.includes(c.metodo)).map(c => c.metodo), ESCRITAS);
+        igual(escritas, ['saveContentDraft'], 'chamadas de escrita');
+    });
+
+    await check('a validação vale para os dois caminhos', async () => {
+        // Guardar um rascunho inválido seria guardar algo que o servidor
+        // recusaria na hora de enviar.
+        await page.evaluate(() => openLinkEditor(null));
+        await page.waitForTimeout(200);
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.click('#lnk-draft');
+        await page.waitForTimeout(200);
+
+        const escreveu = await page.evaluate(() => window.__chamadas
+            .some(c => ['saveContentDraft', 'saveAndSubmitContentDraft'].includes(c.metodo)));
+        igual(escreveu, false, 'guardou sem nome nem URL');
+        await page.evaluate(() => closeModal());
+    });
+
+    await page.close();
+}
+
+{
+    // Um rascunho meu, não enviado.
+    const meu = {
+        links: [{
+            draftId: 'drf_meu', itemId: 'itm_1', module: 'links', key: 'tasks', lang: 'ALL',
+            label: 'Fila de tarefas', value: '{}', status: 'draft',
+            proposedBy: 'lucaste', lockedBy: 'lucaste', lockedAt: new Date().toISOString(),
+        }],
+    };
+    const page = await abrir({ sessao: 'admin', draftsDe: meu });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(300);
+
+    await check('o item diz que existe um rascunho seu', async () => {
+        const texto = await page.locator('#links-list').textContent();
+        verdade(/rascunho seu/.test(texto), 'a linha precisa dizer que há rascunho seu');
+    });
+
+    await check('e oferece descartá-lo', async () => {
+        verdade(await page.locator('button:has-text("Descartar rascunho")').isVisible(),
+            'faltou o botão de descartar');
+    });
+
+    await check('descartar pede confirmação antes', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.click('button:has-text("Descartar rascunho")');
+        await page.waitForTimeout(200);
+
+        const descartou = await page.evaluate(() => window.__chamadas
+            .some(c => c.metodo === 'discardContentDraft'));
+        igual(descartou, false, 'descartou sem confirmar');
+        verdade(await page.locator('#desc-titulo').isVisible(), 'faltou a confirmação');
+
+        await page.click('#desc-go');
+        await page.waitForTimeout(300);
+        const chamadas = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'discardContentDraft'));
+        igual(chamadas.length, 1, 'chamadas de descarte');
+        igual(chamadas[0].args[0], 'drf_meu', 'descartou o rascunho certo');
+    });
+
+    await page.close();
+}
+
+{
+    // Rascunho de OUTRA pessoa, com a trava ainda viva.
+    const alheio = {
+        links: [{
+            draftId: 'drf_ana', itemId: 'itm_1', module: 'links', key: 'tasks', lang: 'ALL',
+            label: 'Fila de tarefas', value: '{}', status: 'draft',
+            proposedBy: 'anaflor', lockedBy: 'anaflor', lockedAt: new Date().toISOString(),
+        }],
+    };
+    const page = await abrir({ sessao: 'admin', draftsDe: alheio });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(300);
+
+    await check('a tela diz QUEM está editando agora', async () => {
+        const texto = await page.locator('#links-list').textContent();
+        verdade(/anaflor está editando/.test(texto),
+            'a trava precisa dizer de quem é, não só que existe');
+    });
+
+    await check('e não oferece descartar o rascunho de outra pessoa', async () => {
+        igual(await page.locator('button:has-text("Descartar rascunho")').count(), 0,
+            'botões de descarte');
+    });
+
+    await page.close();
+}
+
+{
+    // A mesma trava, expirada: o servidor já não a respeita, e a tela não pode
+    // anunciar uma trava que não existe mais.
+    const velho = {
+        links: [{
+            draftId: 'drf_ana', itemId: 'itm_1', module: 'links', key: 'tasks', lang: 'ALL',
+            label: 'Fila de tarefas', value: '{}', status: 'draft',
+            proposedBy: 'anaflor', lockedBy: 'anaflor',
+            lockedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        }],
+    };
+    const page = await abrir({ sessao: 'admin', draftsDe: velho });
+    await page.evaluate(() => switchTab('links'));
+    await page.waitForTimeout(300);
+
+    await check('trava expirada não é anunciada', async () => {
+        const texto = await page.locator('#links-list').textContent();
+        igual(/está editando/.test(texto), false, 'anunciou trava vencida');
     });
 
     await page.close();

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -55,6 +55,9 @@ class FakeSheet {
   getDataRange() { return new FakeRange(this, 1, 1); }
   getRange(row, col, numRows, numCols) { return new FakeRange(this, row, col, numRows, numCols); }
   getLastRow() { return this._data.length; }
+  // Os outros dublês do projeto já modelavam isto; este ficou para trás até
+  // discardContentDraft() precisar remover uma linha de verdade.
+  deleteRow(i) { this._data.splice(i - 1, 1); }
   setFrozenRows() { return this; }
 }
 
@@ -1208,6 +1211,73 @@ check('seedBroadcastNow() migra a aba numa planilha zerada, sem argumentos', () 
   const legado = freshCtx.getBroadcastForLegacyEndpoint(freshSS);
   eq(legado.map(m => m.id), ['msg_2', 'msg_1'], 'mais novo primeiro:');
   eq(legado[0].active, true);
+});
+
+console.log('\n--- Rascunho de verdade ---');
+
+check('salvar sem enviar deixa o rascunho fora da fila', () => {
+  const d = api.saveContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Dica em rascunho',
+    value: 'Ainda pensando na frase.'
+  });
+
+  const meus = api.listContentDrafts('tips').filter(x => x.draftId === d.draftId);
+  eq(meus.length, 1, 'o rascunho existe:');
+  eq(meus[0].status, 'draft');
+
+  // O que separa rascunho de proposta: um não chega a quem revisa.
+  eq(api.listPendingApprovals().filter(x => x.draftId === d.draftId).length, 0,
+    'não apareceu na fila de revisão:');
+});
+
+check('descartar um rascunho o remove de vez', () => {
+  const d = api.saveContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Dica descartável',
+    value: 'Melhor não.'
+  });
+  eq(api.discardContentDraft(d.draftId).status, 'success');
+  eq(api.listContentDrafts('tips').filter(x => x.draftId === d.draftId).length, 0,
+    'sumiu da lista:');
+});
+
+check('proposta JÁ enviada não some por descarte', () => {
+  // Quem ia revisar não pode ver o item desaparecer por baixo. Uma proposta em
+  // revisão se resolve aprovando ou rejeitando.
+  const d = api.saveAndSubmitContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Dica enviada',
+    value: 'Já foi para a fila.'
+  });
+  throws(() => api.discardContentDraft(d.draftId), /Só um rascunho pode ser descartado/);
+  eq(api.listPendingApprovals().filter(x => x.draftId === d.draftId).length, 1,
+    'continua na fila:');
+});
+
+check('o rascunho é de quem escreveu', () => {
+  api.saveContentAccess('qa_rascunho', 'QA', true);
+  const d = as('qa_rascunho', () => api.saveContentDraft({
+    module: 'call_script', key: 'BAU', field: 'inicio', lang: 'PT',
+    label: 'Passo do QA', value: 'Rascunho alheio.'
+  }));
+
+  api.saveContentAccess('qa_outro', 'QA', true);
+  throws(() => as('qa_outro', () => api.discardContentDraft(d.draftId)),
+    /de outra pessoa/, 'outro QA descartando:');
+
+  // Quem aprova pode: é quem destrava a fila quando alguém sai de férias.
+  eq(api.discardContentDraft(d.draftId).status, 'success');
+});
+
+check('salvar registra quem está editando, para a tela poder avisar', () => {
+  const d = as('qa_rascunho', () => api.saveContentDraft({
+    module: 'call_script', key: 'BAU', field: 'inicio', lang: 'PT',
+    label: 'Passo travado', value: 'Editando agora.'
+  }));
+
+  const meu = api.listContentDrafts('call_script').filter(x => x.draftId === d.draftId)[0];
+  eq(meu.lockedBy, 'qa_rascunho', 'a trava diz quem:');
+  eq(!!meu.lockedAt, true, 'e desde quando:');
+
+  api.discardContentDraft(d.draftId);
 });
 
 console.log('\n--- Trava de escrita (concorrência) ---');


### PR DESCRIPTION
## O que muda

Segunda entrega da fase 3. Os cinco editores de catálogo passam a ter **dois caminhos** — "Salvar rascunho" e "Enviar para revisão" — e a linha do item passa a dizer o que existe: rascunho seu, alguém editando (com o nome), ou já em revisão.

## Por que assim

O estado `draft` existia no modelo de dados desde o começo e era **inalcançável na prática**: todo editor tinha um botão só, que salvava e submetia no mesmo gesto. Três consequências:

- não havia como guardar trabalho parcial — fechar o editor descartava tudo, o que é caro num modelo de nota com seis campos ou num corpo de e-mail;
- a pílula "rascunho" que as listas já sabiam desenhar **nunca aparecia**;
- a trava de edição cooperativa (`Locked_By`, 10 min) nunca chegava a valer, porque nada ficava aberto tempo suficiente para outra pessoa esbarrar.

**A trava só é anunciada dentro da janela que o servidor respeita.** Uma trava vencida não aparece — senão a tela alegaria um bloqueio que já não existe, e a pessoa esperaria por nada.

**`discardContentDraft()` é novo no backend**, e existe porque rascunho sem saída vira armadilha: ficaria na lista, contaria na home de quem o criou e reabriria o texto abandonado na edição seguinte. Duas regras: só rascunho — uma proposta já enviada se resolve aprovando ou rejeitando, não sumindo por baixo de quem ia revisar — e só de quem escreveu, ou de quem aprova (que é quem destrava a fila quando alguém sai de férias).

A validação de campo roda nos **dois** caminhos: guardar um rascunho inválido seria guardar algo que o servidor recusaria na hora de enviar.

## Dois erros meus no caminho, para o registro

O smoke pegou os dois antes do PR, e valem a menção porque são exatamente a classe que virou entrada no `LEARNINGS`:

1. O substituidor que gerou os botões interpolou o **objeto função** (`' + loadLinks + '`) em vez do nome dentro da string — despejando o código-fonte inteiro no atributo `onclick`.
2. Filtrei as chamadas de escrita por padrão (`/Draft/`), que também casa `listContentDrafts` — leitura, não escrita. Mesmo tropeço de dois PRs atrás; a correção foi voltar à lista explícita.

## Como verificar

```
npm run test:content     # 102 (eram 97)
npm run smoke:content    # 41 verificações (eram 31)
```

No backend, cinco testes novos:

```
✓ salvar sem enviar deixa o rascunho fora da fila
✓ descartar um rascunho o remove de vez
✓ proposta JÁ enviada não some por descarte
✓ o rascunho é de quem escreveu
✓ salvar registra quem está editando, para a tela poder avisar
```

Na tela, dez novas — com destaque para as duas da trava, que provam os dois lados: **"a tela diz QUEM está editando agora"** e **"trava expirada não é anunciada"**. Um teste que só verificasse o caso vivo passaria com uma tela que anuncia trava vencida para sempre.

Todas as 8 suítes `test:`, o `build` e os smokes de people, broadcast, wizards e env-badge verdes. `smoke:shortcuts` segue com as mesmas 2 falhas anteriores a esta linha de trabalho.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [ ] Testado com o bookmarklet de **dev** contra o CRM real — ver abaixo

## O que ainda precisa de você

A trava é a única parte que **não dá para provar sozinho**: ela depende de duas pessoas com a mesma tela aberta. Vale, em dev, salvar um rascunho num item e abrir a Central noutro navegador com outro LDAP para ver o "fulano está editando" — e conferir que ele some sozinho depois de dez minutos, sem ninguém fazer nada.

## Checklist

- [x] Se mexi em `gas-backend/`: uma função nova (`discardContentDraft`), sem rota JSONP — é `google.script.run`, como todo o resto da escrita da Central. `specs/data-models/api-payloads.md` segue válido.
- [x] Se mexi numa regra de negócio: a regra de quem pode descartar é nova e está no servidor, com teste. A tela só deixa de oferecer o que ia falhar.
- [x] Se é uma decisão que alguém vai questionar depois: por que uma proposta enviada não pode ser descartada está no comentário da função e no teste que a trava.
- [x] Se muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Se bumpei versão: não bumpei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_