### PR TITLE
feat(central): a revisão passa a mostrar o que mudou

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **A revisão passou a mostrar o que mudou** (fase 3). Eram dois blocos de texto
+  integral lado a lado, sem realce: num corpo de e-mail de quarenta linhas,
+  achar a vírgula alterada era trabalho manual. Agora um diff por palavra marca
+  só a diferença nos dois lados, e o valor é lido como conteúdo — assunto e
+  corpo do e-mail, tipo/título/texto do aviso, um campo por linha no modelo de
+  nota — em vez do JSON cru que escondia a mudança real no meio de aspas e
+  chaves. Quem aprova também ganhou a **prévia renderizada** do e-mail, que
+  antes só existia para quem editava.
+
+### Security
+- **A prévia de e-mail passou a rodar em `iframe` fechado** (`sandbox=""`). Um
+  modelo é HTML escrito por uma pessoa e lido por outra, numa tela que fala com
+  o backend na autoridade de quem revisa — injetá-lo direto no documento seria
+  XSS armazenado entre usuários, a classe que `docs/LEARNINGS.md` registrou no
+  Ctrl+K. A prévia do editor foi para o mesmo caminho: dois jeitos de renderizar
+  a mesma coisa é como um deles fica para trás.
 - **Rascunho virou um estado alcançável na Central** (fase 3). Todo editor tinha
   um botão só, que salvava e enviava para revisão no mesmo gesto: não havia como
   guardar trabalho parcial, a pílula "rascunho" que as listas sabiam desenhar

--- a/PLAN.md
+++ b/PLAN.md
@@ -50,7 +50,8 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       versão na Central e no TL Dash, a partir de fonte única no repo.
 - [~] **Fase 3 — ciclo de vida do item** — em andamento. **Entregue:** histórico
       e "voltar para esta versão"; rascunho de verdade, separado do envio, com
-      a trava de edição visível e caminho para descartar — `listContentItemHistory` e `rollbackContentItem` existem no
+      a trava de edição visível e caminho para descartar; diff por palavra e prévia
+      renderizada na revisão — `listContentItemHistory` e `rollbackContentItem` existem no
       backend e nunca foram chamados, enquanto o modal de remoção promete que a
       versão "pode voltar"; rascunho de verdade, separado do envio; trava de
       edição visível; diff por palavra e prévia renderizada na revisão.

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -961,7 +961,10 @@
             var body = document.getElementById('em-body');
             var host = document.getElementById('em-preview');
             if (!body || !host) return;
-            host.innerHTML = body.value;
+            // Mesmo isolamento da prévia da fila: aqui o texto é seu, então o
+            // risco é menor, mas manter dois caminhos diferentes para renderizar
+            // a mesma coisa é como um deles fica para trás.
+            host.innerHTML = previaIsolada(body.value, 200);
         }
 
         function submitEmail(item, draftId, original, btn, apenasRascunho) {

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -326,6 +326,22 @@
             );
         }
 
+        // Renderiza HTML de conteúdo dentro de um iframe fechado.
+        //
+        // Um modelo de e-mail é HTML escrito por uma pessoa e lido por OUTRA —
+        // e a tela de quem lê roda google.script.run com a autoridade dela.
+        // Injetar esse HTML direto no documento é XSS armazenado entre usuários,
+        // exatamente a classe que docs/LEARNINGS.md registrou no Ctrl+K.
+        //
+        // O sandbox vazio nega tudo: nada de script, nada de mesma origem, nada
+        // de navegação. O que sobra é o que a prévia precisa — ver o texto e a
+        // formatação como o anunciante vai receber.
+        function previaIsolada(html, altura) {
+            return '<iframe class="previa-frame" sandbox="" ' +
+                'style="height:' + (altura || 220) + 'px" ' +
+                'title="Prévia do e-mail" srcdoc="' + esc(String(html || '')) + '"></iframe>';
+        }
+
         // --- Hoje ---
         //
         // Responde "o que está acontecendo no conteúdo agora", que é a pergunta

--- a/gas-backend/ContentDashboard_Governance.html
+++ b/gas-backend/ContentDashboard_Governance.html
@@ -22,6 +22,94 @@
                 .listPendingApprovals();
         }
 
+        // --- Diff por palavra ---
+        //
+        // A revisão mostrava dois blocos de texto integral lado a lado, sem
+        // realce nenhum. Num corpo de e-mail de quarenta linhas, achar a vírgula
+        // que mudou era trabalho manual — e a fila de aprovação existe
+        // justamente para evitar o "confie no texto novo".
+        //
+        // LCS clássico sobre PALAVRAS, não caracteres: a unidade que quem revisa
+        // lê é a palavra, e o diff por caractere transforma uma troca de acento
+        // num confete ilegível. Vanilla puro, sem biblioteca — o rulebook do
+        // projeto proíbe dependência de front sem autorização, e são 30 linhas.
+        function separarEmPalavras(texto) {
+            // Mantém os separadores como pedaços próprios: assim uma quebra de
+            // linha que mudou aparece como mudança, e o texto remonta idêntico.
+            return String(texto == null ? '' : texto).split(/(\s+)/).filter(function (p) { return p !== ''; });
+        }
+
+        function diffDePalavras(antes, depois) {
+            var a = separarEmPalavras(antes);
+            var b = separarEmPalavras(depois);
+
+            // Texto muito grande não ganha diff: a matriz do LCS é O(n*m), e
+            // travar a fila de revisão é pior que mostrar os dois lados inteiros.
+            if (a.length * b.length > 400000) return null;
+
+            var m = a.length, n = b.length;
+            var tabela = [];
+            for (var i = 0; i <= m; i++) tabela.push(new Array(n + 1).fill(0));
+
+            for (var i = m - 1; i >= 0; i--) {
+                for (var j = n - 1; j >= 0; j--) {
+                    tabela[i][j] = (a[i] === b[j])
+                        ? tabela[i + 1][j + 1] + 1
+                        : Math.max(tabela[i + 1][j], tabela[i][j + 1]);
+                }
+            }
+
+            var pedacos = [];
+            var x = 0, y = 0;
+            function empurrar(tipo, texto) {
+                var ultimo = pedacos[pedacos.length - 1];
+                if (ultimo && ultimo.tipo === tipo) ultimo.texto += texto;
+                else pedacos.push({ tipo: tipo, texto: texto });
+            }
+
+            while (x < m && y < n) {
+                if (a[x] === b[y]) { empurrar('igual', a[x]); x++; y++; }
+                else if (tabela[x + 1][y] >= tabela[x][y + 1]) { empurrar('saiu', a[x]); x++; }
+                else { empurrar('entrou', b[y]); y++; }
+            }
+            while (x < m) { empurrar('saiu', a[x]); x++; }
+            while (y < n) { empurrar('entrou', b[y]); y++; }
+
+            return pedacos;
+        }
+
+        // Um lado do diff. `lado` escolhe o que este painel mostra: o texto de
+        // antes (o que saiu, marcado) ou o de depois (o que entrou).
+        function pintarLado(pedacos, lado) {
+            return pedacos.map(function (p) {
+                if (p.tipo === 'igual') return esc(p.texto);
+                if (lado === 'antes' && p.tipo === 'saiu') {
+                    return '<mark class="dif-saiu">' + esc(p.texto) + '</mark>';
+                }
+                if (lado === 'depois' && p.tipo === 'entrou') {
+                    return '<mark class="dif-entrou">' + esc(p.texto) + '</mark>';
+                }
+                return '';
+            }).join('');
+        }
+
+        // Modelos de e-mail são HTML. Quem edita já tinha prévia; quem APROVA,
+        // que é justamente quem precisa ver o que o anunciante vai receber,
+        // revisava o código-fonte em fonte monoespaçada.
+        function previaDeEmail(raw) {
+            try {
+                var v = JSON.parse(raw);
+                if (!v || !v.template) return '';
+                return '<details class="previa"><summary>Ver como o anunciante recebe</summary>' +
+                    '<div class="previa-corpo">' +
+                    '<div class="previa-assunto">' + esc(v.subject || '(sem assunto)') + '</div>' +
+                    previaIsolada(v.template) +
+                    '</div></details>';
+            } catch (e) {
+                return '';
+            }
+        }
+
         function loadApprovals() {
             var host = document.getElementById('approvals-list');
 
@@ -47,6 +135,25 @@
                     host.innerHTML = list.map(function (d) {
                         var cur = d.currentValue ? prettyValue(d.currentValue) : '(item novo)';
                         var neu = d.value ? prettyValue(d.value) : '(remoção — item sai do ar)';
+
+                        // Item novo e remoção não têm o que comparar: não existe
+                        // "antes" num, nem "depois" no outro. Nesses dois casos o
+                        // texto integral é a informação, e o diff só atrapalharia.
+                        var pedacos = (d.currentValue && d.value) ? diffDePalavras(cur, neu) : null;
+                        var ladoAntes = pedacos ? pintarLado(pedacos, 'antes') : esc(cur);
+                        var ladoDepois = pedacos ? pintarLado(pedacos, 'depois') : esc(neu);
+
+                        var mudou = pedacos && pedacos.some(function (p) { return p.tipo !== 'igual'; });
+                        var legenda = pedacos
+                            ? (mudou
+                                ? '<div class="dif-legenda">Só o que mudou está marcado.</div>'
+                                : '<div class="dif-legenda">O texto é idêntico ao que está no ar.</div>')
+                            : '';
+
+                        // A prévia é para quem APROVA: quem edita já tinha a dele,
+                        // e é o revisor que precisa ver o que o anunciante recebe.
+                        var previa = (d.module === 'email_template' && d.value)
+                            ? previaDeEmail(d.value) : '';
                         var selfNote = d.isSelfProposed
                             ? (d.canReview
                                 ? '<div class="note warn">Proposta sua. Como ADMIN, você pode aprovar mesmo assim — fica registrado como autoaprovação.</div>'
@@ -58,14 +165,14 @@
                             '<div><div class="card-title">' + esc(d.label) + '</div>' +
                             '<p class="card-sub">' + esc(d.module) + ' · ' + esc(d.key) +
                             ' · proposto por <strong>' + esc(d.proposedBy) + '</strong></p></div>' +
-                            '<span class="pill pending">pendente</span>' +
-                            '</div>' + selfNote +
+                            '<span class="estado estado-espera">pendente</span>' +
+                            '</div>' + selfNote + legenda +
                             '<div class="diff">' +
                             '<div class="diff-side"><div class="diff-label">Hoje no ar</div>' +
-                            '<div class="diff-body">' + esc(cur) + '</div></div>' +
+                            '<div class="diff-body">' + ladoAntes + '</div></div>' +
                             '<div class="diff-side new"><div class="diff-label">Proposto</div>' +
-                            '<div class="diff-body">' + esc(neu) + '</div></div>' +
-                            '</div>' +
+                            '<div class="diff-body">' + ladoDepois + '</div></div>' +
+                            '</div>' + previa +
                             '<div class="modal-actions" style="margin-top:8px">' +
                             '<button class="btn btn-danger btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',false)">Rejeitar</button>' +
                             '<button class="btn btn-success btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',true)"' +
@@ -100,6 +207,24 @@
                     return 'Nome: ' + v.name + '\nURL: ' + v.url +
                         '\nDescrição (PT): ' + (v.desc || '—') +
                         '\nDescrição (ES): ' + (v.desc_es || '—');
+                }
+                // Modelo de e-mail: o revisor compara ASSUNTO e CORPO, não um
+                // objeto JSON. Sem isto o diff marcava aspas e chaves como se
+                // fossem conteúdo, e a mudança real sumia no meio.
+                if (v && typeof v.template === 'string') {
+                    return 'Assunto: ' + (v.subject || '—') + '\n\n' + v.template;
+                }
+                // Aviso: tipo, título e texto — a mesma leitura que o agente faz.
+                if (v && v.text && v.type) {
+                    return 'Tipo: ' + v.type + '\nTítulo: ' + (v.title || '—') + '\n\n' + v.text;
+                }
+                // Modelo de nota: um campo por linha, na ordem em que a nota os
+                // usa. O objeto cru esconde justamente qual campo mudou.
+                if (v && v.fields && typeof v.fields === 'object') {
+                    var campos = Object.keys(v.fields).map(function (k) {
+                        return k.replace(/^field-/, '') + ': ' + v.fields[k];
+                    });
+                    return campos.length ? campos.join('\n') : raw;
                 }
                 return raw;
             } catch (e) {

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -660,6 +660,63 @@
             font-family: 'Roboto Mono', ui-monospace, monospace;
         }
 
+        /* --- Diff por palavra ---
+           Fundo, e não cor de texto: o que mudou tem que saltar numa varredura
+           rápida, e texto colorido some no meio do parágrafo. Os dois lados
+           usam a mesma paleta semântica do resto da tela. */
+        mark.dif-saiu {
+            background: var(--danger-light);
+            color: var(--danger);
+            text-decoration: line-through;
+            border-radius: 3px;
+        }
+
+        mark.dif-entrou {
+            background: var(--success-light);
+            color: var(--success);
+            border-radius: 3px;
+        }
+
+        .dif-legenda {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-bottom: 8px;
+        }
+
+        /* --- Prévia --- */
+        .previa {
+            margin-top: 14px;
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            padding: 10px 14px;
+            background: var(--surface-level-2);
+        }
+
+        .previa summary {
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--gemini-blue);
+        }
+
+        .previa-corpo {
+            margin-top: 12px;
+        }
+
+        .previa-assunto {
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 8px;
+            color: var(--text-primary);
+        }
+
+        .previa-frame {
+            width: 100%;
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            background: #fff;
+        }
+
         /* --- Item list --- */
         .item-row {
             display: flex;

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -130,7 +130,7 @@ const HISTORICO = {
 };
 
 // ------------------------------------------------------- montagem da página
-async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null } = {}) {
+async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null, fila = [] } = {}) {
     const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
     page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
 
@@ -140,7 +140,8 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
 
     // O dublê precisa existir ANTES do script da página rodar: o boot dispara
     // no DOMContentLoaded.
-    await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos }) => {
+    await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos, pendentes }) => {
+        const PENDENTES = pendentes || [];
         const HISTORICO = historico;
         window.__chamadas = [];
 
@@ -151,7 +152,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
                 if (falhar && m === falhar) throw new Error('rede caiu');
                 return (rascunhos && rascunhos[m]) || [];
             },
-            listPendingApprovals: () => [],
+            listPendingApprovals: () => PENDENTES,
             listContentItemHistory: (lineage) => (HISTORICO[lineage] || []),
             rollbackContentItem: () => ({ status: 'success', itemId: 'itm_revivido' }),
             saveContentDraft: () => ({ status: 'success', draftId: 'drf_rascunho' }),
@@ -204,7 +205,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             value: { script: { get run() { return construir(); } } },
             writable: true,
         });
-    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe, historico: HISTORICO, rascunhos: draftsDe });
+    }, { sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe, historico: HISTORICO, rascunhos: draftsDe, pendentes: fila });
 
     await page.goto('file://' + ARQUIVO + hash, { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(300);
@@ -725,6 +726,117 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
     await check('trava expirada não é anunciada', async () => {
         const texto = await page.locator('#links-list').textContent();
         igual(/está editando/.test(texto), false, 'anunciou trava vencida');
+    });
+
+    await page.close();
+}
+
+// --------------------------------------------------- revisão: diff e prévia
+{
+    // O algoritmo é lógica pura: vale prová-lo direto, sem passar pela tela.
+    const page = await abrir({ sessao: 'admin' });
+
+    await check('o diff marca só o que mudou', async () => {
+        const r = await page.evaluate(() => {
+            const p = diffDePalavras('o gato subiu no telhado', 'o gato desceu no telhado');
+            return p.map(x => [x.tipo, x.texto.trim()]).filter(x => x[1]);
+        });
+        igual(r, [['igual', 'o gato'], ['saiu', 'subiu'], ['entrou', 'desceu'], ['igual', 'no telhado']],
+            'pedaços do diff');
+    });
+
+    await check('texto idêntico não produz marcação nenhuma', async () => {
+        const tipos = await page.evaluate(() => {
+            const p = diffDePalavras('mesma frase exata', 'mesma frase exata');
+            return Array.from(new Set(p.map(x => x.tipo)));
+        });
+        igual(tipos, ['igual'], 'tipos encontrados');
+    });
+
+    await check('o diff remonta o texto dos dois lados sem perder nada', async () => {
+        // A garantia que impede o realce de comer conteúdo: juntando os pedaços
+        // de cada lado, tem que sair exatamente o texto original.
+        const r = await page.evaluate(() => {
+            const a = 'linha um\nlinha dois\nlinha três';
+            const b = 'linha um\nlinha DOIS\nlinha três';
+            const p = diffDePalavras(a, b);
+            const antes = p.filter(x => x.tipo !== 'entrou').map(x => x.texto).join('');
+            const depois = p.filter(x => x.tipo !== 'saiu').map(x => x.texto).join('');
+            return { okAntes: antes === a, okDepois: depois === b };
+        });
+        igual(r, { okAntes: true, okDepois: true }, 'remontagem');
+    });
+
+    await check('texto gigante degrada para os dois lados inteiros, sem travar', async () => {
+        const r = await page.evaluate(() => {
+            const enorme = new Array(1200).fill('palavra').join(' ');
+            return diffDePalavras(enorme, enorme + ' extra');
+        });
+        igual(r, null, 'devolveu diff em vez de recusar');
+    });
+
+    await page.close();
+}
+
+{
+    const fila = [
+        {
+            draftId: 'drf_1', module: 'tips', key: 'geral', label: 'Dica revisada',
+            proposedBy: 'anaflor', isSelfProposed: false, canReview: true,
+            currentValue: 'Confira o substatus antes de fechar.',
+            value: 'Confira o substatus antes de encerrar.',
+        },
+        {
+            draftId: 'drf_2', module: 'email_template', key: 'boas_vindas', label: 'E-mail de boas-vindas',
+            proposedBy: 'brunocs', isSelfProposed: false, canReview: true,
+            currentValue: JSON.stringify({ subject: 'Olá', template: '<p>Antigo</p>' }),
+            value: JSON.stringify({ subject: 'Olá!', template: '<p>Bem-vindo à <b>TechSol</b></p>' }),
+        },
+    ];
+    const page = await abrir({ sessao: 'admin', fila });
+    await page.evaluate(() => switchTab('approvals'));
+    await page.waitForTimeout(400);
+
+    await check('a fila realça a palavra trocada nos dois lados', async () => {
+        const saiu = await page.locator('mark.dif-saiu').first().textContent();
+        const entrou = await page.locator('mark.dif-entrou').first().textContent();
+        igual(saiu.trim(), 'fechar.', 'palavra que saiu');
+        igual(entrou.trim(), 'encerrar.', 'palavra que entrou');
+    });
+
+    await check('e diz que só o que mudou está marcado', async () => {
+        verdade(/Só o que mudou está marcado/.test(await page.locator('#approvals-list').textContent()),
+            'faltou a legenda do diff');
+    });
+
+    await check('quem aprova ganha a prévia do e-mail', async () => {
+        verdade(await page.locator('.previa').first().isVisible(), 'faltou a prévia');
+        verdade(/Ver como o anunciante recebe/.test(await page.locator('.previa').first().textContent()),
+            'rótulo da prévia');
+    });
+
+    await check('a prévia roda isolada, sem script e sem mesma origem', async () => {
+        // É HTML escrito por OUTRA pessoa numa tela que fala com o backend na
+        // autoridade de quem revisa. O sandbox vazio é o que impede isso de ser
+        // XSS armazenado entre usuários.
+        await page.locator('.previa summary').first().click();
+        await page.waitForTimeout(200);
+        const frame = page.locator('iframe.previa-frame').first();
+        igual(await frame.getAttribute('sandbox'), '', 'atributo sandbox');
+        verdade(/TechSol/.test(await frame.getAttribute('srcdoc')), 'o conteúdo chegou ao iframe');
+    });
+
+    await check('o e-mail é comparado como conteúdo, não como JSON', async () => {
+        // Sem isto o diff marcava aspas e chaves, e a mudança real sumia no meio
+        // do objeto serializado.
+        const texto = await page.locator('#approvals-list').textContent();
+        verdade(/Assunto:/.test(texto), 'faltou o assunto legível');
+        igual(/\{"subject"/.test(texto), false, 'o JSON cru vazou para a revisão');
+    });
+
+    await check('a prévia aparece só onde faz sentido', async () => {
+        // Uma dica não é HTML: prévia ali seria enfeite.
+        igual(await page.locator('.previa').count(), 1, 'prévias na fila');
     });
 
     await page.close();


### PR DESCRIPTION
## O que muda

Terceira entrega da fase 3. A fila de aprovação passa a marcar **só o que mudou**, a ler o valor como conteúdo em vez de JSON, e a oferecer a **prévia renderizada** do e-mail para quem aprova.

## Por que assim

A fila mostrava dois blocos de texto integral lado a lado, sem realce nenhum. Num corpo de e-mail de quarenta linhas, achar a vírgula alterada era trabalho manual — e a fila existe justamente para evitar o *"confie no texto novo"*.

**Diff por palavra, não por caractere.** A unidade que quem revisa lê é a palavra; o diff por caractere transforma uma troca de acento num confete ilegível. LCS clássico, Vanilla puro, sem biblioteca — o rulebook proíbe dependência de front sem autorização, e são 30 linhas.

Três cuidados que os testes travam: item novo e remoção **não** ganham diff (não existe "antes" num nem "depois" no outro, e ali o texto integral é a informação); texto acima do teto degrada para os dois lados inteiros em vez de travar a fila com uma matriz O(n·m); e juntar os pedaços de cada lado tem que devolver **exatamente** o texto original — é o que impede o realce de comer conteúdo.

**O valor virou conteúdo.** `prettyValue()` só sabia embelezar link e pessoa, então o e-mail chegava à revisão como `{"subject":"...","template":"<p>..."}` — o diff marcava aspas e chaves e a mudança real sumia no meio. Agora e-mail vira assunto + corpo, aviso vira tipo/título/texto, modelo de nota vira um campo por linha. **Isso só apareceu ao olhar a tela renderizada**, não no código: os testes de estrutura passavam felizes com JSON cru na cara do revisor.

**Prévia para quem aprova.** Quem edita já tinha a dele; quem aprova — que é justamente quem precisa ver o que o anunciante recebe — revisava HTML cru em fonte monoespaçada.

## A parte de segurança

A prévia roda em `<iframe sandbox="">`, e isso não é detalhe de implementação. Um modelo de e-mail é **HTML escrito por uma pessoa e lido por outra**, numa tela que fala com o backend na autoridade de quem revisa. Injetá-lo direto no documento seria XSS armazenado entre usuários — exatamente a classe que `docs/LEARNINGS.md` registrou no Ctrl+K, e que a revisão de UX apontou como risco estrutural desta tela.

O sandbox vazio nega tudo: script, mesma origem, navegação. Sobra o que a prévia precisa. A prévia do editor foi para o mesmo caminho — dois jeitos de renderizar a mesma coisa é como um deles fica para trás.

## Como verificar

```
npm run smoke:content    # 50 verificações (eram 41)
```

Quatro exercitam o algoritmo **direto, sem passar pela tela** — é lógica pura e merece prova própria:

```
✓ o diff marca só o que mudou
✓ texto idêntico não produz marcação nenhuma
✓ o diff remonta o texto dos dois lados sem perder nada
✓ texto gigante degrada para os dois lados inteiros, sem travar
```

E na tela, incluindo as duas que mais importam:

```
✓ a prévia roda isolada, sem script e sem mesma origem
✓ o e-mail é comparado como conteúdo, não como JSON
```

Todas as 8 suítes `test:`, o `build` e os smokes de people, broadcast, wizards e env-badge verdes. `smoke:shortcuts` segue com as mesmas 2 falhas anteriores a esta linha de trabalho.

**Conferido renderizado:** o diff mostra `48` riscado em vermelho de um lado e `24` em verde do outro, com "Assunto:" e o corpo legíveis; a prévia abre e renderiza o HTML dentro do iframe.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente, só a tela de quem revisa

## Checklist

- [x] Se mexi em `gas-backend/`: nenhuma função de servidor nova nem rota tocada — é tudo renderização.
- [x] Se mexi numa regra de negócio: nenhuma. Quem aprova, quando aprova e o que a aprovação faz seguem idênticos.
- [x] Se é uma decisão que alguém vai questionar depois: por que palavra e não caractere, e por que iframe fechado, estão comentados no ponto exato do código.
- [x] Se muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`, com a parte de segurança em `### Security`.
- [x] Se bumpei versão: não bumpei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_