### PR TITLE
feat(central): busca global por Ctrl+K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Busca global na Central, por `Ctrl+K`** (fase 5). A tela tem dez destinos e
+  centenas de itens; achar *"aquele link do Ads"* custava lembrar em qual aba
+  ele mora e rolar a lista — e quem não lembra desiste e cria um item duplicado,
+  que é o pior desfecho. A busca acha destino **e** conteúdo, ignora acento
+  ("anuncio" acha "anúncio"), respeita o `ver` da matriz de papéis, e leva
+  direto ao item, apontando a linha na lista. Duas velocidades de propósito: os
+  destinos filtram na tecla, o conteúdo espera 220 ms de silêncio — sem o
+  atraso, cada tecla viraria uma execução do Apps Script. E há um botão no
+  header: atalho de teclado que ninguém sabe que existe não existe.
 - **Cobrança diária das propostas paradas** (fase 5). A fila avisava quem aprova
   **uma vez**, no momento em que a proposta entrava. Quem não abriu o e-mail
   naquele dia nunca mais soube: quem propôs achava que estava em análise, quem

--- a/PLAN.md
+++ b/PLAN.md
@@ -91,7 +91,10 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       bloqueado com frequência e sem aviso).
       **Entregue também:** cobrança diária de pendência parada, lendo
       `CW_DEPLOYMENTS` e não a URL do serviço.
-      **Falta:** prévia "como o agente vê" e busca global Ctrl+K. **PR final:** aba de
+      **Entregue também:** busca global Ctrl+K — destino e conteúdo na mesma
+      lista, sem acento, filtrada pelo `ver` da matriz, com duas velocidades
+      (destino na tecla, conteúdo depois de 220 ms de silêncio).
+      **Falta:** prévia "como o agente vê". **PR final:** aba de
       auditoria restrita, com filtros, paginação e exportação.
 
 ## Ideas — to triage

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -2571,6 +2571,100 @@ function listContentActivity(limite) {
 }
 
 // =========================================================
+//  BUSCA GLOBAL (Ctrl+K)
+// =========================================================
+
+const CONTENT_SEARCH_MIN = 2;
+const CONTENT_SEARCH_MAX = 30;
+
+// Faixa dos diacríticos combináveis (U+0300–U+036F), montada por fromCharCode
+// em vez de literal `\u` — o mesmo cuidado que o bundle já toma com este
+// arquivo servido pelo Apps Script.
+const CONTENT_DIACRITICOS = new RegExp(
+  '[' + String.fromCharCode(768) + '-' + String.fromCharCode(879) + ']', 'g');
+
+// "anuncio" precisa achar "anúncio". Quem busca não digita acento, e uma busca
+// que exige acento é uma busca que a pessoa conclui estar quebrada.
+function semAcento_(texto) {
+  return String(texto == null ? "" : texto)
+    .normalize('NFD')
+    .replace(CONTENT_DIACRITICOS, '')
+    .toLowerCase();
+}
+
+/**
+ * Procura em tudo que a pessoa PODE VER, numa varredura só.
+ *
+ * Uma varredura e não uma por módulo: a alternativa seria a tela pedir os oito
+ * módulos e juntar, que é oito execuções do Apps Script por tecla digitada —
+ * exatamente o padrão que o ADR-0008 existe para não repetir.
+ *
+ * O filtro de leitura é o mesmo `view` da matriz. Uma busca que ignora
+ * permissão é a porta dos fundos mais fácil de esquecer que existe: o módulo
+ * `people` sairia inteiro num "a".
+ */
+function searchContentItems(termo) {
+  const ldap = getCallerLdap_();
+  const role = getContentRoleForLdap_(ldap);
+  if (!role) throw new Error("Acesso negado: você não tem permissão na Central de Conteúdo.");
+
+  const alvo = semAcento_(termo).trim();
+  if (alvo.length < CONTENT_SEARCH_MIN) return [];
+
+  const perms = getContentPermsForRole_(role);
+  const visiveis = {};
+  CONTENT_MODULES.forEach(function (m) {
+    if (podeNoModulo_(perms, m, 'view')) visiveis[m] = true;
+  });
+
+  const achados = [];
+
+  const linhas = readContentRows_(SHEET_CONTENT_ITEMS);
+  for (let i = 0; i < linhas.length && achados.length < CONTENT_SEARCH_MAX; i++) {
+    const r = linhas[i];
+    if (String(r.Status).trim() !== CONTENT_STATUS.LIVE) continue;
+
+    const module = String(r.Module).trim();
+    if (!visiveis[module]) continue;
+
+    const label = String(r.Label || "");
+    const key = String(r.Key || "");
+    const value = String(r.Value || "");
+
+    if (semAcento_(label + ' ' + key + ' ' + value).indexOf(alvo) === -1) continue;
+
+    achados.push({
+      id: String(r.ID || ""),
+      module: module,
+      key: key,
+      label: label,
+      lang: String(r.Lang || 'ALL'),
+      // Um pedaço do valor ao redor do que casou, para a lista distinguir dois
+      // itens de nome parecido sem obrigar a abrir os dois.
+      snippet: trechoDaBusca_(value, alvo)
+    });
+  }
+
+  return achados;
+}
+
+// O valor pode ser JSON, e um JSON cru no resultado atrapalha mais do que
+// ajuda. Corta ao redor do que casou e tira as marcas de estrutura.
+function trechoDaBusca_(value, alvo) {
+  const limpo = String(value || "")
+    .replace(/[{}"\[\]]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const onde = semAcento_(limpo).indexOf(alvo);
+  if (onde === -1) return limpo.slice(0, 90);
+
+  const inicio = Math.max(0, onde - 30);
+  return (inicio ? '…' : '') + limpo.slice(inicio, inicio + 90) +
+    (limpo.length > inicio + 90 ? '…' : '');
+}
+
+// =========================================================
 //  COBRANÇA DE PENDÊNCIA PARADA
 //
 //  A fila avisa quem aprova UMA vez, no momento em que a proposta entra. Se

--- a/gas-backend/ContentDashboard.html
+++ b/gas-backend/ContentDashboard.html
@@ -41,6 +41,13 @@
         <div class="topnav-fim">
             <!-- Nasce escondido: antes de saber quem é a pessoa não há
                  atividade que ela possa ver. -->
+            <!-- Atalho de teclado que ninguém sabe que existe não existe: o
+                 botão é o que ensina o Ctrl+K. -->
+            <button class="topnav-acao hidden" id="btn-busca" onclick="abrirBusca()">
+                <span class="material-symbols-rounded" aria-hidden="true">search</span>
+                <span class="topnav-acao-label">Buscar</span>
+                <kbd class="topnav-kbd">Ctrl K</kbd>
+            </button>
             <button class="topnav-acao hidden" id="btn-ver-como" onclick="abrirVerComo()">
                 <span class="material-symbols-rounded" aria-hidden="true">visibility</span>
                 <span class="topnav-acao-label">Ver como</span>
@@ -568,6 +575,7 @@
 
     </div>
 
+    <div id="busca-root"></div>
     <div id="modal-root"></div>
     <div id="toast" role="status" aria-live="polite"></div>
 

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -83,7 +83,7 @@
                         '</div>'
                         : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
-                    html += '<div class="item-row">' +
+                    html += '<div class="item-row" data-item="' + esc(it.id) + '">' +
                         '<div class="item-main">' +
                         '<div class="item-name">' + esc(v.name) + ' ' + badge + '</div>' +
                         '<div class="item-meta">' + esc(v.desc) + ' — ' + esc(v.url) + '</div>' +
@@ -426,7 +426,7 @@
                         '</div>'
                         : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
-                    html += '<div class="item-row">' +
+                    html += '<div class="item-row" data-item="' + esc(it.id) + '">' +
                         '<div class="item-main">' +
                         '<div class="item-name">' + (idx + 1) + '. ' + badge + '</div>' +
                         '<div class="item-meta">' + esc(it.value) + '</div>' +
@@ -643,7 +643,7 @@
                         '</div>'
                         : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
-                    html += '<div class="item-row">' +
+                    html += '<div class="item-row" data-item="' + esc(it.id) + '">' +
                         '<div class="item-main">' +
                         '<div class="item-name">' + esc(it.label) + ' ' + badge + ' ' + escopo + '</div>' +
                         '<div class="item-meta">' + nCampos + ' campo' + (nCampos === 1 ? '' : 's') +
@@ -883,7 +883,7 @@
                         '</div>'
                         : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
-                    html += '<div class="item-row">' +
+                    html += '<div class="item-row" data-item="' + esc(it.id) + '">' +
                         '<div class="item-main">' +
                         '<div class="item-name">' + esc(it.label) + ' ' + badge + '</div>' +
                         '<div class="item-meta">' + esc(v.subject || '') + ' · ' + esc(phInfo) + '</div>' +
@@ -1061,7 +1061,7 @@
                     '</div>'
                     : '<div style="display:flex;gap:8px">' + historico + descarte + '</div>';
 
-                return '<div class="item-row">' +
+                return '<div class="item-row" data-item="' + esc(it.id) + '">' +
                     '<div class="item-main">' +
                     '<div class="item-meta" style="font-size:14px;color:var(--text-primary)">' +
                     esc(it.value) + ' ' + badge + '</div>' +

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -576,6 +576,220 @@
             if (!document.getElementById('pane-emails').classList.contains('hidden')) renderEmails();
         }
 
+        // --- Busca global (Ctrl+K) ---
+        //
+        // A Central tem dez destinos e centenas de itens. Achar "aquele link do
+        // Ads" custava lembrar em qual aba ele mora e rolar a lista — e quem
+        // não lembra desiste e cria um item duplicado, que é o pior desfecho.
+        //
+        // TUDO que entra aqui passa por esc(): o resultado mistura texto
+        // escrito por outras pessoas com marcação da tela, e é exatamente a
+        // classe de falha que docs/LEARNINGS.md registrou no Ctrl+K do bundle.
+        var BUSCA_ABERTA = false;
+        var BUSCA_TIMER = null;
+        var BUSCA_RESULTADOS = [];
+        var BUSCA_FOCO = 0;
+
+        // Um destino é resultado como qualquer outro: "aprovações" é o que
+        // muita gente vai digitar, e mandar procurar no trilho seria mandar
+        // fazer à mão o que a busca acabou de oferecer.
+        function destinosQueCasam(termo) {
+            var t = semAcentoNaTela(termo);
+            if (!t) return [];
+
+            return Object.keys(DESTINOS).filter(function (d) {
+                var botao = document.getElementById('tab-' + d);
+                // Só o que a pessoa realmente enxerga no trilho.
+                if (botao && botao.classList.contains('hidden')) return false;
+                return semAcentoNaTela(DESTINOS[d].titulo).indexOf(t) !== -1;
+            }).map(function (d) {
+                return { tipo: 'destino', destino: d, label: DESTINOS[d].titulo,
+                         snippet: DESTINOS[d].sub };
+            });
+        }
+
+        var DIACRITICOS_NA_TELA = new RegExp(
+            '[' + String.fromCharCode(768) + '-' + String.fromCharCode(879) + ']', 'g');
+
+        function semAcentoNaTela(texto) {
+            return String(texto == null ? '' : texto)
+                .normalize('NFD').replace(DIACRITICOS_NA_TELA, '').toLowerCase().trim();
+        }
+
+        function abrirBusca() {
+            if (BUSCA_ABERTA) return;
+            BUSCA_ABERTA = true;
+            BUSCA_RESULTADOS = [];
+            BUSCA_FOCO = 0;
+
+            document.getElementById('busca-root').innerHTML =
+                '<div class="busca-backdrop" onclick="if(event.target===this)fecharBusca()">' +
+                '<div class="busca-caixa" role="dialog" aria-modal="true" aria-label="Buscar na Central">' +
+                '<div class="busca-campo">' +
+                '<span class="material-symbols-rounded" aria-hidden="true">search</span>' +
+                '<input type="text" id="busca-input" autocomplete="off" ' +
+                'placeholder="Buscar item, módulo ou destino…" ' +
+                'aria-controls="busca-lista" aria-autocomplete="list">' +
+                '<kbd>Esc</kbd>' +
+                '</div>' +
+                '<div class="busca-lista" id="busca-lista" role="listbox"></div>' +
+                '</div></div>';
+
+            var campo = document.getElementById('busca-input');
+            campo.addEventListener('input', function () { agendarBusca(campo.value); });
+            campo.addEventListener('keydown', teclaNaBusca);
+            campo.focus();
+
+            renderBusca([], '');
+        }
+
+        function fecharBusca() {
+            BUSCA_ABERTA = false;
+            clearTimeout(BUSCA_TIMER);
+            document.getElementById('busca-root').innerHTML = '';
+        }
+
+        /**
+         * Duas velocidades, de propósito.
+         *
+         * Os destinos são calculados na TECLA: eles já estão na memória da
+         * tela, e esperar a rede para mostrar "Aprovações" faria a busca
+         * parecer lenta por causa da parte que nem precisava de rede.
+         *
+         * O conteúdo espera a pessoa parar de digitar. Sem o atraso, cada tecla
+         * vira uma execução do Apps Script — e o teto de execuções simultâneas é
+         * o recurso escasso deste backend (ADR-0008).
+         */
+        function agendarBusca(termo) {
+            var t = String(termo || '').trim();
+
+            BUSCA_RESULTADOS = destinosQueCasam(t);
+            BUSCA_FOCO = 0;
+            renderBusca(BUSCA_RESULTADOS, t, t.length >= 2);
+
+            clearTimeout(BUSCA_TIMER);
+            if (t.length < 2) return;
+            BUSCA_TIMER = setTimeout(function () { buscarAgora(t); }, 220);
+        }
+
+        function buscarAgora(termo) {
+            var t = String(termo || '').trim();
+            var locais = destinosQueCasam(t);
+
+            google.script.run
+                .withSuccessHandler(function (itens) {
+                    if (!BUSCA_ABERTA) return;
+                    var doServidor = (itens || []).map(function (it) {
+                        return { tipo: 'item', destino: destinoDoModulo(it.module),
+                                 module: it.module, id: it.id, label: it.label,
+                                 snippet: it.snippet };
+                    });
+                    BUSCA_RESULTADOS = locais.concat(doServidor);
+                    BUSCA_FOCO = 0;
+                    renderBusca(BUSCA_RESULTADOS, t);
+                })
+                .withFailureHandler(function (err) {
+                    if (BUSCA_ABERTA) renderBuscaErro(err.message);
+                })
+                .searchContentItems(t);
+        }
+
+        // Módulo do servidor -> destino do trilho. São nomes diferentes porque
+        // o trilho fala com quem usa e o módulo fala com o banco.
+        var DESTINO_DO_MODULO = {
+            links: 'links', call_script: 'callscript', note_template: 'notes',
+            email_template: 'emails', tips: 'tips', broadcast: 'broadcast',
+            bau_availability: 'bau', people: 'people'
+        };
+
+        function destinoDoModulo(module) {
+            return DESTINO_DO_MODULO[module] || 'home';
+        }
+
+        function renderBusca(lista, termo, carregando) {
+            var host = document.getElementById('busca-lista');
+            if (!host) return;
+
+            if (!lista.length) {
+                host.innerHTML = '<p class="busca-vazio">' +
+                    (termo.length < 2
+                        ? 'Digite ao menos duas letras.'
+                        : (carregando ? 'Procurando…' : 'Nada encontrado para “' + esc(termo) + '”.')) +
+                    '</p>';
+                return;
+            }
+
+            host.innerHTML = lista.map(function (r, i) {
+                var onde = r.tipo === 'destino'
+                    ? 'Ir para'
+                    : (ATIVIDADE_MODULO[r.module] || r.module);
+
+                return '<button class="busca-item' + (i === BUSCA_FOCO ? ' focado' : '') + '" ' +
+                    'role="option" aria-selected="' + (i === BUSCA_FOCO) + '" ' +
+                    'data-indice="' + i + '" onclick="escolherBusca(' + i + ')">' +
+                    '<span class="busca-onde">' + esc(onde) + '</span>' +
+                    '<span class="busca-nome">' + esc(r.label) + '</span>' +
+                    (r.snippet ? '<span class="busca-trecho">' + esc(r.snippet) + '</span>' : '') +
+                    '</button>';
+            }).join('') + (carregando ? '<p class="busca-vazio">Procurando no conteúdo…</p>' : '');
+        }
+
+        function renderBuscaErro(msg) {
+            var host = document.getElementById('busca-lista');
+            if (host) host.innerHTML = '<p class="busca-vazio">' + esc(msg) + '</p>';
+        }
+
+        function moverFoco(delta) {
+            if (!BUSCA_RESULTADOS.length) return;
+            BUSCA_FOCO = (BUSCA_FOCO + delta + BUSCA_RESULTADOS.length) % BUSCA_RESULTADOS.length;
+
+            var itens = document.querySelectorAll('.busca-item');
+            for (var i = 0; i < itens.length; i++) {
+                itens[i].classList.toggle('focado', i === BUSCA_FOCO);
+                itens[i].setAttribute('aria-selected', i === BUSCA_FOCO ? 'true' : 'false');
+            }
+            if (itens[BUSCA_FOCO]) itens[BUSCA_FOCO].scrollIntoView({ block: 'nearest' });
+        }
+
+        function teclaNaBusca(e) {
+            if (e.key === 'ArrowDown') { e.preventDefault(); moverFoco(1); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); moverFoco(-1); }
+            else if (e.key === 'Enter') { e.preventDefault(); escolherBusca(BUSCA_FOCO); }
+        }
+
+        function escolherBusca(indice) {
+            var r = BUSCA_RESULTADOS[indice];
+            if (!r) return;
+            fecharBusca();
+            switchTab(r.destino);
+            if (r.tipo === 'item') piscarItem(r.id);
+        }
+
+        // O destino abre e a lista carrega em seguida: o pisca espera o item
+        // existir no DOM em vez de procurar por um nó que ainda não chegou.
+        function piscarItem(itemId, tentativas) {
+            var restantes = (tentativas === undefined) ? 12 : tentativas;
+            var alvo = document.querySelector('[data-item="' + itemId + '"]');
+
+            if (!alvo) {
+                if (restantes > 0) setTimeout(function () { piscarItem(itemId, restantes - 1); }, 150);
+                return;
+            }
+
+            alvo.classList.add('flash-applied');
+            alvo.scrollIntoView({ block: 'center' });
+            setTimeout(function () { alvo.classList.remove('flash-applied'); }, 1200);
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
+                e.preventDefault();
+                if (BUSCA_ABERTA) fecharBusca(); else abrirBusca();
+            } else if (e.key === 'Escape' && BUSCA_ABERTA) {
+                fecharBusca();
+            }
+        });
+
         // --- Ver como ---
         //
         // Quem edita a matriz de papéis precisa poder CONFERIR o que configurou.
@@ -767,6 +981,7 @@
                     document.getElementById('shell').classList.remove('sem-trilho');
                     ligarTecladoDoTrilho();
 
+                    document.getElementById('btn-busca').classList.remove('hidden');
                     document.getElementById('btn-lateral').classList.remove('hidden');
                     aplicarLateral(lateralPreferida());
 

--- a/gas-backend/ContentDashboard_Ops.html
+++ b/gas-backend/ContentDashboard_Ops.html
@@ -102,7 +102,7 @@
                 var preview = p.text.replace(/\s+/g, ' ').slice(0, 120);
                 if (p.text.length > 120) preview += '…';
 
-                return '<div class="item-row">' +
+                return '<div class="item-row" data-item="' + esc(it.id) + '">' +
                     '<div class="item-main">' +
                     '<div class="item-name">' + esc(p.title) +
                     ' <span class="pill type-' + esc(p.type) + '">' +

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -284,6 +284,124 @@
         body.em-previa .lateral { top: 116px; }
         body.em-previa .rail { height: calc(100vh - 116px); }
 
+        /* --- Busca global (Ctrl+K) --- */
+        .topnav-kbd,
+        .busca-campo kbd {
+            font-family: inherit;
+            font-size: 11px;
+            letter-spacing: 0.4px;
+            padding: 2px 6px;
+            border-radius: 5px;
+            border: 1px solid var(--nav-border);
+            background: rgba(255, 255, 255, 0.1);
+            opacity: 0.8;
+        }
+
+        .busca-backdrop {
+            position: fixed;
+            inset: 0;
+            z-index: 400;
+            background: rgba(32, 33, 36, 0.45);
+            backdrop-filter: blur(2px);
+            /* Alto na tela e não centralizado: a lista cresce para baixo, e uma
+               caixa centralizada saltaria a cada resultado a mais. */
+            padding: 12vh 20px 20px;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+        }
+
+        .busca-caixa {
+            width: 100%;
+            max-width: 620px;
+            background: var(--surface-level-1);
+            border-radius: var(--radius-md);
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+            overflow: hidden;
+        }
+
+        .busca-campo {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 14px 18px;
+            border-bottom: 1px solid var(--border-subtle);
+        }
+
+        .busca-campo .material-symbols-rounded { color: var(--text-secondary); }
+
+        .busca-campo kbd {
+            border-color: var(--border-subtle);
+            background: var(--surface-level-2);
+            color: var(--text-secondary);
+        }
+
+        .busca-campo input {
+            flex: 1;
+            border: none;
+            outline: none;
+            font-family: inherit;
+            font-size: 16px;
+            color: var(--text-primary);
+            background: transparent;
+        }
+
+        .busca-lista {
+            max-height: 52vh;
+            overflow-y: auto;
+        }
+
+        .busca-item {
+            display: grid;
+            grid-template-columns: 96px minmax(0, 1fr);
+            grid-template-areas: "onde nome" "onde trecho";
+            gap: 2px 14px;
+            width: 100%;
+            padding: 10px 18px;
+            border: none;
+            background: transparent;
+            text-align: left;
+            font-family: inherit;
+            cursor: pointer;
+        }
+
+        .busca-item.focado { background: var(--gemini-blue-light); }
+
+        .busca-onde {
+            grid-area: onde;
+            align-self: center;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            color: var(--text-secondary);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .busca-nome {
+            grid-area: nome;
+            font-size: 14px;
+            color: var(--text-primary);
+        }
+
+        .busca-trecho {
+            grid-area: trecho;
+            font-size: 12px;
+            color: var(--text-secondary);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .busca-vazio {
+            margin: 0;
+            padding: 18px;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
         /* --- Auditoria --- */
         .aud-filtros {
             display: grid;
@@ -1587,7 +1705,10 @@
             100% { background: var(--warning-light); transform: none; }
         }
 
-        .ppl-row.flash-applied {
+        .ppl-row.flash-applied,
+        /* A busca reusa o mesmo pisca: "onde houve" é a mesma pergunta,
+           venha a resposta de uma edição ou de um resultado escolhido. */
+        .item-row.flash-applied {
             animation: ppl-flash-applied .9s var(--spring-functional);
         }
 

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -301,6 +301,15 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             listContentActivity: () => ATIVIDADE,
             listContentRoles: () => matriz,
             listContentRoleNames: () => ['ADMIN', 'QA'],
+            searchContentItems: (t) => {
+                const alvo = String(t || '').toLowerCase();
+                return (itens.links || []).filter((i) =>
+                    (i.label + ' ' + i.value).toLowerCase().indexOf(alvo) !== -1)
+                    .map((i) => ({
+                        id: i.id, module: 'links', key: i.key, label: i.label,
+                        lang: i.lang, snippet: 'Fila do dia — https://go/fila',
+                    }));
+            },
             listContentAudit: (f) => {
                 const filtro = f || {};
                 const casa = (l) => (!filtro.actor || l.actor === filtro.actor) &&
@@ -1551,6 +1560,97 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         igual(chamada.args[0].text, 'CID', 'o filtro precisa acompanhar a exportação');
         verdade(/Content_Audit_Export/.test(await page.locator('#toast').textContent()),
             'faltou dizer onde a exportação foi parar');
+    });
+
+    await page.close();
+}
+
+// -------------------------------------------------------- busca global
+{
+    const page = await abrir({ sessao: 'admin' });
+
+    await check('Ctrl+K abre a busca, Esc fecha', async () => {
+        await page.keyboard.press('Control+k');
+        await page.waitForTimeout(200);
+        verdade(await page.locator('#busca-input').isVisible(), 'a busca deveria abrir');
+
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(200);
+        igual(await page.locator('#busca-input').count(), 0, 'e fechar');
+    });
+
+    await check('o botão do header ensina o atalho', async () => {
+        // Atalho de teclado que ninguém sabe que existe não existe.
+        verdade(await page.locator('#btn-busca').isVisible(), 'o botão deveria aparecer');
+        verdade(/Ctrl/.test(await page.locator('#btn-busca').textContent()),
+            'o botão deveria mostrar o atalho');
+    });
+
+    await check('destino aparece na hora, sem esperar a rede', async () => {
+        await page.locator('#btn-busca').click();
+        await page.waitForTimeout(150);
+        await page.fill('#busca-input', 'aprova');
+        // Antes do debounce de 220ms terminar, o destino já tem que estar lá:
+        // esperar a rede para mostrar "Aprovações" faria a busca parecer lenta
+        // por causa da parte que nem precisava de rede.
+        await page.waitForTimeout(80);
+        verdade(/Aprovações/.test(await page.locator('#busca-lista').textContent()),
+            'o destino deveria aparecer imediatamente');
+    });
+
+    await check('o conteúdo chega depois, do servidor', async () => {
+        await page.fill('#busca-input', 'fila');
+        await page.waitForTimeout(500);
+        const texto = await page.locator('#busca-lista').textContent();
+        verdade(/Fila de tarefas/.test(texto), 'faltou o item vindo do servidor: ' + texto);
+        verdade(/Links/.test(texto), 'faltou dizer de que módulo é');
+    });
+
+    await check('digitar não vira uma execução por tecla', async () => {
+        // O teto de execuções simultâneas do Apps Script é o recurso escasso
+        // deste backend: uma chamada por tecla o consome à toa.
+        await page.evaluate(() => { window.__chamadas.length = 0; });
+        await page.fill('#busca-input', '');
+        for (const c of 'fila') {
+            await page.type('#busca-input', c, { delay: 20 });
+        }
+        await page.waitForTimeout(500);
+        const buscas = await page.evaluate(() => window.__chamadas
+            .filter(c => c.metodo === 'searchContentItems').length);
+        igual(buscas, 1, 'quatro teclas deveriam custar uma busca só');
+    });
+
+    await check('setas movem o foco e Enter escolhe', async () => {
+        await page.waitForTimeout(200);
+        await page.keyboard.press('ArrowDown');
+        await page.waitForTimeout(100);
+        const focado = await page.locator('.busca-item.focado').count();
+        igual(focado, 1, 'exatamente um item focado');
+
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(400);
+        igual(await page.locator('#busca-input').count(), 0, 'a busca deveria fechar');
+        verdade(await page.locator('#pane-links').isVisible(), 'e levar ao módulo do item');
+    });
+
+    await check('o item escolhido é apontado na lista', async () => {
+        // Levar ao módulo e deixar a pessoa procurar de novo seria devolver o
+        // problema que a busca acabou de resolver.
+        await page.waitForTimeout(400);
+        verdade(await page.locator('[data-item="itm_1"]').count() > 0,
+            'a linha precisa ser endereçável para poder ser apontada');
+    });
+
+    await page.close();
+}
+
+{
+    const page = await abrir({ sessao: 'qa' });
+
+    await check('a busca existe para todo mundo que tem acesso', async () => {
+        // Buscar é leitura: o que ela devolve já vem filtrado pelo `ver` do
+        // servidor, então não há por que esconder a porta.
+        verdade(await page.locator('#btn-busca').isVisible(), 'o QA também busca');
     });
 
     await page.close();

--- a/scripts/test-content-api.js
+++ b/scripts/test-content-api.js
@@ -2383,5 +2383,85 @@ check('quem não aprova nada não consulta a cobrança', () => {
   as('quality1', () => throws(() => api.listStaleContentApprovals(), /Acesso negado/));
 });
 
+console.log('\n--- Busca global ---');
+
+const contentAgora = () => new Date().toISOString();
+
+check('a busca ignora acento — quem procura não digita acento', () => {
+  api.publishContentDirect({
+    module: 'broadcast', label: 'Anúncio de manutenção',
+    value: JSON.stringify({ type: 'info', title: 'Anúncio de manutenção', text: 'Sistema fora.' })
+  });
+
+  const r = api.searchContentItems('anuncio');
+  eq(r.length > 0, true, 'deveria achar mesmo sem acento:');
+  eq(r.some(x => /Anúncio/.test(x.label)), true);
+});
+
+check('termo curto demais não vira varredura', () => {
+  eq(api.searchContentItems('a'), []);
+  eq(api.searchContentItems(''), []);
+});
+
+check('a busca respeita o `ver` da matriz', () => {
+  // A busca é a porta dos fundos mais fácil de esquecer: sem o filtro, ela
+  // devolve conteúdo de módulo que a pessoa nem consegue abrir na tela.
+  const cego = api.normalizeRoleMatrix_({ modules: {}, global: {} });
+  cego.modules.tips.view = true;   // enxerga dicas, e SÓ dicas
+  eq(api.saveContentRole('SOTIPS', cego, {}).status, 'success');
+  api.saveContentAccess('sotips1', 'SOTIPS', true);
+
+  SS.getSheetByName('Content_Items').appendRow([
+    'itm_busca_link', 'links', 'tech', '', 'ALL', 'LinkDeTesteDaBusca',
+    JSON.stringify({ name: 'LinkDeTesteDaBusca', url: 'https://go/busca', desc: 'x' }),
+    1, 'live', 'lucaste', contentAgora(), 0, 'itm_busca_link'
+  ]);
+  api.invalidateContentCache_('links');
+
+  // O ADMIN acha o link; quem só vê dicas, não.
+  eq(api.searchContentItems('LinkDeTesteDaBusca').some(x => x.module === 'links'), true,
+    'o ADMIN precisa achar o link para o teste valer:');
+
+  as('sotips1', () => {
+    const r = api.searchContentItems('LinkDeTesteDaBusca');
+    eq(r.some(x => x.module === 'links'), false, 'não pode achar o que não pode ver:');
+  });
+});
+
+check('quem não tem papel não busca nada', () => {
+  as('estranho', () => throws(() => api.searchContentItems('link'), /Acesso negado/));
+});
+
+check('só o que está no ar aparece', () => {
+  const d = api.saveContentDraft({
+    module: 'links', key: 'tech', lang: 'ALL', label: 'RascunhoSecretoXYZ',
+    value: JSON.stringify({ name: 'RascunhoSecretoXYZ', url: 'https://go/x', desc: 'x' })
+  });
+  eq(api.searchContentItems('RascunhoSecretoXYZ'), [], 'rascunho não é conteúdo no ar:');
+  api.discardContentDraft(d.draftId);
+});
+
+check('o trecho mostra o contexto, sem JSON cru na cara', () => {
+  const r = api.searchContentItems('manutencao');
+  eq(r.length > 0, true);
+  eq(/[{}"]/.test(r[0].snippet), false, 'o trecho não pode ter marca de JSON: ' + r[0].snippet);
+});
+
+check('a busca tem teto de resultados', () => {
+  // Uma busca que devolve tudo é uma busca que trava a tela em vez de ajudar.
+  // Precisa de mais itens que o teto para o teto ter o que cortar.
+  const aba = SS.getSheetByName('Content_Items');
+  for (let i = 0; i < 45; i++) {
+    aba.appendRow([
+      'itm_massa_' + i, 'tips', 'geral', '', 'PT', 'Dica massiva ' + i,
+      'Texto padronizado para a busca massiva.', 1, 'live', 'lucaste',
+      contentAgora(), i, 'itm_massa_' + i
+    ]);
+  }
+
+  const r = api.searchContentItems('massiva');
+  eq(r.length, 30, 'o teto precisa cortar, veio ' + r.length);
+});
+
 console.log('\n' + (fail ? '✗' : '✓') + ` ${pass} passaram, ${fail} falharam\n`);
 process.exit(fail ? 1 : 0);

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -260,3 +260,31 @@ e texto:
 - **O gatilho é criado à mão**, uma vez, pelo editor do Apps Script — mesma nota
   que o `Backup.js` já carrega. Antes de ligar, `listStaleContentApprovals()`
   mostra quem seria cobrado e por quantos itens.
+
+---
+
+## Busca global (Ctrl+K)
+
+| Função | Params | Quem pode | Resposta |
+| :--- | :--- | :--- | :--- |
+| `searchContentItems(termo)` | termo com 2+ caracteres | qualquer papel ativo | Até 30 `{ id, module, key, label, lang, snippet }` |
+
+### Regras
+- **O filtro é o `ver` da matriz.** Uma busca que ignora permissão é a porta dos
+  fundos mais fácil de esquecer que existe: sem ela, um termo qualquer devolve
+  conteúdo de módulo que a pessoa nem consegue abrir na tela.
+- **Uma varredura, não uma por módulo.** A alternativa seria a tela pedir os
+  oito módulos e juntar — oito execuções do Apps Script por busca, exatamente o
+  padrão que o ADR-0008 existe para não repetir.
+- **Sem acento dos dois lados.** "anuncio" tem que achar "anúncio": quem busca
+  não digita acento, e uma busca que exige acento é uma busca que a pessoa
+  conclui estar quebrada.
+- **Teto de 30 resultados.** Uma busca que devolve tudo trava a tela em vez de
+  ajudar.
+- **Só `live`.** Rascunho e proposta pendente não são conteúdo no ar, e a busca
+  não é caminho para enxergá-los.
+- **Duas velocidades na tela.** Os destinos (as abas) são filtrados na tecla,
+  porque já estão na memória; só o conteúdo espera 220 ms de silêncio antes de
+  ir ao servidor. Sem o atraso, cada tecla vira uma execução; esperando a rede
+  para mostrar "Aprovações", a busca pareceria lenta por causa da parte que nem
+  precisava de rede.


### PR DESCRIPTION
## O que muda

`Ctrl+K` (ou `⌘K`) abre uma busca sobre **destinos e conteúdo** da Central, e leva direto ao item.

## Por que assim

**O custo real não é o tempo de procurar.** A Central tem dez destinos e centenas de itens; achar *"aquele link do Ads"* custava lembrar em qual aba ele mora e rolar a lista. Quem não lembra desiste e **cria um item duplicado** — que é o pior desfecho possível para um catálogo, porque a partir dali as duas versões divergem em silêncio.

**Uma varredura só no servidor**, não uma por módulo. A alternativa seria a tela pedir os oito módulos e juntar: oito execuções do Apps Script por busca, exatamente o padrão que o ADR-0008 existe para não repetir.

**O filtro é o `ver` da matriz de papéis.** Uma busca que ignora permissão é a porta dos fundos mais fácil de esquecer que existe: sem ela, um termo qualquer devolve conteúdo de módulo que a pessoa nem consegue abrir na tela.

**Sem acento dos dois lados.** "anuncio" acha "anúncio". Quem busca não digita acento, e uma busca que exige acento é uma busca que a pessoa conclui estar quebrada.

**Duas velocidades, de propósito.** Os destinos são filtrados **na tecla**, porque já estão na memória da tela. Só o conteúdo espera 220 ms de silêncio antes de ir ao servidor. Sem o atraso, cada tecla vira uma execução; esperando a rede para mostrar "Aprovações", a busca pareceria lenta por causa da parte que nem precisava de rede.

**Escolher leva ao módulo *e* aponta a linha.** Levar até lá e deixar a pessoa procurar de novo seria devolver o problema que a busca acabou de resolver — daí as linhas ganharem `data-item`, e o pisca ser o mesmo que a aba Pessoas já usava ("onde houve" é a mesma pergunta).

**Tem botão no header.** Atalho de teclado que ninguém sabe que existe não existe.

### A parte de segurança

Tudo que entra na lista passa por `esc()`. O resultado mistura texto escrito por outras pessoas com marcação da tela — é a mesma classe de falha que `docs/LEARNINGS.md` já registrou sobre o Ctrl+K do bundle, e o motivo de o trecho de contexto vir com as marcas de JSON removidas em vez de interpretadas.

## Como verificar

```
npm run test:content    # 177 testes (eram 170)
npm run smoke:content   # 99 verificações (eram 92)
```

```
✓ a busca ignora acento — quem procura não digita acento
✓ a busca respeita o `ver` da matriz
✓ só o que está no ar aparece
✓ a busca tem teto de resultados
✓ Ctrl+K abre a busca, Esc fecha
✓ destino aparece na hora, sem esperar a rede
✓ digitar não vira uma execução por tecla
✓ setas movem o foco e Enter escolhe
```

**As mutações pegaram dois testes meus que não provavam nada** — de novo, e de novo do mesmo jeito. "Respeita o `ver`" procurava por `people`, que não tem linha em `Content_Items`: não havia o que vazar, então desligar o filtro não quebrava. E "tem teto" afirmava `≤ 30` num conjunto que tinha menos de 30 itens. Agora o primeiro cria um papel que só enxerga dicas e verifica que ele não acha um link que o ADMIN acha; o segundo semeia 45 itens e exige exatamente 30. As duas mutações passam a falhar.

E a mutação do debounce (`buscarAgora` direto, sem `setTimeout`) faz "digitar não vira uma execução por tecla" cair.

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente.

## Checklist

- [x] Mexi em `gas-backend/`: `searchContentItems` entrou em `specs/data-models/api-payloads.md`, com as seis regras que o definem.
- [x] Regra de negócio: nenhuma nova — a busca não enxerga nada além do que a matriz já permitia ver.
- [x] Decisão que alguém vai questionar depois: "por que duas velocidades" e "por que uma varredura só" estão comentadas no ponto exato do código.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_