### PR TITLE
feat(central): aba de auditoria com filtro, período e exportação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Aba de auditoria, restrita a quem tem `ver auditoria completa`** (fase 5).
+  A barra lateral responde *"o que está acontecendo"*; esta responde *"o que
+  aconteceu"* — com busca por texto, filtro de quem/ação/módulo, período e
+  paginação, mais exportação do resultado para uma aba da própria planilha. A
+  paginação é por **número de linha**, não por "pule N resultados": é o que
+  mantém o custo de cada página igual em vez de refiltrar tudo que já foi
+  mostrado. Cada chamada tem teto de varredura, porque o Apps Script tem 6
+  minutos e a aba guarda 24 meses — e a tela distingue "acabou o histórico" de
+  "acabou o orçamento desta chamada", que é a diferença entre um "carregar mais"
+  honesto e um que mente.
 - **Aviso com hora: agendamento e validade** (fase 5). Um aviso pode nascer
   agendado e morrer sozinho. Sem isso, *"avisar a operação às 8h de segunda"*
   era alguém acordar e clicar, e *"tirar quando a instabilidade acabar"* era

--- a/PLAN.md
+++ b/PLAN.md
@@ -85,6 +85,10 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       **Entregue também:** agendamento e validade de aviso — janela avaliada no
       servidor, no fuso da planilha, e filtrada DEPOIS do cache (dentro dele a
       janela teria a precisão do cache em vez da sua própria).
+      **Entregue também:** a aba de auditoria restrita — filtro, período,
+      paginação por número de linha e exportação para uma aba da planilha
+      (arquivo não serve: download iniciado dentro do iframe do Apps Script é
+      bloqueado com frequência e sem aviso).
       **Falta:** prévia "como o agente vê"; busca global Ctrl+K;
       cobrança diária de pendência parada — esta lendo
       `CW_DEPLOYMENTS` e não a URL do serviço, porque em gatilho de tempo a

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -2570,6 +2570,192 @@ function listContentActivity(limite) {
   return saida;
 }
 
+// =========================================================
+//  AUDITORIA COMPLETA (aba restrita)
+//
+//  A barra lateral responde "o que aconteceu agora"; esta responde "o que
+//  aconteceu". São perguntas diferentes e por isso duas portas diferentes: a
+//  barra tem janela fixa e nenhum filtro, esta tem filtro, paginação e teto de
+//  varredura por chamada.
+// =========================================================
+
+// Quantas linhas uma chamada pode VARRER (não devolver). O Apps Script tem 6
+// minutos de execução e a aba guarda 24 meses: sem teto, um filtro que casa com
+// pouca coisa faria a chamada percorrer a aba inteira e estourar. Com teto, ela
+// devolve o que achou mais um cursor, e a tela pede a próxima leva.
+const CONTENT_AUDIT_SCAN_MAX = 3000;
+const CONTENT_AUDIT_PAGE = 50;
+const CONTENT_AUDIT_PAGE_MAX = 200;
+const CONTENT_AUDIT_EXPORT_MAX = 5000;
+const SHEET_CONTENT_AUDIT_EXPORT = "Content_Audit_Export";
+
+function textoDoFiltro_(f, chave) {
+  return String((f && f[chave]) || "").trim();
+}
+
+// `from`/`to` são datas (AAAA-MM-DD) e o carimbo é ISO. Comparar como texto
+// funciona porque o ISO começa exatamente pela data — e `to` vira `to + 'Z'`
+// para o dia final entrar inteiro em vez de parar à meia-noite.
+function linhaCasaFiltro_(linha, f) {
+  const at = contentIsoDate_(linha[1]);
+  const actor = String(linha[2] || "");
+  const action = String(linha[3] || "");
+  const module = String(linha[4] || "");
+
+  if (f.actor && actor.toLowerCase() !== f.actor.toLowerCase()) return false;
+  if (f.action && action !== f.action) return false;
+  if (f.module && module !== f.module) return false;
+  if (f.from && at < f.from) return false;
+  if (f.to && at > f.to + 'Z') return false;
+
+  if (f.text) {
+    const alvo = (String(linha[5] || "") + ' ' + String(linha[7] || "") + ' ' +
+      String(linha[8] || "")).toLowerCase();
+    if (alvo.indexOf(f.text.toLowerCase()) === -1) return false;
+  }
+
+  return true;
+}
+
+function linhaDeAuditoria_(linha) {
+  return {
+    id: String(linha[0] || ""),
+    at: contentIsoDate_(linha[1]),
+    actor: String(linha[2] || ""),
+    action: String(linha[3] || ""),
+    module: String(linha[4] || ""),
+    key: String(linha[5] || ""),
+    itemId: String(linha[6] || ""),
+    label: String(linha[7] || ""),
+    detail: String(linha[8] || "")
+  };
+}
+
+/**
+ * A auditoria, da mais recente para a mais antiga, filtrada e paginada.
+ *
+ * `cursor` é o número da linha da planilha em que a varredura anterior parou.
+ * Paginar por número de linha, e não por "pule N resultados", é o que mantém o
+ * custo de cada página igual: pular resultados obrigaria a refiltrar tudo que
+ * já foi mostrado.
+ *
+ * A ordem por linha É a ordem cronológica, e isso não é sorte: a aba só é
+ * ANEXADA, e o backfill reordena pela data o que traz da aba `Logs`. Ordenar
+ * 15 mil linhas a cada consulta para chegar ao mesmo resultado seria pagar
+ * duas vezes.
+ */
+function listContentAudit(filtro) {
+  assertContentRole_('viewAudit', null);
+
+  const f = filtro || {};
+  const filtros = {
+    actor: textoDoFiltro_(f, 'actor'),
+    action: textoDoFiltro_(f, 'action'),
+    module: textoDoFiltro_(f, 'module'),
+    from: textoDoFiltro_(f, 'from'),
+    to: textoDoFiltro_(f, 'to'),
+    text: textoDoFiltro_(f, 'text')
+  };
+
+  const limite = Math.min(
+    Math.max(Number(f.limit) || CONTENT_AUDIT_PAGE, 1), CONTENT_AUDIT_PAGE_MAX);
+
+  const sheet = getContentSheet_(SHEET_CONTENT_LOG);
+  const ultima = sheet.getLastRow();
+  if (ultima < 2) return { rows: [], nextCursor: 0, scanned: 0, done: true };
+
+  // Sem cursor, começa do fim. Com cursor, continua de onde parou.
+  let fim = Number(f.cursor) > 0 ? Number(f.cursor) : ultima;
+  if (fim < 2) return { rows: [], nextCursor: 0, scanned: 0, done: true };
+
+  const rows = [];
+  let varridas = 0;
+  const BLOCO = 200;
+
+  while (fim >= 2 && rows.length < limite && varridas < CONTENT_AUDIT_SCAN_MAX) {
+    const inicio = Math.max(2, fim - BLOCO + 1);
+    const valores = sheet
+      .getRange(inicio, 1, fim - inicio + 1, CONTENT_LOG_HEADERS.length)
+      .getValues();
+
+    for (let i = valores.length - 1; i >= 0 && rows.length < limite; i--) {
+      varridas++;
+      if (linhaCasaFiltro_(valores[i], filtros)) rows.push(linhaDeAuditoria_(valores[i]));
+      // A próxima chamada retoma UMA linha acima da última examinada.
+      fim = inicio + i - 1;
+    }
+
+    if (rows.length < limite) fim = inicio - 1;
+  }
+
+  return {
+    rows: rows,
+    nextCursor: fim >= 2 ? fim : 0,
+    scanned: varridas,
+    // `done` é sobre a ABA ter acabado, não sobre a página ter enchido: uma
+    // página curta porque o teto de varredura foi atingido não significa que
+    // não há mais nada.
+    done: fim < 2
+  };
+}
+
+/**
+ * Exporta o resultado do filtro para uma aba da própria planilha.
+ *
+ * Sheets em vez de arquivo: a Central roda dentro de um iframe do Apps Script,
+ * onde download iniciado pela página é bloqueado com frequência e sem aviso.
+ * Uma aba é o formato que esta operação já sabe abrir, filtrar e baixar — e não
+ * pede permissão nenhuma que o projeto ainda não tenha.
+ *
+ * Sobrescreve sempre a mesma aba, de propósito: uma aba por exportação encheria
+ * a planilha de lixo que ninguém apaga.
+ */
+function exportContentAudit(filtro) {
+  const session = assertContentRole_('viewAudit', null);
+
+  const linhas = [];
+  let cursor = 0;
+
+  // Pagina pela própria listContentAudit: um caminho de filtro só, para o que
+  // se exporta ser exatamente o que se viu na tela.
+  while (linhas.length < CONTENT_AUDIT_EXPORT_MAX) {
+    const pagina = listContentAudit(Object.assign({}, filtro, {
+      cursor: cursor, limit: CONTENT_AUDIT_PAGE_MAX
+    }));
+
+    pagina.rows.forEach(function (r) {
+      if (linhas.length < CONTENT_AUDIT_EXPORT_MAX) {
+        linhas.push([r.at, r.actor, r.action, r.module, r.key, r.itemId, r.label, r.detail]);
+      }
+    });
+
+    if (pagina.done || !pagina.nextCursor || !pagina.rows.length) break;
+    cursor = pagina.nextCursor;
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let aba = ss.getSheetByName(SHEET_CONTENT_AUDIT_EXPORT);
+  if (aba) aba.clear();
+  else aba = ss.insertSheet(SHEET_CONTENT_AUDIT_EXPORT);
+
+  const cabecalho = ["Quando", "Quem", "Ação", "Módulo", "Chave", "Item", "Rótulo", "Detalhe"];
+  aba.getRange(1, 1, 1, cabecalho.length).setValues([cabecalho]);
+  if (linhas.length) {
+    aba.getRange(2, 1, linhas.length, cabecalho.length).setValues(linhas);
+  }
+  aba.setFrozenRows(1);
+
+  logContentEvent_(session.ldap, 'audit_export', { label: SHEET_CONTENT_AUDIT_EXPORT },
+    linhas.length + ' linhas');
+
+  return {
+    sheet: SHEET_CONTENT_AUDIT_EXPORT,
+    rows: linhas.length,
+    truncated: linhas.length >= CONTENT_AUDIT_EXPORT_MAX,
+    url: ss.getUrl ? ss.getUrl() : ''
+  };
+}
+
 // Prefixo do ID das linhas trazidas da aba Logs. É o que torna o backfill
 // idempotente: o ID deriva do NÚMERO DA LINHA de origem, então rodar de novo
 // reconhece o que já veio em vez de duplicar.

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -136,6 +136,9 @@
                     <button class="rail-item hidden" id="tab-people" data-tab="people" onclick="switchTab('people')">
                         <span class="material-symbols-rounded" aria-hidden="true">groups</span> <span class="rail-label">Pessoas</span>
                     </button>
+                    <button class="rail-item hidden" id="tab-audit" data-tab="audit" onclick="switchTab('audit')">
+                        <span class="material-symbols-rounded" aria-hidden="true">manage_search</span> <span class="rail-label">Auditoria</span>
+                    </button>
                     <button class="rail-item hidden" id="tab-roles" data-tab="roles" onclick="switchTab('roles')">
                         <span class="material-symbols-rounded" aria-hidden="true">shield_person</span> <span class="rail-label">Papéis</span>
                     </button>
@@ -404,6 +407,69 @@
                 <div id="approvals-list">
                     <div class="skeleton"></div>
                     <div class="skeleton"></div>
+                </div>
+            </section>
+
+            <!-- TAB: Auditoria (restrita a quem tem viewAudit) -->
+            <section id="pane-audit" class="hidden">
+                <div class="note" id="aud-note">
+                    Tudo que aconteceu na Central, com quem fez e quando. A barra
+                    <strong>Atividade recente</strong> responde “o que está acontecendo”; esta
+                    responde “o que aconteceu”.
+                </div>
+
+                <div class="card">
+                    <div class="aud-filtros">
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-texto">Buscar</label>
+                            <input type="text" id="aud-texto" autocomplete="off"
+                                placeholder="rótulo, chave ou detalhe">
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-quem">Quem</label>
+                            <input type="text" id="aud-quem" autocomplete="off" placeholder="LDAP">
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-acao">Ação</label>
+                            <select id="aud-acao"></select>
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-modulo">Módulo</label>
+                            <select id="aud-modulo"></select>
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-de">De</label>
+                            <input type="date" id="aud-de">
+                        </div>
+                        <div>
+                            <label class="fld" style="margin-top:0" for="aud-ate">Até</label>
+                            <input type="date" id="aud-ate">
+                        </div>
+                    </div>
+                    <div class="aud-acoes">
+                        <button class="btn btn-primary" id="aud-buscar" onclick="buscarAuditoria()">
+                            Buscar
+                        </button>
+                        <button class="btn btn-ghost" id="aud-limpar" onclick="limparAuditoria()">
+                            Limpar filtros
+                        </button>
+                        <button class="btn btn-ghost" id="aud-exportar" onclick="exportarAuditoria(this)">
+                            <span class="material-symbols-rounded" style="font-size:19px"
+                                aria-hidden="true">table_view</span> Exportar para a planilha
+                        </button>
+                        <span class="card-sub" id="aud-resumo" role="status" aria-live="polite"></span>
+                    </div>
+                </div>
+
+                <div class="card" id="aud-lista">
+                    <div class="skeleton"></div>
+                    <div class="skeleton"></div>
+                </div>
+
+                <div style="margin-top:14px">
+                    <button class="btn btn-ghost hidden" id="aud-mais" onclick="maisAuditoria(this)">
+                        Carregar mais
+                    </button>
                 </div>
             </section>
 

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -113,6 +113,10 @@
                 titulo: 'Pessoas', carregar: function () { loadPeople(); },
                 sub: 'O diretório que decide quem é liderança e em que idioma o app abre.'
             },
+            audit: {
+                titulo: 'Auditoria', carregar: function () { loadAudit(); },
+                sub: 'Tudo que aconteceu na Central, com filtro e período.'
+            },
             roles: {
                 titulo: 'Papéis', carregar: function () { loadRoles(); },
                 sub: 'O que cada papel pode fazer. Vale no ato, sem passar por fila.'
@@ -600,6 +604,9 @@
             badge.classList.remove('hidden');
 
             document.getElementById('tab-access').classList.toggle('hidden', !s.canManageAccess);
+            // A auditoria segue a prévia: quem "vê como" um papel que audita
+            // está conferindo a tela dele, e olhar o histórico é leitura.
+            document.getElementById('tab-audit').classList.toggle('hidden', !s.canViewAudit);
             // A aba de papéis some na prévia: editar permissão enquanto se
             // finge ser outra pessoa é como se perde a noção de quem fez o quê.
             document.getElementById('tab-roles').classList.toggle('hidden',

--- a/gas-backend/ContentDashboard_Governance.html
+++ b/gas-backend/ContentDashboard_Governance.html
@@ -726,6 +726,164 @@
             renderPeople();
         });
 
+        // --- Auditoria completa ---
+        //
+        // A barra lateral responde "o que está acontecendo"; esta responde "o
+        // que aconteceu". São perguntas diferentes, e é por isso que são duas
+        // telas: a barra tem janela fixa e nenhum filtro, esta tem filtro,
+        // período e paginação.
+        //
+        // O cursor é o número da LINHA da planilha onde a varredura parou. É o
+        // que faz "carregar mais" custar sempre o mesmo: paginar por "pule N
+        // resultados" obrigaria o servidor a refiltrar tudo que já foi mostrado.
+        var AUD_CURSOR = 0;
+        var AUD_LINHAS = [];
+        var AUD_MONTADO = false;
+
+        function filtroDaAuditoria() {
+            return {
+                text: document.getElementById('aud-texto').value.trim(),
+                actor: document.getElementById('aud-quem').value.trim(),
+                action: document.getElementById('aud-acao').value,
+                module: document.getElementById('aud-modulo').value,
+                from: document.getElementById('aud-de').value,
+                to: document.getElementById('aud-ate').value
+            };
+        }
+
+        function montarFiltrosDaAuditoria() {
+            if (AUD_MONTADO) return;
+            AUD_MONTADO = true;
+
+            var acao = document.getElementById('aud-acao');
+            acao.innerHTML = '<option value="">Todas</option>' +
+                Object.keys(ATIVIDADE_VERBO).sort().map(function (a) {
+                    return '<option value="' + esc(a) + '">' + esc(ATIVIDADE_VERBO[a]) + '</option>';
+                }).join('');
+
+            var mod = document.getElementById('aud-modulo');
+            mod.innerHTML = '<option value="">Todos</option>' +
+                (SESSION.modules || []).map(function (m) {
+                    return '<option value="' + esc(m) + '">' +
+                        esc(ATIVIDADE_MODULO[m] || m) + '</option>';
+                }).join('');
+        }
+
+        function loadAudit() {
+            if (!SESSION.canViewAudit) return;
+            montarFiltrosDaAuditoria();
+            buscarAuditoria();
+        }
+
+        function buscarAuditoria() {
+            AUD_CURSOR = 0;
+            AUD_LINHAS = [];
+            document.getElementById('aud-lista').innerHTML =
+                '<div class="skeleton"></div><div class="skeleton"></div>';
+            pedirAuditoria(null);
+        }
+
+        function maisAuditoria(btn) {
+            pedirAuditoria(btn);
+        }
+
+        function limparAuditoria() {
+            ['aud-texto', 'aud-quem', 'aud-de', 'aud-ate'].forEach(function (id) {
+                document.getElementById(id).value = '';
+            });
+            document.getElementById('aud-acao').value = '';
+            document.getElementById('aud-modulo').value = '';
+            buscarAuditoria();
+        }
+
+        function pedirAuditoria(btn) {
+            if (btn) { btn.disabled = true; btn.textContent = 'Carregando…'; }
+
+            google.script.run
+                .withSuccessHandler(function (r) {
+                    if (btn) { btn.disabled = false; btn.textContent = 'Carregar mais'; }
+                    AUD_LINHAS = AUD_LINHAS.concat(r.rows || []);
+                    AUD_CURSOR = r.nextCursor || 0;
+                    renderAuditoria(r);
+                })
+                .withFailureHandler(function (err) {
+                    if (btn) { btn.disabled = false; btn.textContent = 'Carregar mais'; }
+                    document.getElementById('aud-lista').innerHTML =
+                        '<div class="note warn">' + esc(err.message) + '</div>';
+                })
+                .listContentAudit(Object.assign(filtroDaAuditoria(), { cursor: AUD_CURSOR }));
+        }
+
+        function renderAuditoria(r) {
+            var host = document.getElementById('aud-lista');
+            var mais = document.getElementById('aud-mais');
+
+            if (!AUD_LINHAS.length) {
+                host.innerHTML =
+                    '<div class="state"><span class="material-symbols-rounded" ' +
+                    'aria-hidden="true">manage_search</span><h2>Nada com esses filtros</h2>' +
+                    '<p>Tente um período maior ou tire um filtro.</p></div>';
+                mais.classList.add('hidden');
+                document.getElementById('aud-resumo').textContent = '';
+                return;
+            }
+
+            host.innerHTML =
+                '<div class="aud-scroll"><table class="aud-tabela">' +
+                '<thead><tr>' +
+                '<th scope="col">Quando</th><th scope="col">Quem</th>' +
+                '<th scope="col">O quê</th><th scope="col">Onde</th>' +
+                '<th scope="col">Detalhe</th></tr></thead><tbody>' +
+                AUD_LINHAS.map(function (l) {
+                    var alvo = l.label || l.key || '';
+                    return '<tr>' +
+                        '<td class="aud-quando">' + esc(dataCurta(l.at)) + '</td>' +
+                        '<td>' + fotoDoLdap(l.actor) + ' ' + esc(l.actor) + '</td>' +
+                        '<td>' + esc(ATIVIDADE_VERBO[l.action] || l.action) +
+                        (alvo ? ' <strong>' + esc(alvo) + '</strong>' : '') + '</td>' +
+                        '<td>' + esc(ATIVIDADE_MODULO[l.module] || l.module || '—') + '</td>' +
+                        '<td class="aud-detalhe">' + esc(l.detail) + '</td>' +
+                        '</tr>';
+                }).join('') +
+                '</tbody></table></div>';
+
+            // `done` é sobre a ABA ter acabado, não sobre a página ter enchido:
+            // uma página curta porque o teto de varredura foi atingido ainda tem
+            // continuação, e esconder o botão ali faria parecer que acabou.
+            mais.classList.toggle('hidden', !!r.done || !r.nextCursor);
+
+            document.getElementById('aud-resumo').textContent =
+                AUD_LINHAS.length + (AUD_LINHAS.length === 1 ? ' registro' : ' registros') +
+                (r.done ? ' — fim do histórico.' : ' até aqui.');
+        }
+
+        function exportarAuditoria(btn) {
+            var rotulo = btn.innerHTML;
+            btn.disabled = true;
+            btn.textContent = 'Exportando…';
+
+            google.script.run
+                .withSuccessHandler(function (r) {
+                    btn.disabled = false;
+                    btn.innerHTML = rotulo;
+                    toast('Aba "' + r.sheet + '" gerada com ' + r.rows +
+                        (r.rows === 1 ? ' registro' : ' registros') +
+                        (r.truncated ? ' (cortado no teto de exportação).' : '.'));
+                })
+                .withFailureHandler(function (err) {
+                    btn.disabled = false;
+                    btn.innerHTML = rotulo;
+                    toast(err.message, true);
+                })
+                .exportContentAudit(filtroDaAuditoria());
+        }
+
+        // Enter em qualquer campo de texto busca — é o gesto que se faz sem
+        // pensar num formulário de filtro.
+        document.getElementById('pane-audit').addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && e.target.tagName === 'INPUT') buscarAuditoria();
+        });
+
         // --- Papéis (matriz editável — ADR-0009) ---
         //
         // A tela NÃO é a fronteira: cada regra deste arquivo existe também no

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -284,6 +284,64 @@
         body.em-previa .lateral { top: 116px; }
         body.em-previa .rail { height: calc(100vh - 116px); }
 
+        /* --- Auditoria --- */
+        .aud-filtros {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 12px;
+        }
+
+        .aud-acoes {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            flex-wrap: wrap;
+            margin-top: 16px;
+        }
+
+        .aud-scroll { overflow-x: auto; }
+
+        .aud-tabela {
+            border-collapse: collapse;
+            width: 100%;
+            min-width: 720px;
+            font-size: 13px;
+        }
+
+        .aud-tabela th,
+        .aud-tabela td {
+            padding: 9px 12px;
+            border-bottom: 1px solid var(--border-subtle);
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .aud-tabela thead th {
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            white-space: nowrap;
+        }
+
+        .aud-tabela tbody tr:last-child td { border-bottom: none; }
+        .aud-tabela .aud-quando { white-space: nowrap; color: var(--text-secondary); }
+
+        .aud-tabela img.atividade-foto {
+            width: 20px;
+            height: 20px;
+            vertical-align: middle;
+        }
+
+        /* O detalhe é o campo que pode ser longo — uma justificativa de rejeição
+           ou um diff de permissões. Quebra em vez de esticar a tabela. */
+        .aud-tabela .aud-detalhe {
+            color: var(--text-secondary);
+            overflow-wrap: anywhere;
+            max-width: 380px;
+        }
+
         /* --- Matriz de papéis --- */
         .rol-toolbar {
             display: flex;

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -244,6 +244,21 @@ const ATIVIDADE = [
     },
 ];
 
+// Cinco registros: o bastante para a paginação de duas em duas ter três levas,
+// e com uma "agulha" para o filtro de texto ter o que achar.
+const AUDITORIA = [
+    { id: 'l5', at: agoraMenos(5), actor: 'lucaste', action: 'approve', module: 'links',
+      key: 'tasks', itemId: 'itm_1', label: 'Fila de tarefas', detail: 'v3 por anaflor' },
+    { id: 'l4', at: agoraMenos(60), actor: 'anaflor', action: 'reject', module: 'email_template',
+      key: 'boas_vindas', itemId: '', label: 'E-mail de boas-vindas', detail: 'Falta citar o CID.' },
+    { id: 'l3', at: agoraMenos(600), actor: 'brunocs', action: 'publish_direct', module: 'broadcast',
+      key: 'bc1', itemId: 'itm_bc1', label: 'Instabilidade no CRM', detail: 'v1' },
+    { id: 'l2', at: agoraMenos(2000), actor: 'lucaste', action: 'access_change', module: '',
+      key: '', itemId: '', label: 'brunocs', detail: 'TL ativo' },
+    { id: 'l1', at: agoraMenos(5000), actor: 'lucaste', action: 'role_update', module: '',
+      key: '', itemId: '', label: 'QA', detail: 'links.propose: não → sim' },
+];
+
 // ------------------------------------------------------- montagem da página
 async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', draftsDe = null,
     fila = [], atividade = [], matriz = MATRIZ, confirmarSalvar = null } = {}) {
@@ -268,9 +283,10 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
     // O dublê precisa existir ANTES do script da página rodar: o boot dispara
     // no DOMContentLoaded.
     await page.addInitScript(({ sessao, itens, falhar, historico, rascunhos, pendentes, atividade,
-        matriz, respostaDoSalvar }) => {
+        matriz, respostaDoSalvar, auditoria }) => {
         const PENDENTES = pendentes || [];
         const ATIVIDADE = atividade || [];
+        const AUDITORIA = auditoria || [];
         const HISTORICO = historico;
         window.__chamadas = [];
 
@@ -285,6 +301,28 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             listContentActivity: () => ATIVIDADE,
             listContentRoles: () => matriz,
             listContentRoleNames: () => ['ADMIN', 'QA'],
+            listContentAudit: (f) => {
+                const filtro = f || {};
+                const casa = (l) => (!filtro.actor || l.actor === filtro.actor) &&
+                    (!filtro.action || l.action === filtro.action) &&
+                    (!filtro.text || (l.label + ' ' + l.detail).toLowerCase()
+                        .indexOf(filtro.text.toLowerCase()) !== -1);
+                // O cursor é o índice de onde continuar: o mesmo contrato do
+                // servidor, que pagina por posição e não por "pule N".
+                const inicio = Number(filtro.cursor) || 0;
+                const todas = AUDITORIA.filter(casa);
+                const pagina = todas.slice(inicio, inicio + 2);
+                const fim = inicio + pagina.length;
+                return {
+                    rows: pagina,
+                    nextCursor: fim < todas.length ? fim : 0,
+                    scanned: pagina.length,
+                    done: fim >= todas.length,
+                };
+            },
+            exportContentAudit: () => ({
+                sheet: 'Content_Audit_Export', rows: 3, truncated: false, url: '',
+            }),
             previewContentSession: (papel) => {
                 // O servidor devolve a sessão do papel INTERSECTADA com a de
                 // quem pergunta, mais o que ficou de fora.
@@ -369,7 +407,7 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
     }, {
         sessao: SESSOES[sessao], itens: ITENS, falhar: falharRascunhosDe,
         historico: HISTORICO, rascunhos: draftsDe, pendentes: fila, atividade,
-        matriz, respostaDoSalvar: confirmarSalvar,
+        matriz, respostaDoSalvar: confirmarSalvar, auditoria: AUDITORIA,
     });
 
     await page.goto('file://' + ARQUIVO + hash, { waitUntil: 'domcontentloaded' });
@@ -1431,6 +1469,88 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         igual(await page.locator('#pub-titulo').count(), 0, 'nem deveria chegar à confirmação');
         verdade(/depois do início/.test(await page.locator('#toast').textContent()),
             'faltou explicar por quê');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------------------- auditoria
+{
+    const page = await abrir({ sessao: 'qa' });
+
+    await check('quem não vê a auditoria não tem a aba', async () => {
+        igual(await page.locator('#tab-audit').isVisible(), false, 'aba Auditoria para o QA');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'admin', hash: '#/audit' });
+
+    await check('a auditoria abre já com os registros mais recentes', async () => {
+        await page.waitForTimeout(400);
+        verdade(await page.locator('#tab-audit').isVisible(), 'a aba deveria aparecer');
+        igual(await page.locator('.aud-tabela tbody tr').count(), 2, 'linhas da primeira leva');
+        const texto = await page.locator('#aud-lista').textContent();
+        verdade(/aprovou/.test(texto), 'a ação precisa aparecer em português');
+        verdade(/Fila de tarefas/.test(texto), 'faltou o alvo da ação');
+    });
+
+    await check('"carregar mais" continua de onde parou, sem repetir', async () => {
+        await page.locator('#aud-mais').click();
+        await page.waitForTimeout(350);
+        igual(await page.locator('.aud-tabela tbody tr').count(), 4, 'linhas depois da 2ª leva');
+
+        const ids = await page.evaluate(() => AUD_LINHAS.map(l => l.id));
+        igual(ids.length, new Set(ids).size, 'nenhum registro repetido');
+    });
+
+    await check('chegando ao fim, o botão some e a tela diz que acabou', async () => {
+        await page.locator('#aud-mais').click();
+        await page.waitForTimeout(350);
+        igual(await page.locator('#aud-mais').isVisible(), false, 'botão de carregar mais');
+        verdade(/fim do histórico/.test(await page.locator('#aud-resumo').textContent()),
+            'faltou dizer que acabou');
+    });
+
+    await check('filtrar por quem fez recomeça a busca, não soma', async () => {
+        await page.fill('#aud-quem', 'anaflor');
+        await page.locator('#aud-buscar').click();
+        await page.waitForTimeout(350);
+
+        const linhas = await page.evaluate(() => AUD_LINHAS.map(l => l.actor));
+        igual(linhas, ['anaflor'], 'só o que casa com o filtro');
+    });
+
+    await check('filtro sem resultado explica em vez de mostrar tabela vazia', async () => {
+        await page.fill('#aud-quem', 'ninguem');
+        await page.locator('#aud-buscar').click();
+        await page.waitForTimeout(350);
+        verdade(/Nada com esses filtros/.test(await page.locator('#aud-lista').textContent()),
+            'faltou o estado vazio');
+        igual(await page.locator('#aud-mais').isVisible(), false, 'nem carregar mais');
+    });
+
+    await check('limpar devolve o histórico inteiro', async () => {
+        await page.locator('#aud-limpar').click();
+        await page.waitForTimeout(350);
+        igual(await page.locator('#aud-tabela').count() >= 0, true);
+        igual(await page.evaluate(() => AUD_LINHAS.length), 2, 'volta à primeira leva');
+        igual(await page.inputValue('#aud-quem'), '', 'o campo também limpa');
+    });
+
+    await check('exportar leva o MESMO filtro da tela', async () => {
+        await page.fill('#aud-texto', 'CID');
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.locator('#aud-exportar').click();
+        await page.waitForTimeout(400);
+
+        const chamada = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'exportContentAudit')[0]);
+        igual(chamada.args[0].text, 'CID', 'o filtro precisa acompanhar a exportação');
+        verdade(/Content_Audit_Export/.test(await page.locator('#toast').textContent()),
+            'faltou dizer onde a exportação foi parar');
     });
 
     await page.close();

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -75,6 +75,7 @@ class FakeSheet {
   // Os outros dublês do projeto já modelavam isto; este ficou para trás até
   // discardContentDraft() precisar remover uma linha de verdade.
   deleteRow(i) { this._data.splice(i - 1, 1); }
+  clear() { this._data.length = 0; return this; }
   setFrozenRows() { return this; }
 }
 
@@ -2131,6 +2132,149 @@ check('a janela é avaliada DEPOIS do cache, não dentro dele', () => {
   const servidos = publicoDeBroadcast();
   eq(servidos.length, 1, 'o vencido não pode ser servido:');
   eq(api.listContentItems('broadcast').length, 2, 'mas os dois estão publicados:');
+});
+
+console.log('\n--- Auditoria completa ---');
+
+// Um histórico grande o bastante para a paginação ter o que paginar. Escrito
+// direto na aba: o que se testa aqui é a LEITURA, e produzir 120 ações reais
+// custaria minutos sem provar nada a mais.
+function semearAuditoria(quantas) {
+  const aba = SS.getSheetByName('Content_Log');
+  const modulos = ['links', 'tips', 'call_script'];
+  const acoes = ['approve', 'reject', 'publish_direct'];
+  const gente = ['lucaste', 'anaflor', 'brunocs'];
+
+  // Datas CRESCENTES, como em produção: a aba é só anexada, e o backfill
+  // reordena o que trouxe. É essa garantia que permite a leitura ir de trás
+  // para a frente por número de linha em vez de ordenar 15 mil linhas.
+  for (let i = 0; i < quantas; i++) {
+    const mes = String(Math.floor(i / 28) + 1).padStart(2, '0');
+    const dia = String((i % 28) + 1).padStart(2, '0');
+    aba.appendRow([
+      'log_seed_' + i,
+      '2026-' + mes + '-' + dia + 'T10:00:00.000Z',
+      gente[i % 3],
+      acoes[i % 3],
+      modulos[i % 3],
+      'chave' + i,
+      '',
+      'Item ' + i,
+      i === 7 ? 'agulha no palheiro' : 'detalhe comum'
+    ]);
+  }
+}
+
+check('só quem vê a auditoria completa abre a lista', () => {
+  as('quality1', () => throws(() => api.listContentAudit({}), /Acesso negado/));
+});
+
+check('a auditoria vem da mais recente para a mais antiga', () => {
+  semearAuditoria(120);
+  const r = api.listContentAudit({ limit: 10 });
+  eq(r.rows.length, 10);
+  const datas = r.rows.map(l => l.at);
+  eq(datas.slice().sort().reverse(), datas, 'ordem decrescente:');
+});
+
+check('filtra por quem fez', () => {
+  const r = api.listContentAudit({ actor: 'anaflor', limit: 20 });
+  eq(r.rows.every(l => l.actor === 'anaflor'), true);
+  eq(r.rows.length > 0, true, 'precisa achar alguma coisa:');
+});
+
+check('filtra por ação e por módulo', () => {
+  const r = api.listContentAudit({ action: 'reject', module: 'tips', limit: 20 });
+  eq(r.rows.every(l => l.action === 'reject' && l.module === 'tips'), true);
+  eq(r.rows.length > 0, true);
+});
+
+check('filtra por texto livre, no rótulo e no detalhe', () => {
+  const r = api.listContentAudit({ text: 'agulha', limit: 20 });
+  eq(r.rows.length, 1, 'a agulha é uma só:');
+  eq(/agulha/.test(r.rows[0].detail), true);
+});
+
+check('filtra por período, com o dia final inteiro', () => {
+  // O carimbo é ISO e o filtro é data: sem o cuidado com o fim do dia, uma
+  // linha das 10h do dia `to` ficaria de fora do próprio dia pedido.
+  const r = api.listContentAudit({ from: '2026-02-01', to: '2026-02-28', limit: 200 });
+  eq(r.rows.length > 0, true, 'precisa achar alguma coisa:');
+  eq(r.rows.every(l => l.at >= '2026-02-01' && l.at <= '2026-02-28Z'), true);
+
+  // O que de fato pega o erro: uma linha das 10h do DIA FINAL tem que entrar.
+  // Comparando `at > to` cru, ela ficaria de fora do próprio dia pedido.
+  eq(r.rows.some(l => l.at.indexOf('2026-02-28') === 0), true,
+    'o último dia do período precisa entrar inteiro');
+  // E o dia seguinte, não.
+  eq(r.rows.some(l => l.at.indexOf('2026-03-') === 0), false, 'não pode vazar para março');
+});
+
+check('a paginação não repete nem pula linha', () => {
+  const p1 = api.listContentAudit({ limit: 25 });
+  const p2 = api.listContentAudit({ limit: 25, cursor: p1.nextCursor });
+
+  eq(p1.rows.length, 25);
+  eq(p2.rows.length, 25);
+
+  const ids1 = p1.rows.map(l => l.id);
+  const ids2 = p2.rows.map(l => l.id);
+  eq(ids1.filter(id => ids2.indexOf(id) !== -1), [], 'nenhum id nas duas páginas:');
+
+  // E a segunda continua exatamente onde a primeira parou.
+  eq(p2.rows[0].at <= p1.rows[24].at, true, 'a página 2 começa antes do fim da 1:');
+});
+
+check('paginar até o fim termina, e diz que terminou', () => {
+  let cursor = 0;
+  let total = 0;
+  let voltas = 0;
+  let fim = false;
+
+  while (voltas < 40) {
+    const p = api.listContentAudit({ limit: 200, cursor: cursor });
+    total += p.rows.length;
+    voltas++;
+    if (p.done) { fim = true; break; }
+    if (!p.nextCursor) break;
+    cursor = p.nextCursor;
+  }
+
+  eq(fim, true, 'a varredura precisa terminar sozinha:');
+  eq(total >= 120, true, 'trouxe pelo menos as 120 semeadas, veio ' + total);
+});
+
+check('exportar escreve uma aba com o MESMO filtro da tela', () => {
+  const r = api.exportContentAudit({ actor: 'anaflor' });
+  eq(r.sheet, 'Content_Audit_Export');
+  eq(r.rows > 0, true);
+
+  const aba = SS.getSheetByName('Content_Audit_Export');
+  eq(aba._data[0], ['Quando', 'Quem', 'Ação', 'Módulo', 'Chave', 'Item', 'Rótulo', 'Detalhe']);
+  eq(aba._data.length - 1, r.rows, 'cabeçalho + as linhas:');
+  eq(aba._data.slice(1).every(l => l[1] === 'anaflor'), true, 'o filtro valeu na exportação:');
+});
+
+check('exportar de novo substitui, não empilha', () => {
+  const grande = SS.getSheetByName('Content_Audit_Export')._data.length;
+  eq(grande > 3, true, 'a primeira exportação precisa ser grande para o teste valer:');
+
+  // Uma exportação MENOR depois de uma grande: sem limpar a aba, as linhas
+  // antigas sobreviveriam embaixo e a exportação passaria a misturar dois
+  // filtros diferentes — que é o pior desfecho possível para uma auditoria.
+  const r = api.exportContentAudit({ text: 'agulha' });
+  eq(r.rows, 1);
+  eq(SS.getSheetByName('Content_Audit_Export')._data.length, 2, 'cabeçalho + uma linha:');
+});
+
+check('a própria exportação vai para a auditoria', () => {
+  const linha = logDaCentral().filter(l => l.Action === 'audit_export').pop();
+  eq(linha.Actor, 'lucaste');
+  eq(/linhas/.test(String(linha.Detail)), true);
+});
+
+check('quem não vê a auditoria também não exporta', () => {
+  as('quality1', () => throws(() => api.exportContentAudit({}), /Acesso negado/));
 });
 
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -192,3 +192,40 @@ e texto:
   publicado.
 - **Expirar não arquiva.** O item continua `live` na planilha, fora da janela.
   É o que permite estender a validade editando, em vez de republicar.
+
+---
+
+## Auditoria completa (aba restrita)
+
+| Função | Params | Quem pode | Resposta |
+| :--- | :--- | :--- | :--- |
+| `listContentAudit(filtro)` | `{ text?, actor?, action?, module?, from?, to?, limit?, cursor? }` | `viewAudit` | `{ rows, nextCursor, scanned, done }` |
+| `exportContentAudit(filtro)` | o mesmo filtro | `viewAudit` | `{ sheet, rows, truncated, url }` |
+
+### Regras
+- **Duas portas para duas perguntas.** `listContentActivity()` responde *"o que
+  está acontecendo"* — janela fixa, sem filtro, para a barra lateral.
+  `listContentAudit()` responde *"o que aconteceu"* — filtro, período e
+  paginação. Fundir as duas faria a barra pagar o preço da auditoria.
+- **`cursor` é o número da LINHA da planilha** onde a varredura parou, não um
+  "pule N resultados". É o que mantém o custo de cada página igual: pular
+  resultados obrigaria a refiltrar tudo que já foi mostrado.
+- **A ordem por linha É a ordem cronológica**, e isso não é sorte: `Content_Log`
+  só é anexada, e o backfill reordena o que traz. Ordenar 15 mil linhas por
+  consulta para chegar ao mesmo resultado seria pagar duas vezes.
+- **`done` é sobre a ABA ter acabado, não sobre a página ter enchido.** Cada
+  chamada varre no máximo `CONTENT_AUDIT_SCAN_MAX` linhas (o Apps Script tem 6
+  minutos e a aba guarda 24 meses); uma página curta por causa do teto ainda tem
+  continuação, e esconder "carregar mais" ali faria parecer que acabou.
+- **`to` inclui o dia inteiro.** O carimbo é ISO e o filtro é data: sem o
+  cuidado com o fim do dia, uma linha das 10h do dia final ficaria de fora do
+  próprio dia pedido.
+- **A exportação vai para uma ABA da própria planilha**, não para um arquivo. A
+  Central roda dentro de um iframe do Apps Script, onde download iniciado pela
+  página é bloqueado com frequência e sem aviso; uma aba é o formato que esta
+  operação já sabe abrir, filtrar e baixar, e não pede permissão nenhuma nova.
+- **A exportação sobrescreve sempre a mesma aba** (`Content_Audit_Export`), e
+  limpa antes de escrever. Uma aba por exportação encheria a planilha de lixo;
+  não limpar faria uma exportação menor herdar as linhas da anterior — dois
+  filtros misturados, que é o pior desfecho possível para uma auditoria.
+- **Exportar é auditado.** A própria exportação vira uma linha em `Content_Log`.


### PR DESCRIPTION
## O que muda

A aba **Auditoria**, restrita a quem tem `ver auditoria completa`. É o "PR final adicional" que você pediu lá no começo: o histórico longo, separado da barra lateral.

## Por que assim

**Duas portas para duas perguntas.** A barra lateral responde *"o que está acontecendo"* — janela fixa de 200 linhas, sem filtro, custo constante. Esta responde *"o que aconteceu"* — busca por texto, filtro de quem/ação/módulo, período e paginação. Fundir as duas faria a barra, que carrega em toda visita, pagar o preço da auditoria.

**A paginação é por número de linha da planilha, não por "pule N resultados".** É o que mantém o custo de cada página igual: pular resultados obrigaria o servidor a refiltrar tudo que já foi mostrado, e a décima página custaria dez vezes a primeira. Funciona porque a ordem por linha é a ordem cronológica — e isso não é sorte: `Content_Log` só é anexada, e o backfill reordena o que traz da aba `Logs`. Ordenar 15 mil linhas a cada consulta para chegar ao mesmo resultado seria pagar duas vezes.

**Cada chamada tem teto de varredura**, porque o Apps Script tem 6 minutos e a aba guarda 24 meses. Um filtro que casa com pouca coisa percorreria a aba inteira. Daí a distinção que a tela precisa fazer: **`done` é sobre a aba ter acabado, não sobre a página ter enchido**. Uma página curta por causa do teto ainda tem continuação, e esconder "carregar mais" ali faria parecer que o histórico acabou — um "carregar mais" que mente é pior que não ter.

**A exportação vai para uma aba da própria planilha**, e essa é a decisão que mais mereceu pensar. Arquivo seria o reflexo — mas a Central roda dentro de um iframe do Apps Script, onde download iniciado pela página é bloqueado com frequência **e sem aviso**: o botão pareceria funcionar e nada aconteceria. Uma aba é o formato que esta operação já sabe abrir, filtrar e baixar, e não pede nenhuma permissão que o projeto ainda não tenha. Sempre a mesma aba (uma por exportação encheria a planilha de lixo que ninguém apaga), sempre limpa antes — sem limpar, uma exportação menor herdaria as linhas da anterior, e **duas exportações misturadas é o pior desfecho possível para uma auditoria**.

E a própria exportação vira uma linha na auditoria.

## Como verificar

```
npm run test:content    # 162 testes (eram 150)
npm run smoke:content   # 92 verificações (eram 83)
```

```
--- servidor ---
✓ só quem vê a auditoria completa abre a lista
✓ a auditoria vem da mais recente para a mais antiga
✓ filtra por quem fez / por ação e módulo / por texto livre
✓ filtra por período, com o dia final inteiro
✓ a paginação não repete nem pula linha
✓ paginar até o fim termina, e diz que terminou
✓ exportar escreve uma aba com o MESMO filtro da tela
✓ exportar de novo substitui, não empilha

--- tela ---
✓ quem não vê a auditoria não tem a aba
✓ "carregar mais" continua de onde parou, sem repetir
✓ chegando ao fim, o botão some e a tela diz que acabou
✓ filtro sem resultado explica em vez de mostrar tabela vazia
✓ exportar leva o MESMO filtro da tela
```

**As mutações pegaram dois testes meus que não provavam nada.** "Filtra por período" só afirmava que as linhas estavam dentro do intervalo — o que continua verdadeiro quando o último dia é indevidamente excluído; agora ele afirma que uma linha das 10h do dia final **entra**. E "exportar de novo substitui" comparava o tamanho da aba com o mesmo filtro, o que dá igual com ou sem `clear()`; agora exporta um resultado **menor** depois de um grande, que é o caso em que o lixo sobreviveria. As duas mutações passam a falhar.

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente.

## Checklist

- [x] Mexi em `gas-backend/`: `listContentAudit` e `exportContentAudit` entraram em `specs/data-models/api-payloads.md`, com as sete regras que os definem.
- [x] Regra de negócio: nenhuma nova — é leitura do que já era registrado. A exportação é a única escrita, e ela mesma é auditada.
- [x] Decisão que alguém vai questionar depois: "por que aba e não arquivo", "por que cursor por linha" e "por que `done` não é `rows.length < limit`" estão comentadas no ponto exato do código.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_