### PR TITLE
feat(central): a matriz de permissões vira tela

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Aba "Papéis" na Central: a matriz de permissões virou tela** (fase 4). Uma
+  linha por módulo, uma coluna por ação, e um traço onde a ação não existe
+  naquele regime — não existe "aprovar um aviso", e um checkbox desligado ali
+  prometeria uma operação que o módulo não tem. O aviso de **publicação sem
+  revisão** aparece enquanto se clica, não só ao salvar, e nomeia os módulos
+  afetados; a confirmação mostra **o que muda**, não o estado final. Editar o
+  próprio papel recarrega a sessão, porque o que a tela tinha em memória deixou
+  de valer. O seletor de papel da aba Acessos passou a ler os papéis do
+  servidor, em vez dos quatro fixos no HTML.
 - **Papéis da Central viraram dado editável** (fase 4, ADR-0009). Eram uma
   constante no código: dar links a um QA, ou criar um papel que publica
   disponibilidade sem tocar no catálogo, custava um deploy. Agora a aba
@@ -122,6 +131,10 @@ versions follow [Semantic Versioning](https://semver.org/).
   a mesma coisa é como um deles fica para trás.
 
 ### Changed
+- **O botão de desativar acesso passou a aparecer também para si mesmo.** A
+  trava deixou de ser "não se remova" e passou a ser "não fique sem ninguém que
+  governe" — quem for o último a governar recebe um erro do servidor que explica
+  exatamente isso, e quem tem um colega admin pode simplesmente sair.
 - **A Central de Conteúdo trocou as dez abas por um trilho agrupado pelo regime
   de publicação** (ADR-0007). Catálogo (passa por revisão), Operação (vai ao ar
   na hora) e Governança: o grupo passa a carregar a informação que antes morava

--- a/PLAN.md
+++ b/PLAN.md
@@ -63,8 +63,7 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
          foto, filtrada **no servidor** pelo papel de quem pergunta.
       **Fora da fase:** o job de arquivamento dos 24 meses (ADR-0008), que
       pertence à rotação do `Backup.js`.
-- [~] **Fase 4 — RBAC editável** (ADR-0009) — **servidor entregue**, tela
-      pendente.
+- [x] **Fase 4 — RBAC editável** (ADR-0009) — completa, em dois PRs.
       **Entregue:** aba `Content_Roles`, matriz módulo × ação, permissões globais
       à parte, papéis atuais como preset (com teste comparando preset contra a
       constante antiga — é a prova de que o dia 1 não muda nada), cache de
@@ -72,11 +71,12 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       as invariantes como teste no servidor. Viraram **quatro**: a de aprovar
       autorização entrou porque "só o ADMIN" deixou de ser uma regra defensável
       quando o nome do papel virou editável — ver a correção de rota no ADR-0009.
-      **Falta:** a aba "Papéis" na tela — a matriz de checkboxes, o diálogo de
-      confirmação mostrando o que MUDA (não o estado final), o aviso de escalação
-      e o recarregamento da sessão ao editar o próprio papel. O `<select>` de
-      papel da aba Acessos também segue com os quatro papéis fixos no HTML e
-      precisa passar a ler `listContentRoles()`.
+      **Entregue também (2º PR):** a aba "Papéis" — matriz de checkboxes com
+      traço onde a ação não existe, aviso de escalação ao vivo, confirmação
+      mostrando o que MUDA, recarregamento da sessão ao editar o próprio papel,
+      e o `<select>` da aba Acessos lendo `listContentRoleNames()`.
+      **Falta validar na planilha real:** que a aba `Content_Roles` nasce
+      semeada e que os quatro papéis continuam se comportando igual.
 - [ ] **Fase 5 — diferenciais e auditoria.** Prévia "como o agente vê"; busca
       global Ctrl+K; agendamento e validade de aviso; "ver como" por papel e
       segmento; cobrança diária de pendência parada — esta lendo `CW_DEPLOYMENTS`

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -2119,6 +2119,18 @@ function contentActionsByModule_() {
   return mapa;
 }
 
+/**
+ * Só os nomes, para o seletor de papel da aba Acessos.
+ *
+ * Existe separado de `listContentRoles()` porque quem concede acesso não
+ * necessariamente edita papéis — e precisar da matriz inteira para preencher um
+ * `<select>` obrigaria a dar a permissão maior para fazer a tarefa menor.
+ */
+function listContentRoleNames() {
+  assertContentRole_('manageAccess', null);
+  return Object.keys(contentPermsSnapshot_().roles).sort();
+}
+
 /** A matriz inteira, para a tela desenhar. */
 function listContentRoles() {
   assertContentRole_('manageRoles', null);

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -125,6 +125,9 @@
                     <button class="rail-item hidden" id="tab-people" data-tab="people" onclick="switchTab('people')">
                         <span class="material-symbols-rounded" aria-hidden="true">groups</span> <span class="rail-label">Pessoas</span>
                     </button>
+                    <button class="rail-item hidden" id="tab-roles" data-tab="roles" onclick="switchTab('roles')">
+                        <span class="material-symbols-rounded" aria-hidden="true">shield_person</span> <span class="rail-label">Papéis</span>
+                    </button>
                     <button class="rail-item hidden" id="tab-access" data-tab="access" onclick="switchTab('access')">
                         <span class="material-symbols-rounded" aria-hidden="true">manage_accounts</span> <span class="rail-label">Acessos</span>
                     </button>
@@ -393,11 +396,55 @@
                 </div>
             </section>
 
+            <!-- TAB: Papéis (matriz editável — ADR-0009) -->
+            <section id="pane-roles" class="hidden">
+                <div class="note warn" id="rol-note">
+                    O que um papel pode fazer vale <strong>no ato</strong> para todas as pessoas
+                    que o têm. Não passa por revisão e não tem fila.
+                </div>
+
+                <div class="card">
+                    <div class="rol-toolbar">
+                        <div>
+                            <label class="fld" style="margin-top:0" for="rol-papel">Papel</label>
+                            <select id="rol-papel" onchange="aoTrocarPapel()"></select>
+                        </div>
+                        <p class="card-sub" id="rol-resumo" role="status" aria-live="polite">Carregando…</p>
+                        <button class="btn btn-ghost" id="rol-novo-btn" onclick="novoPapel()">
+                            <span class="material-symbols-rounded" style="font-size:19px"
+                                aria-hidden="true">add</span> Novo papel
+                        </button>
+                    </div>
+
+                    <div id="rol-nome-nova" class="hidden" style="margin-top:14px">
+                        <label class="fld" for="rol-nome">Nome do novo papel</label>
+                        <input type="text" id="rol-nome" autocomplete="off"
+                            placeholder="ex.: EDITOR" maxlength="24">
+                    </div>
+                </div>
+
+                <div class="note warn hidden" id="rol-escalada"></div>
+
+                <div class="card" id="rol-matriz">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+
+                <div class="card" id="rol-globais"></div>
+
+                <div style="margin-top:18px;display:flex;gap:10px;align-items:center">
+                    <button class="btn btn-primary" id="rol-salvar" onclick="salvarPapel(this)">
+                        Salvar papel
+                    </button>
+                    <span class="card-sub" id="rol-mudancas"></span>
+                </div>
+            </section>
+
             <!-- TAB: Acessos -->
             <section id="pane-access" class="hidden">
                 <div class="note warn">
-                    Quem entra aqui passa a ver e propor conteúdo. Papéis <strong>ADMIN</strong> e
-                    <strong>TL</strong> também aprovam.
+                    Quem entra aqui passa a ver e propor conteúdo, conforme o papel.
+                    O que cada papel pode fazer se edita na aba <strong>Papéis</strong>.
                 </div>
                 <div class="card">
                     <div class="card-title">Conceder ou alterar acesso</div>
@@ -408,12 +455,10 @@
                         </div>
                         <div>
                             <label class="fld" for="acc-role">Papel</label>
-                            <select id="acc-role">
-                                <option value="ADMIN">ADMIN — edita tudo, aprova, gerencia acessos</option>
-                                <option value="TL">TL — edita tudo, aprova e publica avisos</option>
-                                <option value="QA">QA — propõe call script e case notes</option>
-                                <option value="WFM">WFM — propõe links e publica a disponibilidade BAU</option>
-                            </select>
+                            <!-- Vazio de propósito: os papéis viraram dado (ADR-0009), e uma
+                                 lista fixa aqui ficaria mentindo no dia em que alguém criar
+                                 um papel novo. `loadAccess()` preenche. -->
+                            <select id="acc-role"></select>
                         </div>
                     </div>
                     <div style="margin-top:18px">

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -113,6 +113,10 @@
                 titulo: 'Pessoas', carregar: function () { loadPeople(); },
                 sub: 'O diretório que decide quem é liderança e em que idioma o app abre.'
             },
+            roles: {
+                titulo: 'Papéis', carregar: function () { loadRoles(); },
+                sub: 'O que cada papel pode fazer. Vale no ato, sem passar por fila.'
+            },
             access: {
                 titulo: 'Acessos', carregar: function () { loadAccess(); },
                 sub: 'Quem entra na Central e com qual papel.'
@@ -587,6 +591,7 @@
 
                     document.getElementById('app').classList.remove('hidden');
                     if (s.canManageAccess) document.getElementById('tab-access').classList.remove('hidden');
+                    if (s.canManageRoles) document.getElementById('tab-roles').classList.remove('hidden');
                     // Pessoas nem aparece para QA/WFM: no servidor, a leitura do
                     // diretório é tão restrita quanto a escrita.
                     if (canPropose('people')) {

--- a/gas-backend/ContentDashboard_Governance.html
+++ b/gas-backend/ContentDashboard_Governance.html
@@ -721,9 +721,356 @@
             renderPeople();
         });
 
+        // --- Papéis (matriz editável — ADR-0009) ---
+        //
+        // A tela NÃO é a fronteira: cada regra deste arquivo existe também no
+        // servidor, e é lá que ela vale. O que a tela faz é dizer em voz alta o
+        // que está prestes a acontecer — que é a parte que o servidor sozinho
+        // não consegue fazer.
+
+        var ROL = null;          // resposta de listContentRoles()
+        var ROL_ATUAL = null;    // nome do papel em edição, ou ROL_NOVO
+        var ROL_NOVO = '__novo__';
+
+        var ROL_ACAO_NOME = {
+            view: 'Ver', propose: 'Propor', approve: 'Aprovar',
+            publish: 'Publicar direto', rollback: 'Reverter'
+        };
+
+        var ROL_GLOBAL_NOME = {
+            manageAccess: 'Gerenciar acessos',
+            manageRoles: 'Gerenciar papéis',
+            viewAudit: 'Ver a auditoria completa',
+            selfApprove: 'Aprovar a própria proposta'
+        };
+
+        var ROL_GLOBAL_AJUDA = {
+            manageAccess: 'Conceder e tirar o acesso de outras pessoas.',
+            manageRoles: 'Editar esta matriz — inclusive a de quem já a edita.',
+            viewAudit: 'Ver quem mudou o quê, incluindo mudanças de acesso.',
+            selfApprove: 'Publicar a própria proposta sem que ninguém revise.'
+        };
+
+        var ROL_MODULO_NOME = {
+            links: 'Links', call_script: 'Call Script', note_template: 'Case Notes',
+            email_template: 'E-mails', tips: 'Dicas', broadcast: 'Avisos',
+            bau_availability: 'Disponibilidade', people: 'Pessoas'
+        };
+
+        function loadRoles() {
+            if (!SESSION.canManageRoles) return;
+
+            google.script.run
+                .withSuccessHandler(function (r) {
+                    ROL = r;
+                    if (!ROL_ATUAL || (ROL_ATUAL !== ROL_NOVO && !acharPapel(ROL_ATUAL))) {
+                        ROL_ATUAL = r.roles.length ? r.roles[0].role : ROL_NOVO;
+                    }
+                    renderRoles();
+                })
+                .withFailureHandler(function (err) {
+                    document.getElementById('rol-matriz').innerHTML =
+                        '<div class="note warn">' + esc(err.message) + '</div>';
+                })
+                .listContentRoles();
+        }
+
+        function acharPapel(nome) {
+            if (!ROL) return null;
+            for (var i = 0; i < ROL.roles.length; i++) {
+                if (ROL.roles[i].role === nome) return ROL.roles[i];
+            }
+            return null;
+        }
+
+        // A matriz que a tela está mostrando AGORA — lida dos checkboxes, não
+        // do que veio do servidor. É ela que vai no salvar e a que alimenta o
+        // aviso de escalada em tempo real.
+        function matrizDaTela() {
+            var modules = {};
+
+            ROL.modules.forEach(function (m) {
+                modules[m] = {};
+                ROL.actionsByModule[m].forEach(function (acao) {
+                    var cx = document.getElementById('rol-cx-' + m + '-' + acao);
+                    modules[m][acao] = !!(cx && cx.checked);
+                });
+            });
+
+            var global = {};
+            ROL.globalPerms.forEach(function (nome) {
+                var cx = document.getElementById('rol-gl-' + nome);
+                global[nome] = !!(cx && cx.checked);
+            });
+
+            return { modules: modules, global: global };
+        }
+
+        // Publicação unilateral: propõe, aprova e pode aprovar a si mesmo.
+        // Mesma conta do servidor — aqui ela existe para APARECER, não para
+        // decidir.
+        function escaladaDaTela(m) {
+            if (!m.global.selfApprove) return [];
+            return ROL.modules.filter(function (mod) {
+                var c = m.modules[mod] || {};
+                if (!c.propose || !c.approve) return false;
+                var exige = ROL.approvalRequiresGlobal[mod];
+                return !exige || m.global[exige];
+            });
+        }
+
+        function renderRoles() {
+            if (!ROL) return;
+
+            var sel = document.getElementById('rol-papel');
+            sel.innerHTML = ROL.roles.map(function (r) {
+                return '<option value="' + esc(r.role) + '"' +
+                    (r.role === ROL_ATUAL ? ' selected' : '') + '>' + esc(r.role) +
+                    ' · ' + r.people + (r.people === 1 ? ' pessoa' : ' pessoas') + '</option>';
+            }).join('') +
+                '<option value="' + ROL_NOVO + '"' +
+                (ROL_ATUAL === ROL_NOVO ? ' selected' : '') + '>— novo papel —</option>';
+
+            document.getElementById('rol-nome-nova').classList.toggle('hidden', ROL_ATUAL !== ROL_NOVO);
+
+            var atual = acharPapel(ROL_ATUAL);
+            var resumo = document.getElementById('rol-resumo');
+
+            if (ROL.fallback) {
+                // Editar em cima de um fallback é editar no escuro: o que está
+                // na tela não é o que está gravado.
+                resumo.textContent =
+                    'A aba Content_Roles não pôde ser lida. Isto é o preset do código — ' +
+                    'salvar aqui vai GRAVAR o que você vir.';
+            } else if (ROL_ATUAL === ROL_NOVO) {
+                resumo.textContent = 'Papel novo. Ninguém o tem ainda.';
+            } else {
+                resumo.textContent = atual.people
+                    ? 'Vale para ' + atual.people + (atual.people === 1 ? ' pessoa' : ' pessoas') +
+                      ', no ato em que você salvar.'
+                    : 'Ninguém tem este papel no momento.';
+            }
+
+            renderMatriz(atual ? atual.permissions : null);
+            renderGlobais(atual ? atual.permissions : null);
+            aoMexerNaMatriz();
+        }
+
+        function renderMatriz(perms) {
+            var acoes = ROL.moduleActions;
+
+            var cabecalho = '<tr><th scope="col">Módulo</th>' + acoes.map(function (a) {
+                return '<th scope="col">' + esc(ROL_ACAO_NOME[a] || a) + '</th>';
+            }).join('') + '</tr>';
+
+            var linhas = ROL.modules.map(function (m) {
+                var possiveis = ROL.actionsByModule[m];
+
+                var celulas = acoes.map(function (acao) {
+                    // Casa que não existe neste regime não vira checkbox
+                    // desligado: vira traço. Um checkbox que não faz nada é uma
+                    // promessa falsa, e a matriz passaria a afirmar coisas sobre
+                    // operações que não existem.
+                    if (possiveis.indexOf(acao) === -1) {
+                        return '<td class="rol-na" aria-label="não se aplica">—</td>';
+                    }
+
+                    var id = 'rol-cx-' + m + '-' + acao;
+                    var marcado = !!(perms && perms.modules[m] && perms.modules[m][acao]);
+                    return '<td><input type="checkbox" id="' + id + '"' +
+                        (marcado ? ' checked' : '') +
+                        ' aria-label="' + esc((ROL_ACAO_NOME[acao] || acao) + ' — ' +
+                            (ROL_MODULO_NOME[m] || m)) + '"></td>';
+                }).join('');
+
+                return '<tr><th scope="row">' + esc(ROL_MODULO_NOME[m] || m) + '</th>' + celulas + '</tr>';
+            }).join('');
+
+            document.getElementById('rol-matriz').innerHTML =
+                '<div class="card-title" style="margin-bottom:4px">O que este papel faz em cada módulo</div>' +
+                '<p class="card-sub" style="margin-bottom:14px">' +
+                'O traço marca o que não existe naquele módulo: catálogo passa pela fila, ' +
+                'operação publica direto.</p>' +
+                '<div class="rol-scroll"><table class="rol-matriz">' +
+                '<thead>' + cabecalho + '</thead><tbody>' + linhas + '</tbody></table></div>';
+        }
+
+        function renderGlobais(perms) {
+            var itens = ROL.globalPerms.map(function (nome) {
+                var marcado = !!(perms && perms.global[nome]);
+                return '<label class="rol-global">' +
+                    '<input type="checkbox" id="rol-gl-' + nome + '"' + (marcado ? ' checked' : '') + '>' +
+                    '<span><strong>' + esc(ROL_GLOBAL_NOME[nome] || nome) + '</strong>' +
+                    '<span class="rol-global-ajuda">' + esc(ROL_GLOBAL_AJUDA[nome] || '') + '</span>' +
+                    '</span></label>';
+            }).join('');
+
+            document.getElementById('rol-globais').innerHTML =
+                '<div class="card-title" style="margin-bottom:14px">Permissões que não são de módulo</div>' +
+                itens;
+        }
+
+        // Um listener só, na aba inteira: a matriz é repintada a cada troca de
+        // papel, e religar handler por checkbox é como se perde evento em lista
+        // que muda.
+        document.getElementById('pane-roles').addEventListener('change', function (e) {
+            if (e.target.type === 'checkbox') aoMexerNaMatriz();
+        });
+
+        function aoMexerNaMatriz() {
+            if (!ROL) return;
+
+            var atual = acharPapel(ROL_ATUAL);
+            var agora = matrizDaTela();
+            var escalada = escaladaDaTela(agora);
+            var aviso = document.getElementById('rol-escalada');
+
+            aviso.classList.toggle('hidden', !escalada.length);
+            if (escalada.length) {
+                aviso.innerHTML = '<strong>Publicação sem revisão.</strong> Quem tem este papel ' +
+                    'propõe e aprova a si mesmo em ' +
+                    esc(escalada.map(function (m) { return ROL_MODULO_NOME[m] || m; }).join(', ')) +
+                    ' — vai ao ar sem ninguém olhar.';
+            }
+
+            // O diff ao vivo, e não só na confirmação: quem está mexendo precisa
+            // saber o que já mudou antes de decidir salvar.
+            var mudancas = diffDaMatriz(atual ? atual.permissions : null, agora);
+            document.getElementById('rol-mudancas').textContent = mudancas.length
+                ? mudancas.length + (mudancas.length === 1 ? ' alteração' : ' alterações')
+                : 'Nada alterado.';
+        }
+
+        function diffDaMatriz(antes, depois) {
+            var linhas = [];
+            var texto = function (v) { return v ? 'sim' : 'não'; };
+
+            ROL.modules.forEach(function (m) {
+                ROL.actionsByModule[m].forEach(function (acao) {
+                    var a = !!(antes && antes.modules[m] && antes.modules[m][acao]);
+                    var b = !!(depois.modules[m] && depois.modules[m][acao]);
+                    if (a !== b) {
+                        linhas.push((ROL_MODULO_NOME[m] || m) + ' · ' +
+                            (ROL_ACAO_NOME[acao] || acao) + ': ' + texto(a) + ' → ' + texto(b));
+                    }
+                });
+            });
+
+            ROL.globalPerms.forEach(function (nome) {
+                var a = !!(antes && antes.global[nome]);
+                var b = !!depois.global[nome];
+                if (a !== b) {
+                    linhas.push((ROL_GLOBAL_NOME[nome] || nome) + ': ' + texto(a) + ' → ' + texto(b));
+                }
+            });
+
+            return linhas;
+        }
+
+        function aoTrocarPapel() {
+            ROL_ATUAL = document.getElementById('rol-papel').value;
+            renderRoles();
+        }
+
+        function novoPapel() {
+            ROL_ATUAL = ROL_NOVO;
+            renderRoles();
+            var campo = document.getElementById('rol-nome');
+            if (campo) { campo.value = ''; campo.focus(); }
+        }
+
+        function salvarPapel(btn, opcoes) {
+            if (!ROL) return;
+
+            var nome = ROL_ATUAL === ROL_NOVO
+                ? String(document.getElementById('rol-nome').value || '').toUpperCase().trim()
+                : ROL_ATUAL;
+
+            if (!nome) return toast('Dê um nome ao papel.', true);
+
+            var perms = matrizDaTela();
+            if (btn) btn.disabled = true;
+
+            google.script.run
+                .withSuccessHandler(function (res) {
+                    if (btn) btn.disabled = false;
+
+                    // `confirm` não é erro: é o servidor pedindo uma declaração,
+                    // e ele NÃO gravou nada. O diálogo mostra o que MUDA, não o
+                    // estado final — "agora tem 14 permissões" não é uma frase
+                    // sobre a qual alguém decida.
+                    if (res.status === 'confirm') {
+                        pedirConfirmacaoDePapel(nome, res, opcoes || {});
+                        return;
+                    }
+
+                    toast('Papel ' + nome + ' salvo. Vale a partir de agora.');
+                    ROL_ATUAL = nome;
+
+                    // Mexeu no próprio papel: o que a tela tem em memória já não
+                    // vale, inclusive as abas que ela decidiu mostrar.
+                    if (res.reloadSession) location.reload();
+                    else loadRoles();
+                })
+                .withFailureHandler(function (err) {
+                    if (btn) btn.disabled = false;
+                    toast(err.message, true);
+                })
+                .saveContentRole(nome, JSON.stringify(perms), opcoes || {});
+        }
+
+        function pedirConfirmacaoDePapel(nome, res, opcoes) {
+            var lista = (res.changes || []).map(function (l) {
+                return '<li>' + esc(l) + '</li>';
+            }).join('');
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:520px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="rol-cf-titulo">' +
+                '<h2 id="rol-cf-titulo">' +
+                (res.reason === 'self' ? 'É o seu próprio papel' : 'Isto publica sem revisão') +
+                '</h2>' +
+                '<div class="note warn">' + esc(res.message) + '</div>' +
+                (lista ? '<p class="card-sub" style="margin-top:16px">O que muda:</p>' +
+                    '<ul class="rol-diff">' + lista + '</ul>' : '') +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Voltar e revisar</button>' +
+                '<button class="btn btn-primary" id="rol-cf-go">Salvar assim mesmo</button>' +
+                '</div></div></div>';
+
+            document.getElementById('rol-cf-go').onclick = function () {
+                closeModal();
+                // Os dois motivos podem aparecer em sequência: acumular a
+                // declaração e reenviar é o que faz a segunda pergunta chegar em
+                // vez de o salvamento voltar à estaca zero.
+                var novas = {};
+                Object.keys(opcoes).forEach(function (k) { novas[k] = opcoes[k]; });
+                if (res.reason === 'escalation') novas.confirmEscalation = true;
+                if (res.reason === 'self') novas.confirmSelf = true;
+                salvarPapel(document.getElementById('rol-salvar'), novas);
+            };
+
+            document.getElementById('rol-cf-go').focus();
+        }
+
         // --- Acessos ---
         function loadAccess() {
             if (!SESSION.canManageAccess) return;
+
+            // Os papéis viraram dado: o seletor tem que perguntar quais existem
+            // em vez de repetir uma lista que envelhece no primeiro papel novo.
+            google.script.run
+                .withSuccessHandler(function (nomes) {
+                    var sel = document.getElementById('acc-role');
+                    var escolhido = sel.value;
+                    sel.innerHTML = (nomes || []).map(function (n) {
+                        return '<option value="' + esc(n) + '">' + esc(n) + '</option>';
+                    }).join('');
+                    if (escolhido) sel.value = escolhido;
+                })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .listContentRoleNames();
 
             google.script.run
                 .withSuccessHandler(function (list) {
@@ -737,10 +1084,14 @@
                             '<div style="display:flex;gap:8px;align-items:center">' +
                             '<span class="pill ' + (a.active ? 'live' : 'archived') + '">' +
                             esc(a.role) + (a.active ? '' : ' · inativo') + '</span>' +
-                            (a.ldap === SESSION.ldap ? '' :
-                                '<button class="btn btn-ghost btn-sm" onclick="toggleAccess(\'' +
-                                esc(a.ldap) + '\',\'' + esc(a.role) + '\',' + (!a.active) + ')">' +
-                                (a.active ? 'Desativar' : 'Reativar') + '</button>') +
+                            // O botão aparece inclusive para si mesmo: a trava
+                            // deixou de ser "não se remova" e passou a ser "não
+                            // fique sem ninguém que governe" (ADR-0009). Quem for
+                            // o último a governar recebe o erro do servidor, que
+                            // explica exatamente isso.
+                            '<button class="btn btn-ghost btn-sm" onclick="toggleAccess(\'' +
+                            esc(a.ldap) + '\',\'' + esc(a.role) + '\',' + (!a.active) + ')">' +
+                            (a.active ? 'Desativar' : 'Reativar') + '</button>' +
                             '</div></div>';
                     }).join('');
                 })

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -254,6 +254,98 @@
             overflow-wrap: anywhere;
         }
 
+        /* --- Matriz de papéis --- */
+        .rol-toolbar {
+            display: flex;
+            gap: 16px;
+            align-items: flex-end;
+            flex-wrap: wrap;
+        }
+
+        .rol-toolbar #rol-resumo {
+            flex: 1 1 240px;
+            margin: 0 0 8px;
+        }
+
+        /* A matriz é larga por natureza: rola dentro do cartão em vez de
+           empurrar a página inteira para o lado. */
+        .rol-scroll { overflow-x: auto; }
+
+        .rol-matriz {
+            border-collapse: collapse;
+            width: 100%;
+            min-width: 560px;
+        }
+
+        .rol-matriz th,
+        .rol-matriz td {
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border-subtle);
+            text-align: center;
+        }
+
+        .rol-matriz thead th {
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            white-space: nowrap;
+        }
+
+        .rol-matriz tbody th {
+            text-align: left;
+            font-weight: 500;
+            white-space: nowrap;
+        }
+
+        .rol-matriz tbody tr:last-child th,
+        .rol-matriz tbody tr:last-child td { border-bottom: none; }
+
+        .rol-matriz input[type="checkbox"] {
+            width: 17px;
+            height: 17px;
+            accent-color: var(--gemini-blue);
+            cursor: pointer;
+        }
+
+        /* Casa que não existe naquele regime. Cinza e sem controle: um checkbox
+           desligado aqui prometeria uma operação que o módulo não tem. */
+        .rol-na { color: var(--text-tertiary); opacity: 0.45; }
+
+        .rol-global {
+            display: flex;
+            gap: 12px;
+            align-items: flex-start;
+            padding: 10px 0;
+            border-bottom: 1px solid var(--border-subtle);
+            cursor: pointer;
+        }
+
+        .rol-global:last-child { border-bottom: none; }
+
+        .rol-global input[type="checkbox"] {
+            width: 17px;
+            height: 17px;
+            margin-top: 2px;
+            accent-color: var(--gemini-blue);
+            flex: 0 0 auto;
+        }
+
+        .rol-global-ajuda {
+            display: block;
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 2px;
+        }
+
+        .rol-diff {
+            margin: 8px 0 0;
+            padding-left: 20px;
+            font-size: 13px;
+            line-height: 1.7;
+        }
+
         /* Abaixo desta largura, trilho (248px) mais barra (304px) deixariam o
            editor com menos da metade da tela. A barra sai do grid e passa a
            flutuar sobre o conteúdo, fechável pelo mesmo botão.

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -75,7 +75,8 @@ function verdade(cond, oque) {
 const SESSOES = {
     admin: {
         ldap: 'lucaste', role: 'ADMIN', hasAccess: true,
-        canApprove: true, canManageAccess: true, canSelfApprove: true,
+        canApprove: true, canManageAccess: true, canManageRoles: true,
+        canViewAudit: true, canSelfApprove: true,
         proposableModules: ['links', 'call_script', 'email_template', 'note_template',
             'tips', 'broadcast', 'bau_availability', 'people'],
     },
@@ -90,6 +91,60 @@ const SESSOES = {
         proposableModules: ['links', 'bau_availability'],
     },
     semAcesso: { ldap: 'estranho', role: null, hasAccess: false },
+};
+
+// A matriz como o servidor a devolve. Os eixos vêm de lá de propósito: a tela
+// desenha as casas a partir de `actionsByModule`, em vez de repetir a regra de
+// regime de cada módulo.
+const ACOES = ['view', 'propose', 'approve', 'publish', 'rollback'];
+const MODULOS_MATRIZ = ['links', 'call_script', 'note_template', 'email_template',
+    'tips', 'broadcast', 'bau_availability', 'people'];
+const DIRETOS = ['broadcast', 'bau_availability'];
+
+const ACOES_POR_MODULO = MODULOS_MATRIZ.reduce((acc, m) => {
+    acc[m] = DIRETOS.includes(m)
+        ? ['view', 'publish', 'rollback']
+        : ['view', 'propose', 'approve', 'rollback'];
+    return acc;
+}, {});
+
+function permsDe(marcadas, global) {
+    const modules = {};
+    MODULOS_MATRIZ.forEach((m) => {
+        modules[m] = {};
+        ACOES.forEach((a) => { modules[m][a] = !!(marcadas[m] || []).includes(a); });
+    });
+    return { modules, global: Object.assign(
+        { manageAccess: false, manageRoles: false, viewAudit: false, selfApprove: false },
+        global || {}) };
+}
+
+const MATRIZ = {
+    roles: [
+        {
+            role: 'ADMIN', people: 1, escalation: ['links'],
+            permissions: permsDe(
+                MODULOS_MATRIZ.reduce((a, m) => {
+                    a[m] = ACOES_POR_MODULO[m];
+                    return a;
+                }, {}),
+                { manageAccess: true, manageRoles: true, viewAudit: true, selfApprove: true }),
+        },
+        {
+            role: 'QA', people: 3, escalation: [],
+            permissions: permsDe({
+                links: ['view'], call_script: ['view', 'propose'],
+                note_template: ['view', 'propose'], email_template: ['view'],
+                tips: ['view'], broadcast: ['view'], bau_availability: ['view'],
+            }, {}),
+        },
+    ],
+    modules: MODULOS_MATRIZ,
+    moduleActions: ACOES,
+    globalPerms: ['manageAccess', 'manageRoles', 'viewAudit', 'selfApprove'],
+    actionsByModule: ACOES_POR_MODULO,
+    approvalRequiresGlobal: { people: 'manageAccess' },
+    fallback: false,
 };
 
 const ITENS = {
@@ -154,7 +209,8 @@ const ATIVIDADE = [
 ];
 
 // ------------------------------------------------------- montagem da página
-async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null, fila = [], atividade = [] } = {}) {
+async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null,
+    fila = [], atividade = [], matriz = MATRIZ, confirmarSalvar = null } = {}) {
     const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } });
     page.on('pageerror', (e) => { console.log('  ! erro de página: ' + e.message); fail++; });
 
@@ -175,7 +231,8 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
 
     // O dublê precisa existir ANTES do script da página rodar: o boot dispara
     // no DOMContentLoaded.
-    await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos, pendentes, atividade }) => {
+    await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos, pendentes, atividade,
+        matriz, respostaDoSalvar }) => {
         const PENDENTES = pendentes || [];
         const ATIVIDADE = atividade || [];
         const HISTORICO = historico;
@@ -190,6 +247,22 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             },
             listPendingApprovals: () => PENDENTES,
             listContentActivity: () => ATIVIDADE,
+            listContentRoles: () => matriz,
+            listContentRoleNames: () => ['ADMIN', 'QA'],
+            saveContentRole: (nome, permsJson, opcoes) => {
+                // O servidor devolve `confirm` até vir a declaração. O dublê
+                // repete esse contrato para o teste poder exercitar o diálogo.
+                if (respostaDoSalvar && !(opcoes || {})[respostaDoSalvar.flag]) {
+                    return {
+                        status: 'confirm',
+                        reason: respostaDoSalvar.reason,
+                        message: respostaDoSalvar.message,
+                        changes: respostaDoSalvar.changes,
+                        modules: respostaDoSalvar.modules || [],
+                    };
+                }
+                return { status: 'success', role: nome, changes: [], reloadSession: false };
+            },
             listContentItemHistory: (lineage) => (HISTORICO[lineage] || []),
             rollbackContentItem: () => ({ status: 'success', itemId: 'itm_revivido' }),
             saveContentDraft: () => ({ status: 'success', draftId: 'drf_rascunho' }),
@@ -245,6 +318,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
     }, {
         sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe,
         historico: HISTORICO, rascunhos: draftsDe, pendentes: fila, atividade,
+        matriz, respostaDoSalvar: confirmarSalvar,
     });
 
     await page.goto('file://' + ARQUIVO + hash, { waitUntil: 'domcontentloaded' });
@@ -971,6 +1045,151 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         igual(await page.evaluate(() => window.__chamadas
             .filter(c => c.metodo === 'listContentActivity').length), 0,
             'pediu atividade sem ter acesso');
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------- matriz de papéis
+{
+    const page = await abrir({ sessao: 'qa' });
+
+    await check('quem não gerencia papéis não vê a aba', async () => {
+        igual(await page.locator('#tab-roles').isVisible(), false, 'aba Papéis para o QA');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'admin', hash: '#/roles' });
+
+    await check('a matriz desenha um módulo por linha e uma ação por coluna', async () => {
+        verdade(await page.locator('#tab-roles').isVisible(), 'a aba deveria aparecer para o ADMIN');
+        igual(await page.locator('.rol-matriz tbody tr').count(), 8, 'linhas (módulos)');
+        igual(await page.locator('.rol-matriz thead th').count(), 6, 'colunas (módulo + 5 ações)');
+    });
+
+    await check('casa que não existe naquele regime é traço, não checkbox', async () => {
+        // Não existe "aprovar um aviso": avisos não passam por fila nenhuma.
+        // Um checkbox desligado ali prometeria uma operação que o módulo não tem.
+        igual(await page.locator('#rol-cx-broadcast-approve').count(), 0,
+            'aprovar aviso não pode ser um checkbox');
+        igual(await page.locator('#rol-cx-broadcast-publish').count(), 1,
+            'publicar aviso tem que ser um checkbox');
+        igual(await page.locator('#rol-cx-links-publish').count(), 0,
+            'não existe publicar direto no catálogo');
+        verdade(await page.locator('.rol-na').count() >= 8, 'faltaram os traços das casas inexistentes');
+    });
+
+    await check('a matriz abre marcada com o que o papel já pode', async () => {
+        igual(await page.locator('#rol-cx-links-propose').isChecked(), true);
+        await page.selectOption('#rol-papel', 'QA');
+        await page.waitForTimeout(150);
+        igual(await page.locator('#rol-cx-links-propose').isChecked(), false, 'QA não propõe links');
+        igual(await page.locator('#rol-cx-call_script-propose').isChecked(), true, 'QA propõe call script');
+    });
+
+    await check('o contador de alterações acompanha o clique', async () => {
+        igual((await page.locator('#rol-mudancas').textContent()).trim(), 'Nada alterado.');
+        await page.locator('#rol-cx-links-propose').check();
+        await page.waitForTimeout(120);
+        igual((await page.locator('#rol-mudancas').textContent()).trim(), '1 alteração');
+    });
+
+    await check('o aviso de publicação sem revisão aparece ANTES de salvar', async () => {
+        // É a parte que o servidor sozinho não faz: dizer em voz alta o que
+        // está prestes a acontecer.
+        igual(await page.locator('#rol-escalada').isVisible(), false, 'ainda não é escalada');
+
+        await page.locator('#rol-cx-links-approve').check();
+        await page.locator('#rol-gl-selfApprove').check();
+        await page.waitForTimeout(150);
+
+        verdade(await page.locator('#rol-escalada').isVisible(), 'o aviso deveria aparecer');
+        const texto = await page.locator('#rol-escalada').textContent();
+        verdade(/sem revisão/i.test(texto), 'faltou dizer que publica sem revisão');
+        verdade(/Links/.test(texto), 'faltou nomear o módulo afetado: ' + texto);
+    });
+
+    await check('o que vai para o servidor é o que está NA TELA', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#rol-salvar').click();
+        await page.waitForTimeout(200);
+
+        const chamada = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'saveContentRole')[0]);
+        igual(chamada.args[0], 'QA', 'papel enviado');
+
+        const perms = JSON.parse(chamada.args[1]);
+        igual(perms.modules.links.propose, true, 'a marcação da tela chegou ao servidor');
+        igual(perms.global.selfApprove, true);
+        // A casa inexistente nem viaja: o payload não diz nada sobre "aprovar
+        // aviso", em vez de dizer que é falso. Dizer que é falso seria afirmar
+        // que a operação existe.
+        igual('approve' in perms.modules.broadcast, false, 'a casa inexistente não deveria viajar');
+        igual('publish' in perms.modules.broadcast, true, 'a casa que existe precisa viajar');
+    });
+
+    await page.close();
+}
+
+{
+    // O servidor devolve `confirm` e NÃO grava. A tela precisa mostrar o que
+    // muda — não o estado final — e só então reenviar com a declaração.
+    const page = await abrir({
+        sessao: 'admin', hash: '#/roles',
+        confirmarSalvar: {
+            reason: 'escalation', flag: 'confirmEscalation',
+            message: 'Com isto, quem tem o papel QA publica sozinho em links.',
+            changes: ['links.approve: não → sim'], modules: ['links'],
+        },
+    });
+
+    await check('confirmação mostra o que MUDA, não o estado final', async () => {
+        await page.locator('#rol-salvar').click();
+        await page.waitForTimeout(250);
+
+        const modal = page.locator('.modal-backdrop .modal');
+        verdade(await modal.isVisible(), 'o diálogo deveria abrir');
+        const texto = await modal.textContent();
+        verdade(/publica sozinho/.test(texto), 'faltou a mensagem do servidor');
+        verdade(/links\.approve: não → sim/.test(texto), 'faltou o diff: ' + texto);
+    });
+
+    await check('voltar não grava nada', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('.modal-actions .btn-ghost').click();
+        await page.waitForTimeout(150);
+        igual(await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'saveContentRole').length), 0, 'chamadas depois de voltar');
+    });
+
+    await check('confirmar reenvia COM a declaração', async () => {
+        await page.locator('#rol-salvar').click();
+        await page.waitForTimeout(250);
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#rol-cf-go').click();
+        await page.waitForTimeout(250);
+
+        const opcoes = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'saveContentRole')[0].args[2]);
+        igual(opcoes.confirmEscalation, true, 'a declaração precisa acompanhar o reenvio');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'admin', hash: '#/access' });
+
+    await check('o seletor de papel vem do servidor, não do HTML', async () => {
+        // Uma lista fixa aqui passaria a mentir no primeiro papel novo criado
+        // pela aba Papéis.
+        await page.waitForTimeout(250);
+        const opcoes = await page.locator('#acc-role option').evaluateAll(
+            (os) => os.map(o => o.value));
+        igual(opcoes, ['ADMIN', 'QA'], 'papéis no seletor');
     });
 
     await page.close();

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -98,6 +98,7 @@ o porquê em `docs/decisions/0009-rbac-editavel-da-central.md`.
 
 | Função | Params | Quem pode | Resposta |
 | :--- | :--- | :--- | :--- |
+| `listContentRoleNames()` | — | `manageAccess` | `["ADMIN", "QA", …]` — só os nomes, para o seletor da aba Acessos |
 | `listContentRoles()` | — | `manageRoles` | `{ roles: [{ role, permissions, people, escalation }], modules, moduleActions, globalPerms, actionsByModule, approvalRequiresGlobal, fallback }` |
 | `saveContentRole(role, permissions, options)` | `options`: `{ active?, confirmEscalation?, confirmSelf? }` | `manageRoles` | `{ status: 'success', role, changes, reloadSession }` **ou** `{ status: 'confirm', reason, message, changes, modules? }` |
 
@@ -115,6 +116,9 @@ o porquê em `docs/decisions/0009-rbac-editavel-da-central.md`.
 - **`fallback: true`** em `listContentRoles()` significa que a aba não pôde ser
   lida e a matriz mostrada é o preset do código. A tela precisa dizer isso —
   editar em cima de um fallback é editar no escuro.
+- **Conceder acesso não exige editar papéis.** `listContentRoleNames()` existe
+  separado por isso: preencher um `<select>` não pode obrigar a dar a permissão
+  maior para fazer a tarefa menor.
 - **`actionsByModule` manda na tela.** A matriz desenha as casas a partir dele,
   em vez de repetir a regra de regime (catálogo tem `propose`/`approve`,
   operação tem `publish`).


### PR DESCRIPTION
## O que muda

Segunda metade da fase 4 (ADR-0009): **a tela**. O servidor já lia os papéis da aba `Content_Roles` (#383); editar continuava sendo mexer na planilha à mão. Agora existe a aba **Papéis** — uma linha por módulo, uma coluna por ação.

## Por que assim

**Traço, não checkbox desligado.** Onde a ação não existe naquele regime, a célula é `—`. Não existe "aprovar um aviso": avisos não passam por fila nenhuma. Um checkbox ali prometeria uma operação que o módulo não tem, e a matriz passaria a afirmar "este papel não aprova avisos" sobre algo que não é uma operação. Pela mesma razão a casa inexistente **nem viaja no payload** — dizer que é falsa seria afirmar que ela existe. Quem decide quais casas existem é o servidor, via `actionsByModule`: a tela não repete a regra de regime.

**O aviso de publicação sem revisão aparece enquanto se clica**, não só ao salvar, e nomeia os módulos afetados. Esta é a parte que o servidor sozinho não faz. Ele recusa gravar sem a declaração — mas quem decide precisa **ver** o que está prestes a acontecer antes de declarar, e um erro depois do clique em Salvar chega tarde demais para ser uma decisão.

**A confirmação mostra o que MUDA, não o estado final**, como o ADR pede. "Agora este papel tem 14 permissões" não é uma frase sobre a qual alguém decida; `Links · Aprovar: não → sim` é. O mesmo diff aparece ao vivo, como contador, enquanto se mexe.

**`confirm` não é erro** e a tela trata assim: é o servidor pedindo uma declaração e **não tendo gravado nada**. Voltar não grava; confirmar reenvia acumulando a flag, para que os dois motivos (escalação e "é o seu próprio papel") possam aparecer em sequência sem o salvamento voltar à estaca zero.

**Editar o próprio papel recarrega a página.** O que a tela tinha em memória — inclusive quais abas mostrar — deixou de valer no instante do salvamento.

**Duas coisas que vieram junto porque ficaram mentindo depois do #383:**
- O `<select>` de papel da aba Acessos tinha os quatro papéis fixos no HTML; passaria a mentir no primeiro papel novo criado. Agora lê `listContentRoleNames()`, que exige `manageAccess` e não `manageRoles` — preencher um select não pode custar a permissão maior para fazer a tarefa menor.
- O botão de desativar acesso era escondido para si mesmo, resquício da trava antiga. A trava agora é sobre **sobrar quem governe**: quem tem um colega admin pode sair, e quem for o último recebe do servidor um erro que explica exatamente isso.

## Como verificar

```
npm run smoke:content   # 70 verificações (eram 59)
```

```
✓ quem não gerencia papéis não vê a aba
✓ a matriz desenha um módulo por linha e uma ação por coluna
✓ casa que não existe naquele regime é traço, não checkbox
✓ a matriz abre marcada com o que o papel já pode
✓ o contador de alterações acompanha o clique
✓ o aviso de publicação sem revisão aparece ANTES de salvar
✓ o que vai para o servidor é o que está NA TELA
✓ confirmação mostra o que MUDA, não o estado final
✓ voltar não grava nada
✓ confirmar reenvia COM a declaração
✓ o seletor de papel vem do servidor, não do HTML
```

**Três mutações confirmam que elas falham quando devem** — casa impossível virando checkbox, aviso de escalação suprimido, e confirmação reenviando sem a declaração.

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes. `smoke:shortcuts` segue com as mesmas 2 falhas anteriores a esta linha de trabalho.

**Conferido renderizado:** a matriz do ADMIN mostra os traços em Publicar direto no catálogo e em Propor/Aprovar na operação; o aviso de escalação nomeia os seis módulos em que o ADMIN publica sozinho; o bloco de permissões globais explica cada uma em uma linha ("Editar esta matriz — inclusive a de quem já a edita").

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente.

## Checklist

- [x] Mexi em `gas-backend/`: `listContentRoleNames()` entrou em `specs/data-models/api-payloads.md`, com o motivo de existir separado de `listContentRoles()`.
- [x] Regra de negócio: nenhuma nova — as quatro regras do RBAC continuam no servidor, e esta tela não decide nenhuma delas. Ela só as diz em voz alta antes.
- [x] Decisão que alguém vai questionar depois: o ADR-0009 já cobre; "por que traço e não checkbox" e "por que o aviso ao vivo" estão comentados no ponto exato do código.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`, incluindo a mudança no botão de desativar o próprio acesso.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_