### PR TITLE
feat(central): ver a Central pelos olhos de outro papel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **"Ver como": conferir a Central pelos olhos de outro papel** (fase 5). Quem
+  edita a matriz de permissões precisa poder verificar o que configurou — ler
+  uma linha de checkboxes e imaginar a tela resultante é o tipo de tradução em
+  que se erra sem perceber, e o erro só aparece quando alguém reclama que não
+  consegue trabalhar. Escolhe-se um papel e um idioma, e a tela inteira passa a
+  mostrar o que aquela pessoa veria: o trilho, os botões, as caixas de "seu
+  papel não edita isto". Uma faixa fica na tela o tempo todo dizendo de quem é a
+  visão. A prévia **nunca concede**: o servidor intersecta o papel escolhido com
+  o de quem pediu, e diz na própria faixa quantas permissões daquele papel não
+  estão sendo mostradas porque quem pediu também não as tem. E fica só de
+  leitura — conferir não é decidir, e uma decisão tomada "de dentro" da prévia
+  sairia no nome de quem clicou, não no do papel previsto.
 - **Aba "Papéis" na Central: a matriz de permissões virou tela** (fase 4). Uma
   linha por módulo, uma coluna por ação, e um traço onde a ação não existe
   naquele regime — não existe "aprovar um aviso", e um checkbox desligado ali

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,12 +77,16 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       e o `<select>` da aba Acessos lendo `listContentRoleNames()`.
       **Falta validar na planilha real:** que a aba `Content_Roles` nasce
       semeada e que os quatro papéis continuam se comportando igual.
-- [ ] **Fase 5 — diferenciais e auditoria.** Prévia "como o agente vê"; busca
-      global Ctrl+K; agendamento e validade de aviso; "ver como" por papel e
-      segmento; cobrança diária de pendência parada — esta lendo `CW_DEPLOYMENTS`
-      e não a URL do serviço, porque em gatilho de tempo a derivação não é
-      confiável (ver `Código.js`). **PR final:** aba de auditoria restrita ao
-      ADMIN, com filtros, paginação e exportação.
+- [~] **Fase 5 — diferenciais e auditoria** — em andamento.
+      **Entregue:** "ver como" por papel e idioma — a tela inteira passa a
+      mostrar o que aquele papel veria, de leitura, com a prévia intersectada no
+      servidor (prévia que concede é escalação com outro nome) e dizendo na
+      faixa o que deixou de mostrar.
+      **Falta:** prévia "como o agente vê"; busca global Ctrl+K; agendamento e
+      validade de aviso; cobrança diária de pendência parada — esta lendo
+      `CW_DEPLOYMENTS` e não a URL do serviço, porque em gatilho de tempo a
+      derivação não é confiável (ver `Código.js`). **PR final:** aba de
+      auditoria restrita, com filtros, paginação e exportação.
 
 ## Ideas — to triage
 

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -697,8 +697,13 @@ function getContentSession() {
     return { ldap: ldap, role: null, hasAccess: false };
   }
 
-  const perms = getContentPermsForRole_(role);
+  return sessionParaPapel_(ldap, role, getContentPermsForRole_(role));
+}
 
+// O formato que a tela consome. Extraído porque a prévia "ver como" devolve
+// exatamente a mesma coisa — se as duas divergirem, a prévia deixa de ser
+// prévia.
+function sessionParaPapel_(ldap, role, perms) {
   return {
     ldap: ldap,
     role: role,
@@ -721,6 +726,58 @@ function getContentSession() {
     modules: CONTENT_MODULES,
     langs: CONTENT_LANGS
   };
+}
+
+/**
+ * "Ver como": o que a Central mostraria para quem tem o papel `role`.
+ *
+ * NUNCA devolve mais poder do que quem pergunta já tem — a matriz do papel é
+ * INTERSECTADA com a de quem chama. Prévia que concede é escalada com outro
+ * nome: o servidor continua julgando pela identidade real, então uma tela
+ * otimista ou ofereceria botões que falham, ou — pior — botões que funcionam
+ * enquanto a pessoa acredita estar "só olhando".
+ *
+ * O que ficou de fora vem em `beyond`, para a tela poder dizer o que ela NÃO
+ * está mostrando. Prévia silenciosamente incompleta é pior que prévia nenhuma:
+ * a pessoa conclui que o papel não pode algo que ele pode.
+ */
+function previewContentSession(role) {
+  const session = assertContentRole_('manageRoles', null);
+  const nome = String(role || "").toUpperCase().trim();
+  const alvo = getContentPermsForRole_(nome);
+  if (!alvo) throw new Error("Papel desconhecido: " + role);
+
+  const meu = session.perms;
+  const modules = {};
+  const alem = [];
+
+  CONTENT_MODULES.forEach(function (m) {
+    modules[m] = {};
+    contentActionsForModule_(m).forEach(function (acao) {
+      const noAlvo = podeNoModulo_(alvo, m, acao);
+      const emMim = podeNoModulo_(meu, m, acao);
+      modules[m][acao] = noAlvo && emMim;
+      if (noAlvo && !emMim) alem.push(m + '.' + acao);
+    });
+  });
+
+  const global = {};
+  CONTENT_GLOBAL_PERMS.forEach(function (g) {
+    const noAlvo = podeGlobal_(alvo, g);
+    const emMim = podeGlobal_(meu, g);
+    global[g] = noAlvo && emMim;
+    if (noAlvo && !emMim) alem.push(g);
+  });
+
+  const previa = sessionParaPapel_(session.ldap, nome, normalizeRoleMatrix_({
+    modules: modules, global: global
+  }));
+
+  previa.preview = true;
+  previa.realRole = session.role;
+  previa.beyond = alem;
+
+  return previa;
 }
 
 // Porta única de todas as ações de escrita. Devolve { ldap, role, perms } pra

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -32,6 +32,7 @@
 
     <div class="ambient-glow"></div>
 
+
     <nav class="topnav">
         <div class="brand-main">
             <span class="material-symbols-rounded">tune</span>
@@ -40,6 +41,10 @@
         <div class="topnav-fim">
             <!-- Nasce escondido: antes de saber quem é a pessoa não há
                  atividade que ela possa ver. -->
+            <button class="topnav-acao hidden" id="btn-ver-como" onclick="abrirVerComo()">
+                <span class="material-symbols-rounded" aria-hidden="true">visibility</span>
+                <span class="topnav-acao-label">Ver como</span>
+            </button>
             <button class="topnav-acao hidden" id="btn-lateral" onclick="alternarLateral()"
                 aria-expanded="true" aria-controls="lateral">
                 <span class="material-symbols-rounded" aria-hidden="true">history</span>
@@ -51,6 +56,12 @@
             </div>
         </div>
     </nav>
+
+    <!-- Faixa da prévia. Logo abaixo do header e fora da área de conteúdo, de
+         propósito: enquanto ela estiver na tela, NADA do que se vê abaixo é a
+         sua própria visão. Vir DEPOIS do header também é o que a mantém
+         clicável — o header é sticky com z-index maior. -->
+    <div class="faixa-previa hidden" id="faixa-previa" role="status" aria-live="polite"></div>
 
     <div class="shell sem-trilho" id="shell">
         <!-- O trilho só aparece depois de sabermos quem é a pessoa: antes disso
@@ -446,7 +457,7 @@
                     Quem entra aqui passa a ver e propor conteúdo, conforme o papel.
                     O que cada papel pode fazer se edita na aba <strong>Papéis</strong>.
                 </div>
-                <div class="card">
+                <div class="card" id="acc-editor">
                     <div class="card-title">Conceder ou alterar acesso</div>
                     <div class="grid-2">
                         <div>

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -76,7 +76,7 @@
                     var historico = '<button class="btn btn-ghost btn-sm" '
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'links\')">Histórico</button>';
 
-                    var actions = canPropose('links')
+                    var actions = podeEscrever('links')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openLinkEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Tirar do ar</button>' +
@@ -419,7 +419,7 @@
                     var historico = '<button class="btn btn-ghost btn-sm" '
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'call_script\')">Histórico</button>';
 
-                    var actions = canPropose('call_script')
+                    var actions = podeEscrever('call_script')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openStepEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
@@ -636,7 +636,7 @@
                     var historico = '<button class="btn btn-ghost btn-sm" '
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'note_template\')">Histórico</button>';
 
-                    var actions = canPropose('note_template')
+                    var actions = podeEscrever('note_template')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openTemplateEditor(\'' + it.id + '\')">Editar</button>' +
                         '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +
@@ -877,7 +877,7 @@
                     var historico = '<button class="btn btn-ghost btn-sm" '
                         + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'email_template\')">Histórico</button>';
 
-                    var actions = canPropose('email_template')
+                    var actions = podeEscrever('email_template')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
                         '<button class="btn btn-ghost btn-sm" onclick="openEmailEditor(\'' + it.id + '\')">Editar</button>' +
                         '</div>'
@@ -1054,7 +1054,7 @@
                 var historico = '<button class="btn btn-ghost btn-sm" '
                     + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'tips\')">Histórico</button>';
 
-                var actions = canPropose('tips')
+                var actions = podeEscrever('tips')
                     ? '<div style="display:flex;gap:8px">' + historico + descarte +
                     '<button class="btn btn-ghost btn-sm" onclick="openTipEditor(\'' + it.id + '\')">Editar</button>' +
                     '<button class="btn btn-danger btn-sm" onclick="askRemoval(\'' + it.id + '\')">Remover</button>' +

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -290,7 +290,7 @@
 
             // Reverter republica sem passar pela fila: é a mesma natureza da
             // publicação direta, e quem pode fazer é quem aprova.
-            var podeReverter = !!(SESSION && SESSION.canApprove);
+            var podeReverter = !MODO_PREVIA && !!(SESSION && SESSION.canApprove);
 
             host.innerHTML = versoes.map(function (v) {
                 var noAr = v.status === 'live';
@@ -572,11 +572,175 @@
             if (!document.getElementById('pane-emails').classList.contains('hidden')) renderEmails();
         }
 
+        // --- Ver como ---
+        //
+        // Quem edita a matriz de papéis precisa poder CONFERIR o que configurou.
+        // Ler uma linha de checkboxes e imaginar a tela resultante é exatamente
+        // o tipo de tradução em que se erra sem perceber — e o erro só aparece
+        // quando alguém reclama que não consegue trabalhar.
+        //
+        // A prévia é do SERVIDOR e nunca concede: `previewContentSession()`
+        // intersecta o papel escolhido com o de quem pergunta. Prévia que
+        // concede é escalada com outro nome.
+        var SESSION_REAL = null;
+        var MODO_PREVIA = false;
+
+        // Em prévia a tela fica de leitura. Quem está "vendo como" não está
+        // decidindo — e um clique que publica no meio de uma conferência é a
+        // pior surpresa possível.
+        function podeEscrever(module) {
+            return !MODO_PREVIA && canPropose(module);
+        }
+
+        function aplicarPermissoes(s) {
+            document.getElementById('user-ldap').textContent = s.ldap || '';
+
+            var badge = document.getElementById('user-role');
+            badge.textContent = s.role;
+            badge.classList.remove('hidden');
+
+            document.getElementById('tab-access').classList.toggle('hidden', !s.canManageAccess);
+            // A aba de papéis some na prévia: editar permissão enquanto se
+            // finge ser outra pessoa é como se perde a noção de quem fez o quê.
+            document.getElementById('tab-roles').classList.toggle('hidden',
+                !s.canManageRoles || MODO_PREVIA);
+            // Pessoas nem aparece para QA/WFM: no servidor, a leitura do
+            // diretório é tão restrita quanto a escrita.
+            document.getElementById('tab-people').classList.toggle('hidden', !canPropose('people'));
+
+            // A caixa de aviso de alguns módulos nasce escondida: o regime agora
+            // é dito pelo trilho, e prosa repetida é ruído. A exceção é
+            // justamente esta — "você não pode editar isto" é informação que só
+            // existe aqui, então tem que aparecer.
+            function explicarSemPermissao(idNota, texto, escondido) {
+                var nota = document.getElementById(idNota);
+                if (escondido) { nota.classList.add('hidden'); return; }
+                nota.textContent = texto;
+                nota.classList.remove('hidden');
+            }
+
+            function gate(module, idBotao, idNota, texto) {
+                if (idBotao) {
+                    document.getElementById(idBotao).classList.toggle('hidden', !podeEscrever(module));
+                }
+                explicarSemPermissao(idNota,
+                    'Seu papel (' + s.role + ') ' + texto, canPropose(module));
+            }
+
+            gate('links', 'links-new-btn', 'links-note',
+                'vê os links, mas não propõe alterações neste módulo.');
+            gate('call_script', 'cs-new-btn', 'cs-note',
+                'vê o roteiro, mas não propõe alterações neste módulo.');
+            gate('tips', 'tp-new-btn', 'tp-note',
+                'vê as dicas, mas não propõe alterações neste módulo.');
+            gate('email_template', null, 'em-note',
+                'vê os modelos, mas não propõe alterações neste módulo.');
+            gate('note_template', 'nt-new-btn', 'nt-note',
+                'vê os modelos de nota, mas não propõe alterações neste módulo.');
+            // Avisos e disponibilidade seguem a mesma regra do resto da tela:
+            // quem tem acesso enxerga o que está no ar, e só quem tem o papel vê
+            // o caminho de publicar. É o WFM que separa os dois na prática —
+            // publica disponibilidade, não avisos.
+            gate('broadcast', 'bc-new-btn', 'bc-note',
+                'vê os avisos no ar, mas não publica neste módulo.');
+            gate('bau_availability', null, 'bau-note',
+                'vê a disponibilidade no ar, mas não publica neste módulo.');
+            document.getElementById('bau-editor').classList
+                .toggle('hidden', !podeEscrever('bau_availability'));
+        }
+
+        function abrirVerComo() {
+            google.script.run
+                .withSuccessHandler(function (r) { renderVerComo(r.roles || []); })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .listContentRoles();
+        }
+
+        function renderVerComo(papeis) {
+            var opcoes = papeis.map(function (p) {
+                return '<option value="' + esc(p.role) + '">' + esc(p.role) + '</option>';
+            }).join('');
+
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:440px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="vc-titulo">' +
+                '<h2 id="vc-titulo">Ver a Central como</h2>' +
+                '<p class="card-sub">A tela passa a mostrar o que esse papel mostraria. ' +
+                'Fica só de leitura — conferir não é decidir.</p>' +
+                '<label class="fld" for="vc-papel">Papel</label>' +
+                '<select id="vc-papel">' + opcoes + '</select>' +
+                '<label class="fld" for="vc-idioma">Idioma do conteúdo</label>' +
+                '<select id="vc-idioma">' +
+                '<option value="PT">Português</option><option value="ES">Español</option>' +
+                '</select>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
+                '<button class="btn btn-primary" id="vc-go">Ver assim</button>' +
+                '</div></div></div>';
+
+            document.getElementById('vc-idioma').value = idiomaAtual();
+            document.getElementById('vc-go').onclick = function () {
+                var papel = document.getElementById('vc-papel').value;
+                var idioma = document.getElementById('vc-idioma').value;
+                closeModal();
+                entrarNaPrevia(papel, idioma);
+            };
+        }
+
+        function entrarNaPrevia(papel, idioma) {
+            google.script.run
+                .withSuccessHandler(function (s) {
+                    SESSION = s;
+                    MODO_PREVIA = true;
+                    document.getElementById('lang-global').value = idioma;
+                    aplicarPermissoes(s);
+                    renderFaixaDePrevia(s);
+                    switchTab(DESTINOS[destinoDaURL()] ? destinoDaURL() : 'home');
+                    refreshContentLists();
+                })
+                .withFailureHandler(function (err) { toast(err.message, true); })
+                .previewContentSession(papel);
+        }
+
+        function sairDaPrevia() {
+            SESSION = SESSION_REAL;
+            MODO_PREVIA = false;
+            aplicarPermissoes(SESSION);
+            renderFaixaDePrevia(null);
+            switchTab(destinoDaURL());
+            refreshContentLists();
+        }
+
+        function renderFaixaDePrevia(s) {
+            var faixa = document.getElementById('faixa-previa');
+            faixa.classList.toggle('hidden', !s);
+            document.body.classList.toggle('em-previa', !!s);
+            if (!s) return;
+
+            // O que o papel pode e você não fica DITO. Uma prévia calada sobre o
+            // que omitiu faz concluir que o papel não pode algo que ele pode.
+            var alem = (s.beyond || []).length
+                ? ' <span class="faixa-nota">' + s.beyond.length +
+                  (s.beyond.length === 1 ? ' permissão desse papel não aparece' :
+                                           ' permissões desse papel não aparecem') +
+                  ' porque você mesmo não a tem.</span>'
+                : '';
+
+            faixa.innerHTML =
+                '<span class="material-symbols-rounded" aria-hidden="true">visibility</span>' +
+                '<span>Vendo a Central como <strong>' + esc(s.role) + '</strong>. ' +
+                'Somente leitura.' + alem + '</span>' +
+                '<button class="btn btn-ghost btn-sm" onclick="sairDaPrevia()">Voltar a ser ' +
+                esc(s.realRole) + '</button>';
+        }
+
         // --- Boot ---
         function boot() {
             google.script.run
                 .withSuccessHandler(function (s) {
                     SESSION = s;
+                    SESSION_REAL = s;
                     document.getElementById('boot-state').classList.add('hidden');
                     document.getElementById('user-ldap').textContent = s.ldap || '';
 
@@ -585,66 +749,11 @@
                         return;
                     }
 
-                    var badge = document.getElementById('user-role');
-                    badge.textContent = s.role;
-                    badge.classList.remove('hidden');
-
                     document.getElementById('app').classList.remove('hidden');
-                    if (s.canManageAccess) document.getElementById('tab-access').classList.remove('hidden');
-                    if (s.canManageRoles) document.getElementById('tab-roles').classList.remove('hidden');
-                    // Pessoas nem aparece para QA/WFM: no servidor, a leitura do
-                    // diretório é tão restrita quanto a escrita.
-                    if (canPropose('people')) {
-                        document.getElementById('tab-people').classList.remove('hidden');
-                    }
+                    aplicarPermissoes(s);
 
-                    // A caixa de aviso de alguns módulos nasce escondida: o
-                    // regime agora é dito pelo trilho, e prosa repetida é ruído.
-                    // A exceção é justamente esta — "você não pode editar isto"
-                    // é informação que só existe aqui, então tem que aparecer.
-                    function explicarSemPermissao(idNota, texto) {
-                        var nota = document.getElementById(idNota);
-                        nota.textContent = texto;
-                        nota.classList.remove('hidden');
-                    }
-
-                    if (!canPropose('links')) {
-                        document.getElementById('links-new-btn').classList.add('hidden');
-                        explicarSemPermissao('links-note',
-                            'Seu papel (' + s.role + ') vê os links, mas não propõe alterações neste módulo.');
-                    }
-                    if (!canPropose('call_script')) {
-                        document.getElementById('cs-new-btn').classList.add('hidden');
-                        explicarSemPermissao('cs-note',
-                            'Seu papel (' + s.role + ') vê o roteiro, mas não propõe alterações neste módulo.');
-                    }
-                    if (!canPropose('tips')) {
-                        document.getElementById('tp-new-btn').classList.add('hidden');
-                        explicarSemPermissao('tp-note',
-                            'Seu papel (' + s.role + ') vê as dicas, mas não propõe alterações neste módulo.');
-                    }
-                    if (!canPropose('email_template')) {
-                        explicarSemPermissao('em-note',
-                            'Seu papel (' + s.role + ') vê os modelos, mas não propõe alterações neste módulo.');
-                    }
-                    if (!canPropose('note_template')) {
-                        document.getElementById('nt-new-btn').classList.add('hidden');
-                        explicarSemPermissao('nt-note',
-                            'Seu papel (' + s.role + ') vê os modelos de nota, mas não propõe alterações neste módulo.');
-                    }
-                    // Avisos e disponibilidade seguem a mesma regra do resto da
-                    // tela: quem tem acesso enxerga o que está no ar, e só quem
-                    // tem o papel vê o caminho de publicar. É o WFM que separa
-                    // os dois na prática — publica disponibilidade, não avisos.
-                    if (!canPropose('broadcast')) {
-                        document.getElementById('bc-new-btn').classList.add('hidden');
-                        explicarSemPermissao('bc-note',
-                            'Seu papel (' + s.role + ') vê os avisos no ar, mas não publica neste módulo.');
-                    }
-                    if (!canPropose('bau_availability')) {
-                        document.getElementById('bau-editor').classList.add('hidden');
-                        explicarSemPermissao('bau-note',
-                            'Seu papel (' + s.role + ') vê a disponibilidade no ar, mas não publica neste módulo.');
+                    if (s.canManageRoles) {
+                        document.getElementById('btn-ver-como').classList.remove('hidden');
                     }
 
                     document.getElementById('rail').classList.remove('hidden');

--- a/gas-backend/ContentDashboard_Governance.html
+++ b/gas-backend/ContentDashboard_Governance.html
@@ -173,11 +173,16 @@
                             '<div class="diff-side new"><div class="diff-label">Proposto</div>' +
                             '<div class="diff-body">' + ladoDepois + '</div></div>' +
                             '</div>' + previa +
-                            '<div class="modal-actions" style="margin-top:8px">' +
-                            '<button class="btn btn-danger btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',false)">Rejeitar</button>' +
-                            '<button class="btn btn-success btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',true)"' +
-                            (d.canReview ? '' : ' disabled') + '>Aprovar e publicar</button>' +
-                            '</div></div>';
+                            // Em prévia a fila é para OLHAR. Quem está vendo como
+                            // outra pessoa não está decidindo, e a decisão sairia
+                            // no nome de quem clicou, não no do papel previsto.
+                            (MODO_PREVIA ? '' :
+                                '<div class="modal-actions" style="margin-top:8px">' +
+                                '<button class="btn btn-danger btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',false)">Rejeitar</button>' +
+                                '<button class="btn btn-success btn-sm" onclick="reviewDraft(\'' + d.draftId + '\',true)"' +
+                                (d.canReview ? '' : ' disabled') + '>Aprovar e publicar</button>' +
+                                '</div>') +
+                            '</div>';
                     }).join('');
                 })
                 .withFailureHandler(function (err) {
@@ -758,7 +763,7 @@
         };
 
         function loadRoles() {
-            if (!SESSION.canManageRoles) return;
+            if (!SESSION.canManageRoles || MODO_PREVIA) return;
 
             google.script.run
                 .withSuccessHandler(function (r) {
@@ -1058,6 +1063,9 @@
         function loadAccess() {
             if (!SESSION.canManageAccess) return;
 
+            // Conceder acesso é decisão; em prévia a aba é só a lista.
+            document.getElementById('acc-editor').classList.toggle('hidden', MODO_PREVIA);
+
             // Os papéis viraram dado: o seletor tem que perguntar quais existem
             // em vez de repetir uma lista que envelhece no primeiro papel novo.
             google.script.run
@@ -1089,9 +1097,10 @@
                             // fique sem ninguém que governe" (ADR-0009). Quem for
                             // o último a governar recebe o erro do servidor, que
                             // explica exatamente isso.
-                            '<button class="btn btn-ghost btn-sm" onclick="toggleAccess(\'' +
-                            esc(a.ldap) + '\',\'' + esc(a.role) + '\',' + (!a.active) + ')">' +
-                            (a.active ? 'Desativar' : 'Reativar') + '</button>' +
+                            (MODO_PREVIA ? '' :
+                                '<button class="btn btn-ghost btn-sm" onclick="toggleAccess(\'' +
+                                esc(a.ldap) + '\',\'' + esc(a.role) + '\',' + (!a.active) + ')">' +
+                                (a.active ? 'Desativar' : 'Reativar') + '</button>') +
                             '</div></div>';
                     }).join('');
                 })

--- a/gas-backend/ContentDashboard_Ops.html
+++ b/gas-backend/ContentDashboard_Ops.html
@@ -70,7 +70,7 @@
 
             summary.textContent = ordered.length + (ordered.length === 1 ? ' aviso publicado' : ' avisos publicados');
 
-            var podeEditar = canPropose('broadcast');
+            var podeEditar = podeEscrever('broadcast');
 
             host.innerHTML = ordered.map(function (it) {
                 var p = bcParse(it);

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -254,6 +254,36 @@
             overflow-wrap: anywhere;
         }
 
+        /* --- Faixa da prévia "ver como" --- */
+        .faixa-previa {
+            position: sticky;
+            top: 72px;
+            z-index: 90;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 24px;
+            background: var(--warning-light);
+            border-bottom: 1px solid var(--warning);
+            color: var(--warning-text);
+            font-size: 13px;
+        }
+
+        .faixa-previa .material-symbols-rounded { font-size: 20px; }
+        .faixa-previa > span:nth-of-type(2) { flex: 1; }
+        .faixa-previa .faixa-nota { opacity: 0.85; }
+
+        .faixa-previa .btn {
+            border-color: var(--warning);
+            color: var(--warning-text);
+        }
+
+        /* Com a faixa na tela, o trilho e a barra lateral começam mais abaixo:
+           são os dois elementos grudados no topo. */
+        body.em-previa .rail,
+        body.em-previa .lateral { top: 116px; }
+        body.em-previa .rail { height: calc(100vh - 116px); }
+
         /* --- Matriz de papéis --- */
         .rol-toolbar {
             display: flex;

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -249,6 +249,21 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             listContentActivity: () => ATIVIDADE,
             listContentRoles: () => matriz,
             listContentRoleNames: () => ['ADMIN', 'QA'],
+            previewContentSession: (papel) => {
+                // O servidor devolve a sessão do papel INTERSECTADA com a de
+                // quem pergunta, mais o que ficou de fora.
+                const base = papel === 'QA'
+                    ? {
+                        ldap: sessao.ldap, role: 'QA', hasAccess: true,
+                        canApprove: false, canManageAccess: false, canManageRoles: false,
+                        canViewAudit: false, canSelfApprove: false,
+                        proposableModules: ['call_script', 'note_template'],
+                    }
+                    : Object.assign({}, sessao, { role: papel });
+                return Object.assign(base, {
+                    preview: true, realRole: sessao.role, beyond: ['links.propose'],
+                });
+            },
             saveContentRole: (nome, permsJson, opcoes) => {
                 // O servidor devolve `confirm` até vir a declaração. O dublê
                 // repete esse contrato para o teste poder exercitar o diálogo.
@@ -1190,6 +1205,119 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         const opcoes = await page.locator('#acc-role option').evaluateAll(
             (os) => os.map(o => o.value));
         igual(opcoes, ['ADMIN', 'QA'], 'papéis no seletor');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------------------- ver como
+{
+    const page = await abrir({ sessao: 'qa' });
+
+    await check('quem não gerencia papéis não tem "ver como"', async () => {
+        igual(await page.locator('#btn-ver-como').isVisible(), false, 'botão para o QA');
+    });
+
+    await page.close();
+}
+
+{
+    const fila = [{
+        draftId: 'drf_9', module: 'tips', key: 'geral', label: 'Dica revisada',
+        proposedBy: 'anaflor', isSelfProposed: false, canReview: true,
+        currentValue: 'Confira o substatus antes de fechar.',
+        value: 'Confira o substatus antes de encerrar.',
+    }];
+    const page = await abrir({ sessao: 'admin', fila });
+
+    await check('o ADMIN tem "ver como", e ele abre a escolha de papel', async () => {
+        verdade(await page.locator('#btn-ver-como').isVisible(), 'o botão deveria aparecer');
+        await page.locator('#btn-ver-como').click();
+        await page.waitForTimeout(250);
+        verdade(await page.locator('#vc-papel').isVisible(), 'faltou o seletor de papel');
+    });
+
+    await check('entrar na prévia troca o papel mostrado e avisa em faixa', async () => {
+        await page.selectOption('#vc-papel', 'QA');
+        await page.locator('#vc-go').click();
+        await page.waitForTimeout(400);
+
+        verdade(await page.locator('#faixa-previa').isVisible(), 'a faixa deveria aparecer');
+        igual((await page.locator('#user-role').textContent()).trim(), 'QA', 'selo de papel');
+
+        const texto = await page.locator('#faixa-previa').textContent();
+        verdade(/Somente leitura/i.test(texto), 'faltou dizer que é só leitura');
+        // Prévia calada sobre o que omitiu faz concluir que o papel não pode
+        // algo que ele pode.
+        verdade(/não a tem|não aparecem/.test(texto),
+            'faltou dizer o que ficou de fora: ' + texto);
+    });
+
+    await check('vendo como QA, os botões que o QA não tem somem', async () => {
+        await page.evaluate(() => switchTab('links'));
+        await page.waitForTimeout(250);
+        igual(await page.locator('#links-new-btn').isVisible(), false, 'botão de novo link');
+    });
+
+    await check('e a fila de aprovação não oferece decidir', async () => {
+        await page.evaluate(() => switchTab('approvals'));
+        await page.waitForTimeout(300);
+        const texto = await page.locator('#approvals-list').textContent();
+        // O QA nem revisa: o painel explica isso em vez de mostrar a fila.
+        verdade(/não revisa/i.test(texto), 'o painel deveria explicar que o papel não revisa');
+        igual(await page.locator('#approvals-list .btn-success').count(), 0, 'botões de aprovar');
+    });
+
+    await check('nem mesmo vendo como um papel que revisa', async () => {
+        // O caso que importa: prever um papel que APROVA. A fila aparece
+        // inteira — é para isso que se está olhando —, mas decidir não. A
+        // decisão sairia no nome de quem clicou, não no do papel previsto.
+        await page.locator('#faixa-previa .btn').click();
+        await page.waitForTimeout(300);
+        await page.locator('#btn-ver-como').click();
+        await page.waitForTimeout(250);
+        await page.selectOption('#vc-papel', 'ADMIN');
+        await page.locator('#vc-go').click();
+        await page.waitForTimeout(400);
+
+        await page.evaluate(() => switchTab('approvals'));
+        await page.waitForTimeout(350);
+
+        verdade(/Dica revisada/.test(await page.locator('#approvals-list').textContent()),
+            'a fila deveria aparecer para um papel que revisa');
+        igual(await page.locator('#approvals-list .btn-success').count(), 0,
+            'aprovar não pode existir em prévia');
+        igual(await page.locator('#approvals-list .btn-danger').count(), 0,
+            'rejeitar não pode existir em prévia');
+    });
+
+    await check('e escrever também não, mesmo no papel que escreve tudo', async () => {
+        // Este é o caso que a prévia como QA não pega: o papel previsto PODE
+        // tudo, e é só o modo prévia que segura a mão.
+        await page.evaluate(() => switchTab('links'));
+        await page.waitForTimeout(300);
+        igual(await page.locator('#links-new-btn').isVisible(), false,
+            'novo link não pode aparecer em prévia');
+        const lista = await page.locator('#links-list').textContent();
+        igual(/Editar|Tirar do ar/.test(lista), false, 'nem Editar nem Tirar do ar');
+        // Histórico continua: olhar o passado de um item é leitura, e é
+        // justamente o tipo de coisa que se quer poder fazer numa conferência.
+        verdade(/Histórico/.test(lista), 'Histórico deveria continuar disponível');
+        // Editar permissão fingindo ser outra pessoa é como se perde a noção de
+        // quem fez o quê.
+        igual(await page.locator('#tab-roles').isVisible(), false, 'aba Papéis em prévia');
+    });
+
+    await check('sair da prévia devolve a tela de quem você é', async () => {
+        await page.locator('#faixa-previa .btn').click();
+        await page.waitForTimeout(400);
+
+        igual(await page.locator('#faixa-previa').isVisible(), false, 'a faixa deveria sumir');
+        igual((await page.locator('#user-role').textContent()).trim(), 'ADMIN');
+        await page.evaluate(() => switchTab('links'));
+        await page.waitForTimeout(250);
+        verdade(await page.locator('#links-new-btn').isVisible(), 'o botão deveria voltar');
+        verdade(await page.locator('#tab-roles').isVisible(), 'a aba Papéis deveria voltar');
     });
 
     await page.close();

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -177,6 +177,7 @@ function eq(a, b, m) {
   const A = JSON.stringify(a), B = JSON.stringify(b);
   if (A !== B) throw new Error((m || '') + ' esperado ' + B + ', veio ' + A);
 }
+function verdadeiro(cond, m) { if (!cond) throw new Error(m || 'esperado verdadeiro'); }
 function throws(fn, re, m) {
   try { fn(); } catch (e) {
     if (re && !re.test(e.message)) throw new Error((m || '') + ' erro inesperado: ' + e.message);
@@ -1962,6 +1963,58 @@ check('uma linha quebrada não derruba os outros papéis', () => {
 
   aba._data[alvo][1] = guardado;
   api.invalidateContentPermsCache_();
+});
+
+console.log('\n--- Ver como: a prévia nunca concede ---');
+
+check('só quem gerencia papéis pode ver como outro', () => {
+  as('quality1', () => throws(() => api.previewContentSession('ADMIN'), /Acesso negado/));
+});
+
+check('a prévia devolve a sessão do papel escolhido', () => {
+  const p = api.previewContentSession('QA');
+  eq(p.role, 'QA');
+  eq(p.preview, true);
+  eq(p.realRole, 'ADMIN', 'a prévia diz de quem ela é:');
+  eq(p.ldap, 'lucaste', 'a identidade real não muda:');
+  eq(p.proposableModules, ['call_script', 'note_template']);
+  eq(p.canManageAccess, false);
+});
+
+check('a prévia é INTERSECTADA com quem pergunta — nunca amplia', () => {
+  // Um papel que governa mas não toca no catálogo. É o caso que importa:
+  // ver como ADMIN, sendo ele, não pode virar um caminho para agir como ADMIN.
+  const gov = api.normalizeRoleMatrix_({ modules: {}, global: {} });
+  gov.global.manageRoles = true;
+  gov.global.manageAccess = true;
+  gov.modules.links.view = true;
+  eq(api.saveContentRole('GOV', gov, {}).status, 'success');
+  api.saveContentAccess('gov1', 'GOV', true);
+
+  as('gov1', () => {
+    const p = api.previewContentSession('ADMIN');
+    eq(p.role, 'ADMIN', 'o rótulo é o do papel previsto:');
+    // ...mas nada do poder que gov1 não tem atravessa.
+    eq(p.proposableModules, [], 'a prévia não deu escrita nenhuma:');
+    eq(p.canSelfApprove, false, 'nem aprovar a si mesmo:');
+    eq(p.canApprove, false);
+    verdadeiro(p.beyond.length > 0, 'o que ficou de fora precisa ser dito');
+    verdadeiro(p.beyond.indexOf('links.propose') !== -1,
+      'links.propose deveria estar no que ficou de fora: ' + p.beyond.join(','));
+  });
+});
+
+check('a prévia não é caminho de escrita: o servidor segue julgando quem clicou', () => {
+  as('gov1', () => {
+    api.previewContentSession('ADMIN');
+    // Mesmo "sendo ADMIN" na tela, escrever continua sendo recusado.
+    throws(() => api.saveContentDraft({ module: 'links', key: 'tech', label: 'X', value: '{}' }),
+      /não edita o módulo/);
+  });
+});
+
+check('papel inexistente na prévia é recusado', () => {
+  throws(() => api.previewContentSession('NAOEXISTE'), /Papel desconhecido/);
 });
 
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -100,6 +100,7 @@ o porquê em `docs/decisions/0009-rbac-editavel-da-central.md`.
 | :--- | :--- | :--- | :--- |
 | `listContentRoleNames()` | — | `manageAccess` | `["ADMIN", "QA", …]` — só os nomes, para o seletor da aba Acessos |
 | `listContentRoles()` | — | `manageRoles` | `{ roles: [{ role, permissions, people, escalation }], modules, moduleActions, globalPerms, actionsByModule, approvalRequiresGlobal, fallback }` |
+| `previewContentSession(role)` | — | `manageRoles` | A mesma forma de `getContentSession()`, mais `preview: true`, `realRole` e `beyond` |
 | `saveContentRole(role, permissions, options)` | `options`: `{ active?, confirmEscalation?, confirmSelf? }` | `manageRoles` | `{ status: 'success', role, changes, reloadSession }` **ou** `{ status: 'confirm', reason, message, changes, modules? }` |
 
 ### Regras
@@ -116,6 +117,17 @@ o porquê em `docs/decisions/0009-rbac-editavel-da-central.md`.
 - **`fallback: true`** em `listContentRoles()` significa que a aba não pôde ser
   lida e a matriz mostrada é o preset do código. A tela precisa dizer isso —
   editar em cima de um fallback é editar no escuro.
+- **A prévia nunca concede.** `previewContentSession()` devolve a matriz do
+  papel escolhido **intersectada com a de quem pergunta**. Prévia que amplia é
+  escalação com outro nome: o servidor continua julgando pela identidade real,
+  então uma tela otimista ofereceria botões que falham — ou, pior, botões que
+  funcionam enquanto a pessoa acredita estar "só olhando". `beyond` lista o que
+  o papel tem e quem pergunta não, para a tela poder dizer o que não mostrou;
+  prévia calada sobre a própria omissão faz concluir que o papel não pode algo
+  que ele pode.
+- **A prévia é de leitura, e isso é decisão da tela.** O servidor não tem como
+  saber que um clique veio "de dentro de uma prévia" — a identidade é a mesma.
+  Por isso a Central esconde toda ação de escrita enquanto a faixa está na tela.
 - **Conceder acesso não exige editar papéis.** `listContentRoleNames()` existe
   separado por isso: preencher um `<select>` não pode obrigar a dar a permissão
   maior para fazer a tarefa menor.


### PR DESCRIPTION
## O que muda

Primeira entrega da fase 5. Um botão **"Ver como"** no header: escolhe-se um papel e um idioma, e a Central inteira passa a mostrar o que aquela pessoa veria — o trilho, os botões, as caixas de "seu papel não edita isto".

## Por que assim

**A fase 4 deixou uma pergunta sem resposta.** Você agora edita permissões numa matriz de checkboxes. Mas ler uma linha de checkboxes e imaginar a tela resultante é o tipo de tradução em que se erra sem perceber — e o erro só aparece dias depois, quando alguém reclama que não consegue trabalhar. Conferir tinha que ser possível sem pedir o notebook de um QA emprestado.

**A prévia nunca concede.** `previewContentSession()` devolve a matriz do papel escolhido **intersectada com a de quem pergunta**. Isso não é excesso de zelo: o servidor continua julgando pela identidade real, então uma tela otimista ou ofereceria botões que falham, ou — pior — botões que **funcionam** enquanto a pessoa acredita estar só olhando. Com a interseção, toda casa que a prévia mostra corresponde a um poder que quem pediu de fato tem.

**E o que ela omitiu fica dito.** A faixa diz *"3 permissões desse papel não aparecem porque você mesmo não a tem"*. Prévia calada sobre a própria omissão é pior que prévia nenhuma: leva a concluir que o papel não pode algo que ele pode.

**Só de leitura, e essa decisão é da tela.** O servidor não tem como saber que um clique veio "de dentro de uma prévia" — a identidade é a mesma. Então é a Central que esconde toda ação de escrita enquanto a faixa está lá. Conferir não é decidir, e uma decisão tomada de dentro da prévia sairia no nome de quem clicou, não no do papel previsto. **Histórico continua disponível**: olhar o passado de um item é leitura, e é justamente o tipo de coisa que se quer poder fazer numa conferência.

**A aba Papéis some durante a prévia.** Editar permissão fingindo ser outra pessoa é como se perde a noção de quem fez o quê.

### Um refactor que a feature exigiu

O bloco de permissões do `boot()` virou `aplicarPermissoes(s)`. Era um trecho inline que rodava uma vez só; a prévia precisa reaplicá-lo com outra sessão. Junto veio `podeEscrever(module)` — `canPropose(module) && !MODO_PREVIA` —, que é o ponto único por onde os renderizadores decidem mostrar uma ação.

## Como verificar

```
npm run test:content    # 142 testes (eram 137)
npm run smoke:content   # 77 verificações (eram 70)
```

```
--- servidor ---
✓ só quem gerencia papéis pode ver como outro
✓ a prévia é INTERSECTADA com quem pergunta — nunca amplia
✓ a prévia não é caminho de escrita: o servidor segue julgando quem clicou
✓ papel inexistente na prévia é recusado

--- tela ---
✓ quem não gerencia papéis não tem "ver como"
✓ entrar na prévia troca o papel mostrado e avisa em faixa
✓ vendo como QA, os botões que o QA não tem somem
✓ nem mesmo vendo como um papel que revisa
✓ e escrever também não, mesmo no papel que escreve tudo
✓ sair da prévia devolve a tela de quem você é
```

**As mutações acharam um buraco real no meu próprio teste.** As duas primeiras versões de "em prévia a tela fica de leitura" previam como **QA** — um papel que já não pode aquilo. Desligar `MODO_PREVIA` não quebrava nada, porque o botão estava escondido pelo motivo errado. O teste que vale é o que prevê como **ADMIN**: o papel previsto pode tudo, e é só o modo prévia que segura a mão. Com isso, quatro mutações passaram a falhar como devem (bloqueio de escrita, ações da fila, o aviso do que foi omitido, e a aba Papéis).

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

**Conferido renderizado:** vendo como QA, o selo do header vira `QA`, a faixa amarela diz "Somente leitura" e conta as 3 permissões omitidas, a caixa "Seu papel (QA) vê os links, mas não propõe alterações neste módulo" aparece, Editar e Tirar do ar somem, Histórico fica, e o trilho perde Pessoas, Papéis e Acessos.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente.

## Checklist

- [x] Mexi em `gas-backend/`: `previewContentSession()` entrou em `specs/data-models/api-payloads.md`, com as duas regras que a definem (nunca amplia; a leitura é decisão da tela porque o servidor não distingue o clique).
- [x] Regra de negócio: nenhuma nova. A prévia não pode conceder nada — é literalmente uma interseção com o que já existe.
- [x] Decisão que alguém vai questionar depois: "por que interseção e não a matriz do papel" está comentado no ponto exato do código e na spec.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_