### PR TITLE
feat(central): aviso pode nascer agendado e morrer sozinho

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Aviso com hora: agendamento e validade** (fase 5). Um aviso pode nascer
+  agendado e morrer sozinho. Sem isso, *"avisar a operação às 8h de segunda"*
+  era alguém acordar e clicar, e *"tirar quando a instabilidade acabar"* era
+  alguém lembrar — e o aviso que ninguém lembra de tirar continua na tela do
+  agente dizendo que um problema resolvido há três dias está acontecendo agora.
+  Aviso velho não é ruído neutro: ele ensina o agente a ignorar avisos. As duas
+  pontas são opcionais (sem início já vale, sem fim não expira), então ligar
+  isto não muda nenhum aviso existente. A janela é avaliada **no servidor, no
+  horário de Brasília**, e a tela diz isso — a operação atende fusos diferentes,
+  e três relógios implícitos são piores que um declarado. A lista da Central
+  marca cada aviso com o seu estado, e a confirmação de publicação passou a
+  declarar **quando**, não só para quem.
 - **"Ver como": conferir a Central pelos olhos de outro papel** (fase 5). Quem
   edita a matriz de permissões precisa poder verificar o que configurou — ler
   uma linha de checkboxes e imaginar a tela resultante é o tipo de tradução em

--- a/PLAN.md
+++ b/PLAN.md
@@ -82,8 +82,11 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       mostrar o que aquele papel veria, de leitura, com a prévia intersectada no
       servidor (prévia que concede é escalação com outro nome) e dizendo na
       faixa o que deixou de mostrar.
-      **Falta:** prévia "como o agente vê"; busca global Ctrl+K; agendamento e
-      validade de aviso; cobrança diária de pendência parada — esta lendo
+      **Entregue também:** agendamento e validade de aviso — janela avaliada no
+      servidor, no fuso da planilha, e filtrada DEPOIS do cache (dentro dele a
+      janela teria a precisão do cache em vez da sua própria).
+      **Falta:** prévia "como o agente vê"; busca global Ctrl+K;
+      cobrança diária de pendência parada — esta lendo
       `CW_DEPLOYMENTS` e não a URL do serviço, porque em gatilho de tempo a
       derivação não é confiável (ver `Código.js`). **PR final:** aba de
       auditoria restrita, com filtros, paginação e exportação.

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -1037,6 +1037,68 @@ function checkEmailTemplate(rawValue, lang) {
 
 const BROADCAST_TYPES = ['info', 'critical', 'success'];
 
+// Janela de exibição: um aviso pode nascer agendado e morrer sozinho.
+//
+// Sem isto, "avisar a operação às 8h de segunda" é alguém acordar e clicar, e
+// "tirar quando acabar a instabilidade" é alguém lembrar — e o aviso que
+// ninguém lembra de tirar continua na tela do agente dizendo que um problema
+// resolvido há três dias está acontecendo agora. Aviso velho não é ruído
+// neutro: ele ensina o agente a ignorar avisos.
+const CONTENT_WINDOWED_MODULES = ['broadcast'];
+
+// `YYYY-MM-DDTHH:MM`, que é exatamente o que um <input type="datetime-local">
+// produz. Sem fuso na string de propósito — ver janelaAgora_().
+const CONTENT_WINDOW_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+/**
+ * O "agora" com que a janela é comparada.
+ *
+ * A janela é avaliada NO SERVIDOR, no fuso da planilha (America/São Paulo), e
+ * não no relógio de quem lê. A operação atende PT e ES em fusos diferentes: se
+ * cada navegador decidisse, "vai ao ar às 8h" seria um horário diferente para
+ * cada agente, e quem publicou não teria como saber qual. Um relógio só,
+ * declarado na tela, é mais honesto que três relógios implícitos.
+ *
+ * Comparação como TEXTO: as duas pontas estão no formato `YYYY-MM-DDTHH:MM`,
+ * onde a ordem alfabética é a ordem cronológica. Isso evita a armadilha de
+ * `new Date('2026-09-05T08:00')`, cujo fuso de interpretação muda conforme o
+ * ambiente.
+ */
+function janelaAgora_() {
+  return Utilities.formatDate(
+    new Date(),
+    Session.getScriptTimeZone ? Session.getScriptTimeZone() : 'America/Sao_Paulo',
+    "yyyy-MM-dd'T'HH:mm"
+  );
+}
+
+/** `{ startsAt, endsAt }` de um item, ou vazio quando o módulo não tem janela. */
+function janelaDoItem_(item) {
+  if (CONTENT_WINDOWED_MODULES.indexOf(String(item.module || "").trim()) === -1) return {};
+
+  let v;
+  try { v = JSON.parse(String(item.value || "{}")); } catch (e) { return {}; }
+
+  return {
+    startsAt: CONTENT_WINDOW_RE.test(String(v.startsAt || "")) ? String(v.startsAt) : "",
+    endsAt: CONTENT_WINDOW_RE.test(String(v.endsAt || "")) ? String(v.endsAt) : ""
+  };
+}
+
+/**
+ * O item está dentro da janela agora?
+ *
+ * Ausência de ponta é ausência de restrição: sem `startsAt` já vale, sem
+ * `endsAt` não expira. É o comportamento de todo aviso que existe hoje, e é o
+ * que garante que ligar esta feature não apague nada.
+ */
+function itemNaJanela_(item, agora) {
+  const j = janelaDoItem_(item);
+  if (j.startsAt && agora < j.startsAt) return false;
+  if (j.endsAt && agora >= j.endsAt) return false;
+  return true;
+}
+
 // Um aviso é um registro composto num `Value` só, no mesmo padrão já usado por
 // email_template e note_template. O que a validação garante é o que a tela do
 // agente assume sem checar: tipo conhecido, título e texto presentes.
@@ -1059,6 +1121,21 @@ function assertValidBroadcast_(rawValue) {
 
   if (!String(parsed.title || "").trim()) throw new Error("O aviso precisa de um título.");
   if (!String(parsed.text || "").trim()) throw new Error("O aviso precisa de uma mensagem.");
+
+  const inicio = String(parsed.startsAt || "").trim();
+  const fim = String(parsed.endsAt || "").trim();
+
+  if (inicio && !CONTENT_WINDOW_RE.test(inicio)) {
+    throw new Error("Data de início inválida. Use o formato AAAA-MM-DDTHH:MM.");
+  }
+  if (fim && !CONTENT_WINDOW_RE.test(fim)) {
+    throw new Error("Data de fim inválida. Use o formato AAAA-MM-DDTHH:MM.");
+  }
+  // Uma janela invertida não é um aviso "que ninguém vê": é um aviso que a
+  // pessoa acredita ter publicado. Recusar é a única forma de ela descobrir.
+  if (inicio && fim && fim <= inicio) {
+    throw new Error("O fim do aviso precisa vir depois do início.");
+  }
 
   return parsed;
 }
@@ -2663,7 +2740,16 @@ function readPublicModuleItems_(module) {
     throw new Error("Módulo '" + module + "' não tem leitura pública.");
   }
 
-  return readLiveItemsCached_(module);
+  const itens = readLiveItemsCached_(module);
+  if (CONTENT_WINDOWED_MODULES.indexOf(module) === -1) return itens;
+
+  // O filtro vem DEPOIS do cache, não dentro dele. Dentro, um aviso agendado
+  // para as 10h ficaria de fora da entrada gravada às 9h58 e só apareceria
+  // quando o TTL expirasse — a janela passaria a ter a precisão do cache em vez
+  // da sua própria. Assim o cache guarda "o que está publicado" e a janela
+  // decide "o que vale agora", que são perguntas diferentes.
+  const agora = janelaAgora_();
+  return itens.filter(function (it) { return itemNaJanela_(it, agora); });
 }
 
 // =========================================================

--- a/gas-backend/ContentDashboard_Ops.html
+++ b/gas-backend/ContentDashboard_Ops.html
@@ -22,11 +22,16 @@
                     type: p.type || 'info',
                     title: p.title || item.label || '',
                     text: p.text || '',
+                    startsAt: p.startsAt || '',
+                    endsAt: p.endsAt || '',
                     publishedAt: p.publishedAt || item.publishedAt || '',
                     author: p.author || item.publishedBy || ''
                 };
             } catch (e) {
-                return { type: 'info', title: item.label || '(ilegível)', text: '', publishedAt: '', author: '', broken: true };
+                return {
+                    type: 'info', title: item.label || '(ilegível)', text: '',
+                    startsAt: '', endsAt: '', publishedAt: '', author: '', broken: true
+                };
             }
         }
 
@@ -86,6 +91,12 @@
                     ? ' · ' + esc(BC_LANG_LABEL[it.lang] || it.lang)
                     : '';
 
+                // A Central mostra TODOS os avisos publicados, inclusive os que
+                // o agente ainda não vê ou já não vê mais. Sem o selo, um aviso
+                // agendado pareceria estar no ar e um vencido pareceria vigente
+                // — e a lista deixaria de responder "o que o agente está vendo".
+                var estado = estadoDaJanela(p);
+
                 // O texto vai truncado: a lista é para reconhecer o aviso, não
                 // para ler. O texto inteiro está a um clique, no editor.
                 var preview = p.text.replace(/\s+/g, ' ').slice(0, 120);
@@ -95,12 +106,41 @@
                     '<div class="item-main">' +
                     '<div class="item-name">' + esc(p.title) +
                     ' <span class="pill type-' + esc(p.type) + '">' +
-                    esc(BC_TYPE_LABEL[p.type] || p.type) + '</span></div>' +
+                    esc(BC_TYPE_LABEL[p.type] || p.type) + '</span>' + estado + '</div>' +
                     '<div class="item-meta">' + esc(preview) + '</div>' +
                     '<div class="item-meta">por ' + esc(p.author || it.publishedBy || '—') +
                     ' em ' + esc(bcFormatDate(p.publishedAt)) + segmento + '</div>' +
                     '</div>' + actions + '</div>';
             }).join('');
+        }
+
+        // Mesma conta do servidor (itemNaJanela_), e pelo mesmo motivo de sempre:
+        // aqui ela existe para APARECER, não para decidir. Quem decide o que o
+        // agente recebe é a leitura pública.
+        //
+        // Comparação como texto: as duas pontas estão em `YYYY-MM-DDTHH:MM`,
+        // onde a ordem alfabética é a ordem cronológica — e assim a tela não
+        // reinterpreta a data num fuso diferente do que o servidor usou.
+        function agoraLocalISO() {
+            var d = new Date();
+            var dois = function (n) { return String(n).padStart(2, '0'); };
+            return d.getFullYear() + '-' + dois(d.getMonth() + 1) + '-' + dois(d.getDate()) +
+                'T' + dois(d.getHours()) + ':' + dois(d.getMinutes());
+        }
+
+        function estadoDaJanela(p) {
+            var agora = agoraLocalISO();
+            if (p.startsAt && agora < p.startsAt) {
+                return ' <span class="estado estado-espera">agendado para ' +
+                    esc(bcFormatDate(p.startsAt)) + '</span>';
+            }
+            if (p.endsAt && agora >= p.endsAt) {
+                return ' <span class="estado">saiu do ar em ' + esc(bcFormatDate(p.endsAt)) + '</span>';
+            }
+            if (p.endsAt) {
+                return ' <span class="estado">sai em ' + esc(bcFormatDate(p.endsAt)) + '</span>';
+            }
+            return '';
         }
 
         function openBroadcastEditor(itemId) {
@@ -145,6 +185,22 @@
                 '<label class="fld" for="bc-text">Mensagem</label>' +
                 '<textarea id="bc-text" style="min-height:130px" ' +
                 'placeholder="O que aconteceu, o que o agente deve fazer e até quando.">' + esc(p.text) + '</textarea>' +
+                '<div class="grid-2" style="margin-top:6px">' +
+                '<div>' +
+                '<label class="fld" for="bc-inicio">Começa a aparecer (opcional)</label>' +
+                '<input type="datetime-local" id="bc-inicio" value="' + esc(p.startsAt || '') + '">' +
+                '</div>' +
+                '<div>' +
+                '<label class="fld" for="bc-fim">Sai do ar (opcional)</label>' +
+                '<input type="datetime-local" id="bc-fim" value="' + esc(p.endsAt || '') + '">' +
+                '</div>' +
+                '</div>' +
+                // Um relógio só, declarado. A operação atende PT e ES em fusos
+                // diferentes: se cada navegador decidisse, "às 8h" seria um
+                // horário diferente para cada agente e quem publicou não teria
+                // como saber qual.
+                '<p class="card-sub" style="margin-top:6px">Horário de Brasília. ' +
+                'Deixar em branco significa "já vale" e "não expira".</p>' +
                 '<div class="modal-actions">' +
                 '<button class="btn btn-ghost" onclick="closeModal()">Cancelar</button>' +
                 '<button class="btn btn-primary" id="bc-save">' +
@@ -163,21 +219,40 @@
             return 'todos os agentes, de todos os segmentos';
         }
 
+        // "Vai ao ar agora" e "vai ao ar segunda às 8h" são publicações
+        // diferentes, e a confirmação que declara o alcance também tem que
+        // declarar o quando — senão ela afirma uma coisa que pode não acontecer.
+        function descreverJanela(inicio, fim) {
+            if (!inicio && !fim) return 'Vai ao ar agora e fica até alguém tirar.';
+            if (inicio && fim) return 'Aparece em ' + bcFormatDate(inicio) + ' e sai em ' + bcFormatDate(fim) + '.';
+            if (inicio) return 'Só aparece a partir de ' + bcFormatDate(inicio) + '.';
+            return 'Vai ao ar agora e sai sozinho em ' + bcFormatDate(fim) + '.';
+        }
+
         function submitBroadcast(item, btn) {
             var title = document.getElementById('bc-title').value.trim();
             var text = document.getElementById('bc-text').value.trim();
+            var inicio = document.getElementById('bc-inicio').value;
+            var fim = document.getElementById('bc-fim').value;
 
             if (!title) return toast('Dê um título ao aviso.', true);
             if (!text) return toast('Escreva a mensagem do aviso.', true);
+            // Recusado no servidor de qualquer jeito; aqui é só para o erro
+            // aparecer com o texto ainda em tela.
+            if (inicio && fim && fim <= inicio) {
+                return toast('O fim do aviso precisa vir depois do início.', true);
+            }
+
+            var janela = { inicio: inicio, fim: fim };
 
             confirmarPublicacao(
                 alcanceDoSegmento(document.getElementById('bc-lang').value),
-                title,
-                function () { publicarBroadcast(item, btn, title, text); }
+                title + ' — ' + descreverJanela(inicio, fim),
+                function () { publicarBroadcast(item, btn, title, text, janela); }
             );
         }
 
-        function publicarBroadcast(item, btn, title, text) {
+        function publicarBroadcast(item, btn, title, text, janela) {
             var rotulo = btn.textContent;
             btn.disabled = true;
             btn.textContent = 'Publicando…';
@@ -204,6 +279,8 @@
                         type: document.getElementById('bc-type').value,
                         title: title,
                         text: text,
+                        startsAt: janela.inicio,
+                        endsAt: janela.fim,
                         publishedAt: new Date().toISOString(),
                         author: SESSION.ldap
                     })

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -162,7 +162,43 @@ const ITENS = {
         value: 'Confira o substatus antes de fechar.',
     }],
     call_script: [], email_template: [], note_template: [],
-    broadcast: [], bau_availability: [], people: [],
+    // Três avisos que cobrem os três estados da janela: um vigente para sempre,
+    // um agendado e um vencido. É o que faz a lista da Central ter o que dizer.
+    broadcast: [
+        {
+            id: 'itm_bc1', module: 'broadcast', key: 'bc1', field: '', lang: 'ALL',
+            label: 'Instabilidade no CRM', version: 1, status: 'live',
+            publishedBy: 'lucaste', publishedAt: '2026-09-01T10:00:00Z', sortOrder: 0,
+            lineage: 'itm_bc1',
+            value: JSON.stringify({
+                type: 'critical', title: 'Instabilidade no CRM', text: 'O CRM está lento.',
+                publishedAt: '2026-09-01T10:00:00Z', author: 'lucaste',
+            }),
+        },
+        {
+            id: 'itm_bc2', module: 'broadcast', key: 'bc2', field: '', lang: 'ALL',
+            label: 'Manutenção de segunda', version: 1, status: 'live',
+            publishedBy: 'lucaste', publishedAt: '2026-09-01T10:00:00Z', sortOrder: 1,
+            lineage: 'itm_bc2',
+            value: JSON.stringify({
+                type: 'info', title: 'Manutenção de segunda', text: 'Sistema fora das 2h às 4h.',
+                startsAt: '2099-01-05T08:00', endsAt: '2099-01-05T12:00',
+                publishedAt: '2026-09-01T10:00:00Z', author: 'lucaste',
+            }),
+        },
+        {
+            id: 'itm_bc3', module: 'broadcast', key: 'bc3', field: '', lang: 'ALL',
+            label: 'Fila priorizada', version: 1, status: 'live',
+            publishedBy: 'lucaste', publishedAt: '2026-09-01T10:00:00Z', sortOrder: 2,
+            lineage: 'itm_bc3',
+            value: JSON.stringify({
+                type: 'success', title: 'Fila priorizada', text: 'Criação priorizada até quinta.',
+                startsAt: '2020-01-01T08:00', endsAt: '2020-01-02T08:00',
+                publishedAt: '2026-09-01T10:00:00Z', author: 'lucaste',
+            }),
+        },
+    ],
+    bau_availability: [], people: [],
 };
 
 // Duas versões do mesmo link: é o mínimo para provar que a versão arquivada
@@ -1318,6 +1354,83 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         await page.waitForTimeout(250);
         verdade(await page.locator('#links-new-btn').isVisible(), 'o botão deveria voltar');
         verdade(await page.locator('#tab-roles').isVisible(), 'a aba Papéis deveria voltar');
+    });
+
+    await page.close();
+}
+
+// ---------------------------------------------- aviso com hora (janela)
+{
+    const page = await abrir({ sessao: 'admin', hash: '#/broadcast' });
+
+    await check('a lista distingue vigente, agendado e vencido', async () => {
+        await page.waitForTimeout(300);
+        const texto = await page.locator('#bc-list').textContent();
+        // Sem os selos, um aviso agendado pareceria estar no ar e um vencido
+        // pareceria vigente: a lista deixaria de responder "o que o agente vê".
+        verdade(/agendado para/.test(texto), 'faltou o selo do agendado: ' + texto.slice(0, 200));
+        verdade(/saiu do ar em/.test(texto), 'faltou o selo do vencido');
+    });
+
+    await check('o editor oferece começar e sair de cena', async () => {
+        await page.evaluate(() => openBroadcastEditor(null));
+        await page.waitForTimeout(250);
+        igual(await page.locator('#bc-inicio').getAttribute('type'), 'datetime-local');
+        igual(await page.locator('#bc-fim').getAttribute('type'), 'datetime-local');
+        // Um relógio só, declarado: a operação atende fusos diferentes.
+        verdade(/Brasília/.test(await page.locator('.modal').textContent()),
+            'faltou dizer de que relógio se está falando');
+    });
+
+    await check('o editor traz a janela que o aviso já tem', async () => {
+        await page.evaluate(() => openBroadcastEditor('itm_bc2'));
+        await page.waitForTimeout(250);
+        igual(await page.locator('#bc-inicio').inputValue(), '2099-01-05T08:00');
+        igual(await page.locator('#bc-fim').inputValue(), '2099-01-05T12:00');
+    });
+
+    await check('a confirmação declara o QUANDO, não só o alcance', async () => {
+        await page.evaluate(() => openBroadcastEditor(null));
+        await page.waitForTimeout(250);
+        await page.fill('#bc-title', 'Manutenção');
+        await page.fill('#bc-text', 'Sistema fora do ar.');
+        await page.fill('#bc-inicio', '2099-03-01T08:00');
+        await page.locator('#bc-save').click();
+        await page.waitForTimeout(300);
+
+        const texto = await page.locator('#pub-titulo').locator('..').textContent();
+        // "Vai ao ar agora" e "vai ao ar em março" são publicações diferentes:
+        // uma confirmação que só declara o alcance afirma o que pode não ocorrer.
+        verdade(/Só aparece a partir de/.test(texto),
+            'a confirmação deveria dizer quando: ' + texto.slice(0, 200));
+    });
+
+    await check('a janela viaja no valor publicado', async () => {
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#pub-sim').click();
+        await page.waitForTimeout(400);
+
+        const chamada = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'publishContentDirect')[0]);
+        const valor = JSON.parse(chamada.args[0].value);
+        igual(valor.startsAt, '2099-03-01T08:00');
+        igual(valor.endsAt, '', 'sem fim é "não expira", e vai vazio mesmo');
+    });
+
+    await check('janela invertida é barrada antes de sair da tela', async () => {
+        await page.evaluate(() => openBroadcastEditor(null));
+        await page.waitForTimeout(250);
+        await page.fill('#bc-title', 'Errado');
+        await page.fill('#bc-text', 'Texto.');
+        await page.fill('#bc-inicio', '2099-03-02T08:00');
+        await page.fill('#bc-fim', '2099-03-01T08:00');
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#bc-save').click();
+        await page.waitForTimeout(300);
+
+        igual(await page.locator('#pub-titulo').count(), 0, 'nem deveria chegar à confirmação');
+        verdade(/depois do início/.test(await page.locator('#toast').textContent()),
+            'faltou explicar por quê');
     });
 
     await page.close();

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -85,6 +85,19 @@ class FakeSpreadsheet {
 }
 
 // ---- Ambiente ----
+
+// `Utilities` do Apps Script, só o que o módulo usa. `formatDate` entrou com a
+// janela de exibição dos avisos: ela compara horários como TEXTO no fuso da
+// planilha, e o teste precisa de um relógio previsível.
+const UTILITIES_STUB = {
+  getUuid: () => require('node:crypto').randomUUID(),
+  formatDate: (d, tz, fmt) => {
+    const dois = (n) => String(n).padStart(2, '0');
+    return d.getFullYear() + '-' + dois(d.getMonth() + 1) + '-' + dois(d.getDate()) +
+      'T' + dois(d.getHours()) + ':' + dois(d.getMinutes());
+  }
+};
+
 let CURRENT_USER = 'lucaste@google.com';
 const SS = new FakeSpreadsheet();
 const SENT_MAIL = [];
@@ -118,10 +131,10 @@ const sandbox = {
     })
   },
   SpreadsheetApp: { getActiveSpreadsheet: () => SS },
-  Session: { getActiveUser: () => ({ getEmail: () => CURRENT_USER }) },
+  Session: { getActiveUser: () => ({ getEmail: () => CURRENT_USER }), getScriptTimeZone: () => 'America/Sao_Paulo' },
   MailApp: { sendEmail: (o) => SENT_MAIL.push(o) },
   Logger: { log: (m) => LOGGER.push(m) },
-  Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+  Utilities: UTILITIES_STUB,
   handleLog: (p) => LOGGED.push(p),
   console,
 };
@@ -438,10 +451,10 @@ check('seedLinksNow() popula o módulo numa planilha zerada', () => {
   const freshSS = new FakeSpreadsheet();
   const freshCtx = vm.createContext({
     SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
-    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }), getScriptTimeZone: () => 'America/Sao_Paulo' },
     MailApp: { sendEmail: () => { } },
     Logger: { log: () => { } },
-    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    Utilities: UTILITIES_STUB,
     handleLog: () => { },
     console,
   });
@@ -478,10 +491,10 @@ check('seedCallScriptNow() popula o roteiro numa planilha zerada', () => {
   const freshSS = new FakeSpreadsheet();
   const freshCtx = vm.createContext({
     SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
-    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }), getScriptTimeZone: () => 'America/Sao_Paulo' },
     MailApp: { sendEmail: () => { } },
     Logger: { log: () => { } },
-    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    Utilities: UTILITIES_STUB,
     handleLog: () => { },
     console,
   });
@@ -541,10 +554,10 @@ function makeTipsEnv(linhas) {
 
   const ctx2 = vm.createContext({
     SpreadsheetApp: { getActiveSpreadsheet: () => ss },
-    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }), getScriptTimeZone: () => 'America/Sao_Paulo' },
     MailApp: { sendEmail: () => { } },
     Logger: { log: () => { } },
-    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    Utilities: UTILITIES_STUB,
     handleLog: () => { },
     SHEET_TIPS: 'Tips',
     console,
@@ -728,10 +741,10 @@ check('seedEmailsNow() popula os modelos numa planilha zerada', () => {
   const freshSS = new FakeSpreadsheet();
   const freshCtx = vm.createContext({
     SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
-    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }), getScriptTimeZone: () => 'America/Sao_Paulo' },
     MailApp: { sendEmail: () => { } },
     Logger: { log: () => { } },
-    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    Utilities: UTILITIES_STUB,
     handleLog: () => { },
     console,
   });
@@ -866,10 +879,10 @@ check('seedNoteTemplatesNow() migra os cenários existentes', () => {
   const freshSS = new FakeSpreadsheet();
   const freshCtx = vm.createContext({
     SpreadsheetApp: { getActiveSpreadsheet: () => freshSS },
-    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }) },
+    Session: { getActiveUser: () => ({ getEmail: () => 'lucaste@google.com' }), getScriptTimeZone: () => 'America/Sao_Paulo' },
     MailApp: { sendEmail: () => { } },
     Logger: { log: () => { } },
-    Utilities: { getUuid: () => require('node:crypto').randomUUID() },
+    Utilities: UTILITIES_STUB,
     handleLog: () => { },
     console,
   });
@@ -2015,6 +2028,109 @@ check('a prévia não é caminho de escrita: o servidor segue julgando quem clic
 
 check('papel inexistente na prévia é recusado', () => {
   throws(() => api.previewContentSession('NAOEXISTE'), /Papel desconhecido/);
+});
+
+console.log('\n--- Aviso com hora: agendamento e validade ---');
+
+// Um "agora" fixo para a janela, para o teste não depender do relógio da
+// máquina. O formato é o mesmo que janelaAgora_() produz.
+function comJanela(inicio, fim) {
+  return JSON.stringify({
+    type: 'info', title: 'Instabilidade', text: 'O CRM está lento.',
+    startsAt: inicio || '', endsAt: fim || ''
+  });
+}
+
+function publicoDeBroadcast() {
+  return api.handleContentPublicRead({ module: 'broadcast' }).items;
+}
+
+function limparBroadcasts() {
+  api.listContentItems('broadcast').forEach((it) => api.unpublishContentDirect(it.id));
+}
+
+check('aviso sem janela continua valendo sempre — ligar isto não apaga nada', () => {
+  limparBroadcasts();
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Sem janela',
+    value: JSON.stringify({ type: 'info', title: 'Sem janela', text: 'Vale sempre.' })
+  });
+  eq(publicoDeBroadcast().length, 1);
+});
+
+check('aviso agendado para o futuro NÃO chega ao agente', () => {
+  limparBroadcasts();
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Agendado', value: comJanela('2099-01-01T08:00', '')
+  });
+  eq(publicoDeBroadcast().length, 0, 'ainda não é hora:');
+  // Mas continua na Central, que é onde se administra.
+  eq(api.listContentItems('broadcast').length, 1, 'a Central mostra o agendado:');
+});
+
+check('aviso vencido para de chegar sozinho', () => {
+  limparBroadcasts();
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Vencido', value: comJanela('2020-01-01T08:00', '2020-01-02T08:00')
+  });
+  eq(publicoDeBroadcast().length, 0, 'a validade passou:');
+  eq(api.listContentItems('broadcast').length, 1, 'e ele continua auditável na Central:');
+});
+
+check('aviso dentro da janela chega normalmente', () => {
+  limparBroadcasts();
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Vigente', value: comJanela('2020-01-01T08:00', '2099-01-01T08:00')
+  });
+  eq(publicoDeBroadcast().length, 1);
+});
+
+check('a janela é do MÓDULO certo — não some conteúdo de outros', () => {
+  // O filtro roda só onde a janela existe. Um `startsAt` perdido no valor de um
+  // link não pode fazer o link sumir da tela do agente.
+  const antes = api.handleContentPublicRead({ module: 'links' }).items.length;
+  eq(antes > 0, true, 'precisa haver link para o teste valer:');
+  eq(api.handleContentPublicRead({ module: 'links' }).items.length, antes);
+});
+
+check('janela invertida é recusada na publicação', () => {
+  throws(() => api.publishContentDirect({
+    module: 'broadcast', label: 'Invertido', value: comJanela('2026-05-02T08:00', '2026-05-01T08:00')
+  }), /precisa vir depois do início/);
+});
+
+check('formato de data errado é recusado', () => {
+  throws(() => api.publishContentDirect({
+    module: 'broadcast', label: 'Ruim', value: comJanela('02/05/2026', '')
+  }), /Data de início inválida/);
+});
+
+check('a janela é avaliada DEPOIS do cache, não dentro dele', () => {
+  // O que o cache guarda é "o que está publicado"; o que a janela decide é "o
+  // que vale agora". Se o filtro morasse dentro do cache, um aviso agendado
+  // para daqui a um minuto ficaria de fora da entrada gravada agora e só
+  // apareceria quando o TTL expirasse.
+  limparBroadcasts();
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Vigente', value: comJanela('2020-01-01T08:00', '2099-01-01T08:00')
+  });
+  eq(publicoDeBroadcast().length, 1, 'aquece o cache:');
+
+  // Com o cache quente, um item VENCIDO entrando na aba não pode ser servido —
+  // o que só é verdade se o filtro rodar na leitura, não na gravação do cache.
+  const aba = SS.getSheetByName('Content_Items');
+  const cabecalho = aba._data[0];
+  const vigente = aba._data.find((r) => String(r[1]) === 'broadcast' && String(r[8]) === 'live');
+  const vencido = vigente.slice();
+  vencido[0] = 'itm_vencido';
+  vencido[6] = comJanela('2020-01-01T08:00', '2020-01-02T08:00');
+  vencido[12] = 'itm_vencido';
+  aba._data.push(vencido);
+  api.invalidateContentCache_('broadcast');
+
+  const servidos = publicoDeBroadcast();
+  eq(servidos.length, 1, 'o vencido não pode ser servido:');
+  eq(api.listContentItems('broadcast').length, 2, 'mas os dois estão publicados:');
 });
 
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -150,3 +150,45 @@ Além do que já devolvia (`ldap`, `role`, `hasAccess`, `canApprove`,
 
 `canApprove` continua existindo e agora significa **"aprova alguma coisa"** — a
 fila filtra item a item com `canReview`.
+
+---
+
+## Janela de exibição de um aviso (`broadcast`)
+
+O valor de um aviso aceita duas pontas opcionais, no mesmo JSON do tipo, título
+e texto:
+
+```json
+{ "type": "info", "title": "…", "text": "…",
+  "startsAt": "2026-09-08T08:00", "endsAt": "2026-09-08T18:00" }
+```
+
+| Campo | Formato | Ausente significa |
+| :--- | :--- | :--- |
+| `startsAt` | `AAAA-MM-DDTHH:MM` | já vale |
+| `endsAt` | `AAAA-MM-DDTHH:MM` | não expira |
+
+### Regras
+- **Um relógio só, e ele é o da planilha** (`America/Sao_Paulo`). A janela é
+  avaliada no servidor, nunca no navegador de quem lê: a operação atende PT e
+  ES em fusos diferentes, e se cada navegador decidisse, *"vai ao ar às 8h"*
+  seria um horário diferente para cada agente — e quem publicou não teria como
+  saber qual. A tela declara o fuso em vez de escondê-lo.
+- **A comparação é de TEXTO**, não de `Date`. As duas pontas estão em
+  `AAAA-MM-DDTHH:MM`, onde a ordem alfabética é a cronológica. Isso evita
+  `new Date('2026-09-05T08:00')`, cujo fuso de interpretação muda conforme o
+  ambiente.
+- **O filtro roda DEPOIS do cache**, em `readPublicModuleItems_()`. Dentro do
+  cache, um aviso agendado para as 10h ficaria de fora da entrada gravada às
+  9h58 e só apareceria quando o TTL expirasse — a janela passaria a ter a
+  precisão do cache em vez da sua própria. O cache guarda *o que está
+  publicado*; a janela decide *o que vale agora*.
+- **A Central não filtra.** `listContentItems('broadcast')` devolve tudo que
+  está publicado, e a tela marca cada linha com o estado (`agendado para…`,
+  `sai em…`, `saiu do ar em…`). Um aviso agendado que não aparecesse na lista
+  seria um aviso que ninguém consegue mais editar.
+- **Janela invertida é recusada**, na tela e no servidor. Um aviso que nunca
+  aparece não é "um aviso que ninguém viu": é um aviso que a pessoa acredita ter
+  publicado.
+- **Expirar não arquiva.** O item continua `live` na planilha, fora da janela.
+  É o que permite estender a validade editando, em vez de republicar.


### PR DESCRIPTION
## O que muda

Segunda entrega da fase 5. Um aviso ganhou duas pontas opcionais: **quando começa a aparecer** e **quando sai do ar**.

## Por que assim

**O problema não é conveniência, é confiança.** "Avisar a operação às 8h de segunda" era alguém acordar e clicar. "Tirar quando a instabilidade acabar" era alguém lembrar — e o aviso que ninguém lembra de tirar continua na tela do agente dizendo que um problema resolvido há três dias está acontecendo agora. **Aviso velho não é ruído neutro: ele ensina o agente a ignorar avisos.** Depois disso, o alerta que importa também não é lido.

**Ligar isto não muda nada do que já está no ar.** Ausência de ponta é ausência de restrição: sem início já vale, sem fim não expira. É exatamente o comportamento de todo aviso existente, e tem teste dizendo isso.

**Um relógio só, e ele é declarado.** A janela é avaliada no servidor, no fuso da planilha (Brasília), nunca no navegador de quem lê. A operação atende PT e ES em fusos diferentes: se cada navegador decidisse, *"vai ao ar às 8h"* seria um horário diferente para cada agente — e quem publicou não teria como saber qual. A tela escreve "Horário de Brasília" em vez de esconder a questão.

**A comparação é de texto, não de `Date`.** As duas pontas estão em `AAAA-MM-DDTHH:MM`, onde a ordem alfabética é a cronológica. Isso evita a armadilha de `new Date('2026-09-05T08:00')`, cujo fuso de interpretação muda conforme o ambiente — a mesma classe de bug que já custou caro em datas neste projeto.

**O filtro roda DEPOIS do cache**, e isso é a decisão menos óbvia do PR. Dentro do cache, um aviso agendado para as 10h ficaria de fora da entrada gravada às 9h58 e só apareceria quando o TTL de 5 minutos expirasse — a janela passaria a ter a precisão do cache em vez da sua própria. Separando, o cache guarda *o que está publicado* e a janela decide *o que vale agora*, que são perguntas diferentes. Tem um teste que prova exatamente isso, injetando um item vencido com o cache já quente.

**A Central não filtra.** A lista mostra tudo que está publicado e marca cada linha: `agendado para…`, `sai em…`, `saiu do ar em…`. Um aviso agendado que sumisse da lista seria um aviso que ninguém consegue mais editar. E a confirmação de publicação, que já declarava *para quem*, passou a declarar *quando* — "vai ao ar agora" e "vai ao ar em março" são publicações diferentes, e uma confirmação que só fala do alcance afirma algo que pode não acontecer.

## Como verificar

```
npm run test:content    # 150 testes (eram 142)
npm run smoke:content   # 83 verificações (eram 77)
```

```
✓ aviso sem janela continua valendo sempre — ligar isto não apaga nada
✓ aviso agendado para o futuro NÃO chega ao agente
✓ aviso vencido para de chegar sozinho
✓ a janela é do MÓDULO certo — não some conteúdo de outros
✓ janela invertida é recusada na publicação
✓ a janela é avaliada DEPOIS do cache, não dentro dele
✓ a lista distingue vigente, agendado e vencido
✓ a confirmação declara o QUANDO, não só o alcance
✓ a janela viaja no valor publicado
✓ janela invertida é barrada antes de sair da tela
```

**Quatro mutações confirmam que elas falham quando devem** — sem o filtro na leitura pública (3 falhas), janela invertida aceita (1), sem os selos na lista (1), confirmação sem o quando (1).

Nada muda no bundle do agente: ele simplesmente recebe menos itens. Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — **não testado no CRM real**, e vale dizer por quê: o caminho que muda é a leitura pública, que os testes cobrem ponta a ponta com a planilha dublada. O que só a planilha real prova é o fuso — `Utilities.formatDate` com o timezone do projeto —, e isso pede um aviso agendado para dali a alguns minutos, olhando o app do agente.

## Checklist

- [x] Mexi em `gas-backend/`: a forma do valor com janela e as seis regras que a governam entraram em `specs/data-models/api-payloads.md`.
- [x] Mexi numa regra de negócio: sim — o que a leitura pública serve deixou de ser só "está `live`" e passou a ser "está `live` e dentro da janela". Está na spec, com o motivo de o filtro ficar fora do cache.
- [x] Decisão que alguém vai questionar depois: "por que texto e não `Date`" e "por que depois do cache" estão comentadas no ponto exato do código.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_