### PR TITLE
feat(central): cobrança diária das propostas paradas na fila

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Cobrança diária das propostas paradas** (fase 5). A fila avisava quem aprova
+  **uma vez**, no momento em que a proposta entrava. Quem não abriu o e-mail
+  naquele dia nunca mais soube: quem propôs achava que estava em análise, quem
+  aprova nunca viu, e o item ficava parado por semanas sem que o sistema tivesse
+  errado em nada. Agora um gatilho diário manda **um e-mail por aprovador, só
+  com o que ele pode resolver** — mandar a fila inteira para todo mundo é como a
+  cobrança vira ruído e passa a ser apagada sem ler —, e não cobra ninguém pela
+  própria proposta. O link vem do mapa de implantações e não de
+  `getUrl()`: num gatilho de tempo o serviço pode devolver a URL de outra
+  implantação, e a pessoa cairia no ambiente errado. O gatilho precisa ser
+  criado à mão uma vez, como o do `Backup.js`; `listStaleContentApprovals()`
+  mostra quem seria cobrado antes de ligá-lo.
 - **Aba de auditoria, restrita a quem tem `ver auditoria completa`** (fase 5).
   A barra lateral responde *"o que está acontecendo"*; esta responde *"o que
   aconteceu"* — com busca por texto, filtro de quem/ação/módulo, período e

--- a/PLAN.md
+++ b/PLAN.md
@@ -89,10 +89,9 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       paginação por número de linha e exportação para uma aba da planilha
       (arquivo não serve: download iniciado dentro do iframe do Apps Script é
       bloqueado com frequência e sem aviso).
-      **Falta:** prévia "como o agente vê"; busca global Ctrl+K;
-      cobrança diária de pendência parada — esta lendo
-      `CW_DEPLOYMENTS` e não a URL do serviço, porque em gatilho de tempo a
-      derivação não é confiável (ver `Código.js`). **PR final:** aba de
+      **Entregue também:** cobrança diária de pendência parada, lendo
+      `CW_DEPLOYMENTS` e não a URL do serviço.
+      **Falta:** prévia "como o agente vê" e busca global Ctrl+K. **PR final:** aba de
       auditoria restrita, com filtros, paginação e exportação.
 
 ## Ideas — to triage
@@ -103,6 +102,11 @@ Raw ideas, captured before they're lost (e.g. via `/groundrules:idea`). Not yet 
 
 ## Waiting / blocked
 
+- [ ] **Criar o gatilho diário de `notifyStaleContentApprovals()`** pelo editor
+      do Apps Script (o projeto não cria gatilho por código — mesma nota do
+      `Backup.js`). Antes de ligar, rode `listStaleContentApprovals()` e confira
+      quem seria cobrado e por quantos itens: é a leitura que existe justamente
+      para o primeiro disparo não surpreender ninguém.
 - [ ] **Rodar o `backfillContentLog()` na planilha de verdade.** Só quem tem
       `manageAccess` roda, e o passo 1 é `backfillContentLog()` **sem argumento**:
       ele apenas relata quantas linhas traria. Confira o número contra a aba

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -2571,6 +2571,145 @@ function listContentActivity(limite) {
 }
 
 // =========================================================
+//  COBRANÇA DE PENDÊNCIA PARADA
+//
+//  A fila avisa quem aprova UMA vez, no momento em que a proposta entra. Se
+//  ninguém abrir o e-mail naquele dia, a proposta some do radar: quem propôs
+//  acha que está em análise, quem aprova nunca soube, e o item fica parado por
+//  semanas sem que o sistema tenha errado em nada.
+//
+//  Roda por gatilho de tempo. Criar o gatilho é passo manual pelo editor do
+//  Apps Script, uma vez — mesma nota que o Backup.js já carrega.
+// =========================================================
+
+// Dias corridos, não úteis. Contar dias úteis exigiria um calendário de
+// feriados que este projeto não tem, e errar para MAIS avisos é o lado barato
+// do erro: uma cobrança a mais numa segunda incomoda, uma cobrança a menos
+// deixa a proposta parada.
+const CONTENT_STALE_DAYS = 2;
+
+// Teto de itens listados por e-mail. Acima disso o e-mail vira parede de texto
+// que ninguém lê — e a Central está a um clique.
+const CONTENT_STALE_MAX_LISTED = 10;
+
+function contentStaleCutoff_() {
+  const d = new Date();
+  d.setDate(d.getDate() - CONTENT_STALE_DAYS);
+  return d.toISOString();
+}
+
+/**
+ * As propostas paradas, agrupadas POR QUEM PODE RESOLVÊ-LAS.
+ *
+ * Agrupar por aprovador e não mandar a fila inteira para todo mundo é o que
+ * evita a cobrança virar ruído: um QA recebendo pendência de e-mail que ele não
+ * revisa aprende a apagar o e-mail sem ler.
+ */
+function staleContentApprovals_() {
+  const corte = contentStaleCutoff_();
+
+  const paradas = readContentRows_(SHEET_CONTENT_DRAFTS)
+    .filter(function (r) {
+      return String(r.Status).trim() === CONTENT_STATUS.PENDING &&
+        String(r.Proposed_At || "") < corte;
+    })
+    .map(mapDraftRow_);
+
+  if (!paradas.length) return { stale: [], porPessoa: {} };
+
+  const porPessoa = {};
+
+  readContentRows_(SHEET_CONTENT_ACCESS).forEach(function (r) {
+    const ativo = String(r.Active).toUpperCase().trim();
+    if (ativo !== 'TRUE' && ativo !== '1') return;
+
+    const ldap = String(r.LDAP || "").toLowerCase().trim();
+    const perms = getContentPermsForRole_(String(r.Role || "").toUpperCase().trim());
+    if (!ldap || !perms) return;
+
+    const minhas = paradas.filter(function (d) {
+      if (!podeAprovarModulo_(perms, d.module)) return false;
+      // Não cobrar alguém pela própria proposta: quem não pode se
+      // autoaprovar receberia um lembrete de algo que não consegue resolver.
+      if (d.proposedBy === ldap && !podeGlobal_(perms, 'selfApprove')) return false;
+      return true;
+    });
+
+    if (minhas.length) porPessoa[ldap] = minhas;
+  });
+
+  return { stale: paradas, porPessoa: porPessoa };
+}
+
+/** Leitura da cobrança, para conferir antes de deixar o gatilho rodar sozinho. */
+function listStaleContentApprovals() {
+  assertContentRole_('approve', null);
+
+  const r = staleContentApprovals_();
+  return {
+    days: CONTENT_STALE_DAYS,
+    stale: r.stale.length,
+    recipients: Object.keys(r.porPessoa).sort().map(function (ldap) {
+      return { ldap: ldap, items: r.porPessoa[ldap].length };
+    })
+  };
+}
+
+/**
+ * O disparo diário. Sem argumentos, para caber num gatilho de tempo.
+ *
+ * Nunca lança: um gatilho que falha some do radar do mesmo jeito que a
+ * pendência que ele existe para lembrar. O que der errado vai para o log.
+ */
+function notifyStaleContentApprovals() {
+  try {
+    const r = staleContentApprovals_();
+    const destinatarios = Object.keys(r.porPessoa);
+
+    if (!destinatarios.length) {
+      return { status: 'ok', stale: r.stale.length, notified: 0 };
+    }
+
+    // Link montado a partir do MAPA de implantações, não de getUrl(): num
+    // gatilho de tempo o serviço pode devolver a URL de outra implantação, e a
+    // pessoa cairia no ambiente errado. Ver buildProductionPageUrl().
+    const url = buildProductionPageUrl('content');
+
+    destinatarios.forEach(function (ldap) {
+      const itens = r.porPessoa[ldap];
+      const listados = itens.slice(0, CONTENT_STALE_MAX_LISTED);
+
+      const linhas = listados.map(function (d) {
+        return '<li><strong>' + d.label + '</strong> — ' + d.module +
+          ' · proposto por ' + d.proposedBy + '</li>';
+      }).join('');
+
+      const sobra = itens.length > listados.length
+        ? '<p>…e mais ' + (itens.length - listados.length) + '.</p>' : '';
+
+      MailApp.sendEmail({
+        to: ldap + '@google.com',
+        subject: '⏳ Central de Conteúdo: ' + itens.length +
+          (itens.length === 1 ? ' proposta parada' : ' propostas paradas'),
+        htmlBody:
+          '<p>Estas propostas estão esperando revisão há mais de ' +
+          CONTENT_STALE_DAYS + ' dias:</p><ul>' + linhas + '</ul>' + sobra +
+          '<p><a href="' + url + '">Abrir a Central de Conteúdo</a></p>',
+        name: 'Cases Wizard'
+      });
+    });
+
+    logContentEvent_('system', 'stale_digest', {},
+      r.stale.length + ' paradas · ' + destinatarios.length + ' avisados');
+
+    return { status: 'ok', stale: r.stale.length, notified: destinatarios.length };
+  } catch (e) {
+    logContentEvent_('system', 'stale_digest_failed', {}, String(e));
+    return { status: 'error', error: String(e) };
+  }
+}
+
+// =========================================================
 //  AUDITORIA COMPLETA (aba restrita)
 //
 //  A barra lateral responde "o que aconteceu agora"; esta responde "o que

--- a/gas-backend/Código.js
+++ b/gas-backend/Código.js
@@ -101,7 +101,23 @@ function getDeploymentEnv() {
 function buildDeploymentPageUrl(page) {
   var info = getDeploymentEnv();
   var id = CW_DEPLOYMENTS[info.env] || CW_DEPLOYMENTS.production;
-  return 'https://script.google.com/a/macros/google.com/s/' + id +
+  return buildPageUrlFor_(id, page);
+}
+
+/**
+ * URL de uma página numa implantação ESPECÍFICA, sem perguntar ao serviço.
+ *
+ * É o que um gatilho de tempo precisa: ali `getUrl()` pode devolver a URL de
+ * outra implantação do projeto, e o link do e-mail levaria a pessoa para o
+ * ambiente errado. Um gatilho é do PROJETO, não da implantação — ele roda uma
+ * vez, e o destino certo é sempre produção.
+ */
+function buildProductionPageUrl(page) {
+  return buildPageUrlFor_(CW_DEPLOYMENTS.production, page);
+}
+
+function buildPageUrlFor_(deploymentId, page) {
+  return 'https://script.google.com/a/macros/google.com/s/' + deploymentId +
     '/exec?page=' + encodeURIComponent(page);
 }
 

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -2277,5 +2277,111 @@ check('quem não vê a auditoria também não exporta', () => {
   as('quality1', () => throws(() => api.exportContentAudit({}), /Acesso negado/));
 });
 
+console.log('\n--- Cobrança de pendência parada ---');
+
+// Envelhece um rascunho mexendo na coluna Proposed_At: o que se testa é a
+// regra de "parado há mais de N dias", não a passagem do tempo.
+function envelhecerProposta(draftId, dias) {
+  const aba = SS.getSheetByName('Content_Drafts');
+  const linha = aba._data.find((l) => String(l[0]) === draftId);
+  const d = new Date();
+  d.setDate(d.getDate() - dias);
+  linha[10] = d.toISOString();
+}
+
+check('proposta recente não vira cobrança', () => {
+  api.saveContentAccess('rev1', 'TL', true);
+  const d = as('rev1', () => api.saveAndSubmitContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Dica nova',
+    value: 'Confira o idioma antes de encerrar.'
+  }));
+
+  const r = api.listStaleContentApprovals();
+  eq(r.stale, 0, 'nada parado ainda:');
+  return d;
+});
+
+let draftParado;
+check('passados os dias, ela aparece — e para quem PODE resolvê-la', () => {
+  const d = as('rev1', () => api.saveAndSubmitContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Dica esquecida',
+    value: 'Confira o substatus antes de encerrar.'
+  }));
+  draftParado = d.draftId;
+  envelhecerProposta(draftParado, 5);
+
+  const r = api.listStaleContentApprovals();
+  eq(r.stale, 1);
+  const quem = r.recipients.map(x => x.ldap);
+  eq(quem.indexOf('lucaste') !== -1, true, 'o ADMIN aprova dicas:');
+  // O QA não revisa dicas. Mandar a fila inteira para todo mundo é como a
+  // cobrança vira ruído e passa a ser apagada sem ler.
+  eq(quem.indexOf('quality1'), -1, 'o QA não deveria ser cobrado:');
+});
+
+check('quem propôs não é cobrado pela própria proposta', () => {
+  // rev1 é TL: aprova dicas, mas não aprova a si mesmo. Um lembrete de algo
+  // que a pessoa não consegue resolver é só barulho.
+  const quem = api.listStaleContentApprovals().recipients.map(x => x.ldap);
+  eq(quem.indexOf('rev1'), -1, 'o autor não deveria ser cobrado:');
+});
+
+check('o disparo manda um e-mail por pessoa, com o link de PRODUÇÃO', () => {
+  const antes = SENT_MAIL.length;
+  const r = api.notifyStaleContentApprovals();
+
+  eq(r.status, 'ok');
+  eq(r.notified > 0, true, 'alguém precisa ser avisado:');
+
+  const enviados = SENT_MAIL.slice(antes);
+  eq(enviados.length, r.notified, 'um e-mail por pessoa:');
+  eq(/Dica esquecida/.test(enviados[0].htmlBody), true, 'o item precisa estar no corpo:');
+
+  // Num gatilho de tempo getUrl() pode devolver a URL de OUTRA implantação: o
+  // link tem que vir do mapa, e apontar para produção.
+  const producao = vm.runInContext('CW_DEPLOYMENTS.production', ctx);
+  eq(enviados[0].htmlBody.indexOf(producao) !== -1, true,
+    'o link deveria apontar para a implantação de produção');
+  eq(/page=content/.test(enviados[0].htmlBody), true);
+});
+
+check('o disparo vai para a auditoria', () => {
+  const linha = logDaCentral().filter(l => l.Action === 'stale_digest').pop();
+  eq(linha.Actor, 'system');
+  eq(/paradas/.test(String(linha.Detail)), true);
+});
+
+check('sem nada parado, o disparo não manda e-mail nenhum', () => {
+  api.approveContentDraft(draftParado, '');
+  const antes = SENT_MAIL.length;
+  const r = api.notifyStaleContentApprovals();
+  eq(r.notified, 0);
+  eq(SENT_MAIL.length, antes, 'nenhum e-mail:');
+});
+
+check('o gatilho nunca lança — falha vira log, não exceção', () => {
+  // Um gatilho que estoura some do radar do mesmo jeito que a pendência que
+  // ele existe para lembrar.
+  const original = sandbox.MailApp.sendEmail;
+  sandbox.MailApp.sendEmail = () => { throw new Error('quota estourada'); };
+
+  const d = as('rev1', () => api.saveAndSubmitContentDraft({
+    module: 'tips', key: 'geral', lang: 'PT', label: 'Outra parada',
+    value: 'Confira o fluxo antes de encerrar.'
+  }));
+  envelhecerProposta(d.draftId, 5);
+
+  const r = api.notifyStaleContentApprovals();
+  sandbox.MailApp.sendEmail = original;
+
+  eq(r.status, 'error', 'devolve o erro em vez de estourar:');
+  const linha = logDaCentral().filter(l => l.Action === 'stale_digest_failed').pop();
+  eq(/quota estourada/.test(String(linha.Detail)), true, 'e o motivo fica registrado:');
+});
+
+check('quem não aprova nada não consulta a cobrança', () => {
+  as('quality1', () => throws(() => api.listStaleContentApprovals(), /Acesso negado/));
+});
+
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);
 process.exit(fail ? 1 : 0);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -229,3 +229,34 @@ e texto:
   não limpar faria uma exportação menor herdar as linhas da anterior — dois
   filtros misturados, que é o pior desfecho possível para uma auditoria.
 - **Exportar é auditado.** A própria exportação vira uma linha em `Content_Log`.
+
+---
+
+## Cobrança de pendência parada (gatilho de tempo)
+
+| Função | Params | Quem pode | Resposta |
+| :--- | :--- | :--- | :--- |
+| `notifyStaleContentApprovals()` | — (para caber num gatilho) | o gatilho | `{ status, stale, notified }` |
+| `listStaleContentApprovals()` | — | `approve` em algum módulo | `{ days, stale, recipients: [{ ldap, items }] }` |
+
+### Regras
+- **Um e-mail por aprovador, com o que ELE pode resolver.** Mandar a fila
+  inteira para todo mundo é como a cobrança vira ruído: um QA que recebe
+  pendência de e-mail que ele não revisa aprende a apagar o e-mail sem ler.
+- **Quem propôs não é cobrado pela própria proposta**, a menos que possa
+  aprovar a si mesmo. Lembrete de algo que a pessoa não consegue resolver é
+  só barulho.
+- **O link vem do MAPA de implantações** (`buildProductionPageUrl`), nunca de
+  `ScriptApp.getService().getUrl()`. Num gatilho de tempo o serviço pode
+  devolver a URL de outra implantação do projeto, e a pessoa cairia no ambiente
+  errado. Um gatilho é do **projeto**, não da implantação: ele roda uma vez, e o
+  destino certo é sempre produção.
+- **Nunca lança.** Um gatilho que estoura some do radar exatamente como a
+  pendência que ele existe para lembrar; o que der errado vira linha em
+  `Content_Log` (`stale_digest_failed`).
+- **Dias corridos, não úteis.** Contar dias úteis exigiria um calendário de
+  feriados que o projeto não tem, e errar para MAIS avisos é o lado barato do
+  erro.
+- **O gatilho é criado à mão**, uma vez, pelo editor do Apps Script — mesma nota
+  que o `Backup.js` já carrega. Antes de ligar, `listStaleContentApprovals()`
+  mostra quem seria cobrado e por quantos itens.


### PR DESCRIPTION
## O que muda

Um gatilho diário que cobra as propostas paradas na fila há mais de dois dias.

## Por que assim

**O buraco não era um bug.** A fila avisava quem aprova **uma vez**, no momento em que a proposta entrava. Se ninguém abriu aquele e-mail naquele dia, a proposta sumia do radar: quem propôs achava que estava em análise, quem aprova nunca soube, e o item ficava parado por semanas sem que o sistema tivesse errado em nada.

**Um e-mail por aprovador, só com o que ele pode resolver.** Mandar a fila inteira para todo mundo é exatamente como uma cobrança vira ruído: um QA que recebe pendência de e-mail que ele não revisa aprende a apagar o e-mail sem ler — e aí a cobrança deixa de funcionar justamente quando importa. O agrupamento usa a matriz do ADR-0009, então ele acompanha qualquer papel novo sem mudança de código.

**Ninguém é cobrado pela própria proposta** quando não pode se autoaprovar. Lembrete de algo que a pessoa não consegue resolver é só barulho.

**O link vem do mapa `CW_DEPLOYMENTS`, não de `getUrl()`.** Num gatilho de tempo o serviço pode devolver a URL de outra implantação do projeto, e a pessoa cairia no ambiente errado — é a mesma ressalva que o `TL_DASHBOARD_URL` do `EmailEngine.js` já registrava, e o motivo de eu **não** ter mexido nele lá na fase 1. Um gatilho é do **projeto**, não da implantação: roda uma vez, e o destino certo é sempre produção. Entrou `buildProductionPageUrl()` ao lado do `buildDeploymentPageUrl()` que já existia, para os dois casos ficarem lado a lado com o porquê escrito.

**Nunca lança.** Um gatilho que estoura some do radar do mesmo jeito que a pendência que ele existe para lembrar; o que der errado vira linha no `Content_Log`.

**Dias corridos, não úteis.** Contar dias úteis exigiria um calendário de feriados que o projeto não tem, e errar para *mais* avisos é o lado barato do erro: uma cobrança a mais numa segunda incomoda, uma cobrança a menos deixa a proposta parada.

## Como verificar

```
npm run test:content    # 170 testes (eram 162)
```

```
✓ proposta recente não vira cobrança
✓ passados os dias, ela aparece — e para quem PODE resolvê-la
✓ quem propôs não é cobrado pela própria proposta
✓ o disparo manda um e-mail por pessoa, com o link de PRODUÇÃO
✓ sem nada parado, o disparo não manda e-mail nenhum
✓ o gatilho nunca lança — falha vira log, não exceção
✓ quem não aprova nada não consulta a cobrança
```

**Quatro mutações confirmam que elas falham quando devem** — cobrar sem olhar quem aprova o módulo, cobrar o próprio autor, link fora do mapa de implantações, e deixar a exceção subir.

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica; e **nada dispara sozinho até alguém criar o gatilho**, o que é deliberado (ver abaixo).

## O passo manual, e a ordem certa

Está registrado no `PLAN.md` → *Waiting*. O projeto não cria gatilho por código — mesma nota que o `Backup.js` carrega. Antes de ligar:

1. rode **`listStaleContentApprovals()`** pelo editor: ele mostra quem seria cobrado e por quantos itens, sem mandar nada;
2. confira a lista — é a leitura que existe justamente para o primeiro disparo não surpreender ninguém;
3. só então crie o gatilho diário para `notifyStaleContentApprovals`.

## Checklist

- [x] Mexi em `gas-backend/`: as duas funções e as seis regras entraram em `specs/data-models/api-payloads.md`.
- [x] Regra de negócio: quem recebe a cobrança deriva da matriz de permissões, não de uma lista à parte — um papel novo já entra sozinho.
- [x] Decisão que alguém vai questionar depois: "por que o mapa e não `getUrl()`" e "por que dias corridos" estão comentadas no ponto exato do código.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_