### PR TITLE
feat(central): prévia "como o agente vê"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Prévia "como o agente vê"** (fase 5). O editor mostra **campos**; o agente lê
+  **texto**. Entre os dois cabe o erro que ninguém pega revisando o formulário: a
+  descrição em espanhol que ficou em português, o passo do roteiro que só faz
+  sentido com o anterior na frente, o placeholder que sobrou literal. A prévia
+  resolve o item no idioma escolhido e **nomeia o que está faltando** em vez de
+  mostrar um cartão vazio — o editor, que exibe PT e ES lado a lado, é
+  justamente o lugar onde essa falta passa despercebida. Aviso agendado ou
+  vencido vem com o aviso de que nenhum agente está vendo aquilo agora.
 - **Busca global na Central, por `Ctrl+K`** (fase 5). A tela tem dez destinos e
   centenas de itens; achar *"aquele link do Ads"* custava lembrar em qual aba
   ele mora e rolar a lista — e quem não lembra desiste e cria um item duplicado,

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,7 +77,7 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       e o `<select>` da aba Acessos lendo `listContentRoleNames()`.
       **Falta validar na planilha real:** que a aba `Content_Roles` nasce
       semeada e que os quatro papéis continuam se comportando igual.
-- [~] **Fase 5 — diferenciais e auditoria** — em andamento.
+- [x] **Fase 5 — diferenciais e auditoria** — completa, em seis PRs.
       **Entregue:** "ver como" por papel e idioma — a tela inteira passa a
       mostrar o que aquele papel veria, de leitura, com a prévia intersectada no
       servidor (prévia que concede é escalação com outro nome) e dizendo na
@@ -93,8 +93,9 @@ prioridade). Cada fase é um ou mais PRs contra `refactor-structure`.
       `CW_DEPLOYMENTS` e não a URL do serviço.
       **Entregue também:** busca global Ctrl+K — destino e conteúdo na mesma
       lista, sem acento, filtrada pelo `ver` da matriz, com duas velocidades
-      (destino na tecla, conteúdo depois de 220 ms de silêncio).
-      **Falta:** prévia "como o agente vê". **PR final:** aba de
+      (destino na tecla, conteúdo depois de 220 ms de silêncio) — e a prévia
+      "como o agente vê", que resolve o item no idioma escolhido e nomeia o que
+      falta em vez de mostrar cartão vazio. **PR final:** aba de
       auditoria restrita, com filtros, paginação e exportação.
 
 ## Ideas — to triage

--- a/gas-backend/ContentAPI.js
+++ b/gas-backend/ContentAPI.js
@@ -2570,6 +2570,34 @@ function listContentActivity(limite) {
   return saida;
 }
 
+/**
+ * Um item publicado, cru, para a tela montar a prévia "como o agente vê".
+ *
+ * Existe em vez de a tela procurar na lista que já tem em memória porque as
+ * seis listas são seis variáveis diferentes, e a prévia teria de saber em qual
+ * procurar — um `if` por módulo que envelhece no próximo módulo novo. Uma
+ * chamada por clique é barata; a busca é que não podia ser.
+ */
+function getContentItemForPreview(itemId) {
+  const item = findContentRow_(SHEET_CONTENT_ITEMS, 'ID', itemId);
+  if (!item) throw new Error("Item não encontrado.");
+
+  const module = String(item.Module).trim();
+  // Mesma porta de leitura do resto: `view` do módulo, nada de exceção só
+  // porque a prévia "é só olhar".
+  assertContentRole_('read', module);
+
+  return {
+    id: String(item.ID),
+    module: module,
+    key: String(item.Key || ""),
+    lang: String(item.Lang || 'ALL'),
+    label: String(item.Label || ""),
+    value: String(item.Value || ""),
+    version: Number(item.Version) || 1
+  };
+}
+
 // =========================================================
 //  BUSCA GLOBAL (Ctrl+K)
 // =========================================================

--- a/gas-backend/ContentDashboard_Catalog.html
+++ b/gas-backend/ContentDashboard_Catalog.html
@@ -74,7 +74,8 @@
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
                     var historico = '<button class="btn btn-ghost btn-sm" '
-                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'links\')">Histórico</button>';
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'links\')">Histórico</button>'
+                        + botaoComoAgente(it.id);
 
                     var actions = podeEscrever('links')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
@@ -417,7 +418,8 @@
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
                     var historico = '<button class="btn btn-ghost btn-sm" '
-                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'call_script\')">Histórico</button>';
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'call_script\')">Histórico</button>'
+                        + botaoComoAgente(it.id);
 
                     var actions = podeEscrever('call_script')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
@@ -634,7 +636,8 @@
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
                     var historico = '<button class="btn btn-ghost btn-sm" '
-                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'note_template\')">Histórico</button>';
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'note_template\')">Histórico</button>'
+                        + botaoComoAgente(it.id);
 
                     var actions = podeEscrever('note_template')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
@@ -875,7 +878,8 @@
                     // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                     // passou. Só reverter é que depende de aprovar.
                     var historico = '<button class="btn btn-ghost btn-sm" '
-                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'email_template\')">Histórico</button>';
+                        + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'email_template\')">Histórico</button>'
+                        + botaoComoAgente(it.id);
 
                     var actions = podeEscrever('email_template')
                         ? '<div style="display:flex;gap:8px">' + historico + descarte +
@@ -1052,7 +1056,8 @@
                 // Histórico é LEITURA: quem enxerga o item enxerga por onde ele
                 // passou. Só reverter é que depende de aprovar.
                 var historico = '<button class="btn btn-ghost btn-sm" '
-                    + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'tips\')">Histórico</button>';
+                    + 'onclick="abrirHistorico(\'' + it.id + '\',\'' + it.lineage + '\',\'tips\')">Histórico</button>'
+                    + botaoComoAgente(it.id);
 
                 var actions = podeEscrever('tips')
                     ? '<div style="display:flex;gap:8px">' + historico + descarte +

--- a/gas-backend/ContentDashboard_Core.html
+++ b/gas-backend/ContentDashboard_Core.html
@@ -576,6 +576,112 @@
             if (!document.getElementById('pane-emails').classList.contains('hidden')) renderEmails();
         }
 
+        // --- Como o agente vê ---
+        //
+        // O editor mostra CAMPOS; o agente lê TEXTO. Entre os dois cabe o erro
+        // que ninguém pega revisando o formulário: a descrição em espanhol que
+        // ficou em português, o passo do roteiro que só faz sentido com o
+        // anterior na frente, o placeholder que sobrou literal.
+        //
+        // O que esta prévia promete é CONTEÚDO, não pixel: é o texto que o
+        // agente recebe, no idioma dele. Copiar o visual do bundle aqui criaria
+        // uma segunda cópia da aparência, que envelhece sozinha — e uma prévia
+        // desatualizada mente com mais convicção que prévia nenhuma.
+        // Conferir é leitura: aparece para quem enxerga o item, e continua
+        // aparecendo em prévia "ver como" — é justamente lá que se quer olhar.
+        function botaoComoAgente(itemId) {
+            return '<button class="btn btn-ghost btn-sm" onclick="verComoAgente(\'' +
+                esc(itemId) + '\')">Como o agente vê</button>';
+        }
+
+        function verComoAgente(itemId) {
+            document.getElementById('modal-root').innerHTML =
+                '<div class="modal-backdrop" onclick="if(event.target===this)closeModal()">' +
+                '<div class="modal" style="max-width:620px" role="dialog" aria-modal="true"' +
+                ' aria-labelledby="ag-titulo">' +
+                '<h2 id="ag-titulo">Como o agente vê</h2>' +
+                '<div id="ag-corpo"><div class="skeleton"></div><div class="skeleton"></div></div>' +
+                '<div class="modal-actions">' +
+                '<button class="btn btn-ghost" onclick="closeModal()">Fechar</button>' +
+                '</div></div></div>';
+
+            google.script.run
+                .withSuccessHandler(renderComoAgente)
+                .withFailureHandler(function (err) {
+                    var host = document.getElementById('ag-corpo');
+                    if (host) host.innerHTML = '<div class="note warn">' + esc(err.message) + '</div>';
+                })
+                .getContentItemForPreview(itemId);
+        }
+
+        function renderComoAgente(item) {
+            var host = document.getElementById('ag-corpo');
+            if (!host || !item) return;
+
+            var idioma = idiomaAtual();
+            var v = {};
+            try { v = JSON.parse(item.value || '{}'); } catch (e) { v = {}; }
+
+            var corpo = '';
+
+            if (item.module === 'links') {
+                // O agente lê a descrição no SEU idioma. É o campo que mais
+                // silenciosamente fica em português dentro do bloco ES.
+                var desc = idioma === 'ES' ? (v.desc_es || '') : (v.desc || '');
+                corpo =
+                    '<div class="ag-cartao">' +
+                    '<div class="ag-titulo">' + esc(v.name || item.label) + '</div>' +
+                    '<div class="ag-texto">' + (desc
+                        ? esc(desc)
+                        : '<em class="ag-falta">sem descrição em ' + esc(idioma) +
+                          ' — o agente vê o cartão sem explicação</em>') + '</div>' +
+                    '<div class="ag-meta">abre ' + esc(v.url || '') + '</div>' +
+                    '</div>';
+            } else if (item.module === 'tips') {
+                corpo = '<div class="ag-cartao ag-dica">' +
+                    '<span class="material-symbols-rounded" aria-hidden="true">lightbulb</span> ' +
+                    esc(item.value) + '</div>';
+            } else if (item.module === 'broadcast') {
+                corpo =
+                    '<div class="ag-cartao ag-aviso ag-aviso-' + esc(v.type || 'info') + '">' +
+                    '<div class="ag-titulo">' + esc(v.title || item.label) + '</div>' +
+                    '<div class="ag-texto">' + esc(v.text || '') + '</div>' +
+                    '</div>' + avisoDaJanelaNaPrevia(v);
+            } else if (item.module === 'email_template') {
+                corpo =
+                    '<div class="ag-cartao">' +
+                    '<div class="ag-meta">Assunto</div>' +
+                    '<div class="ag-titulo">' + esc(v.subject || '') + '</div>' +
+                    '</div>' + previaIsolada(v.template || '', 260);
+            } else if (item.module === 'call_script' || item.module === 'note_template') {
+                corpo = '<div class="ag-cartao"><pre class="ag-pre">' +
+                    esc(prettyValue(item.value)) + '</pre></div>';
+            } else {
+                corpo = '<div class="ag-cartao"><pre class="ag-pre">' +
+                    esc(prettyValue(item.value)) + '</pre></div>';
+            }
+
+            host.innerHTML =
+                '<p class="card-sub">Conteúdo que o agente recebe, no idioma <strong>' +
+                esc(idioma) + '</strong>. O visual é o desta tela, não o do app — ' +
+                'o que se confere aqui é o texto.</p>' + corpo;
+        }
+
+        // Um aviso agendado ou vencido não chega ao agente hoje. A prévia tem
+        // que dizer isso, senão ela mostra um cartão que ninguém está vendo.
+        function avisoDaJanelaNaPrevia(v) {
+            var agora = agoraLocalISO();
+            if (v.startsAt && agora < v.startsAt) {
+                return '<div class="note warn">Ainda não. Este aviso só aparece a partir de ' +
+                    esc(bcFormatDate(v.startsAt)) + '.</div>';
+            }
+            if (v.endsAt && agora >= v.endsAt) {
+                return '<div class="note warn">Já saiu do ar em ' +
+                    esc(bcFormatDate(v.endsAt)) + '. Nenhum agente vê isto agora.</div>';
+            }
+            return '';
+        }
+
         // --- Busca global (Ctrl+K) ---
         //
         // A Central tem dez destinos e centenas de itens. Achar "aquele link do

--- a/gas-backend/ContentDashboard_Ops.html
+++ b/gas-backend/ContentDashboard_Ops.html
@@ -80,12 +80,13 @@
             host.innerHTML = ordered.map(function (it) {
                 var p = bcParse(it);
 
-                var actions = podeEditar
-                    ? '<div style="display:flex;gap:8px">' +
-                    '<button class="btn btn-ghost btn-sm" onclick="openBroadcastEditor(\'' + it.id + '\')">Editar</button>' +
-                    '<button class="btn btn-danger btn-sm" onclick="askUnpublish(\'' + it.id + '\')">Tirar do ar</button>' +
-                    '</div>'
-                    : '';
+                var actions = '<div style="display:flex;gap:8px">' +
+                    botaoComoAgente(it.id) +
+                    (podeEditar
+                        ? '<button class="btn btn-ghost btn-sm" onclick="openBroadcastEditor(\'' + it.id + '\')">Editar</button>' +
+                          '<button class="btn btn-danger btn-sm" onclick="askUnpublish(\'' + it.id + '\')">Tirar do ar</button>'
+                        : '') +
+                    '</div>';
 
                 var segmento = it.lang && it.lang !== 'ALL'
                     ? ' · ' + esc(BC_LANG_LABEL[it.lang] || it.lang)

--- a/gas-backend/ContentDashboard_Styles.html
+++ b/gas-backend/ContentDashboard_Styles.html
@@ -284,6 +284,64 @@
         body.em-previa .lateral { top: 116px; }
         body.em-previa .rail { height: calc(100vh - 116px); }
 
+        /* --- Prévia "como o agente vê" ---
+           O visual é o DESTA tela, não o do bundle: copiar a aparência do app
+           aqui criaria uma segunda cópia que envelhece sozinha, e uma prévia
+           desatualizada mente com mais convicção que prévia nenhuma. */
+        .ag-cartao {
+            background: var(--surface-level-2);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            padding: 14px 16px;
+            margin-top: 12px;
+        }
+
+        .ag-titulo {
+            font-size: 15px;
+            font-weight: 500;
+            color: var(--text-primary);
+        }
+
+        .ag-texto {
+            font-size: 13px;
+            color: var(--text-primary);
+            margin-top: 4px;
+            white-space: pre-wrap;
+        }
+
+        .ag-meta {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            color: var(--text-secondary);
+            margin-top: 8px;
+        }
+
+        /* O que FALTA é a informação mais útil de uma prévia de tradução. */
+        .ag-falta { color: var(--danger); }
+
+        .ag-dica {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .ag-aviso { border-left: 4px solid var(--gemini-blue); }
+        .ag-aviso-critical { border-left-color: var(--danger); }
+        .ag-aviso-success { border-left-color: var(--success); }
+
+        .ag-pre {
+            margin: 0;
+            font-family: 'Roboto Mono', ui-monospace, monospace;
+            font-size: 12px;
+            line-height: 1.6;
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+            color: var(--text-primary);
+        }
+
         /* --- Busca global (Ctrl+K) --- */
         .topnav-kbd,
         .busca-campo kbd {

--- a/scripts/smoke-content-dashboard.mjs
+++ b/scripts/smoke-content-dashboard.mjs
@@ -301,6 +301,18 @@ async function abrir({ sessao = 'admin', falharRascunhosDe = null, hash = '', dr
             listContentActivity: () => ATIVIDADE,
             listContentRoles: () => matriz,
             listContentRoleNames: () => ['ADMIN', 'QA'],
+            getContentItemForPreview: (id) => {
+                for (const m of Object.keys(itens)) {
+                    const achado = (itens[m] || []).filter((i) => i.id === id)[0];
+                    if (achado) {
+                        return {
+                            id: achado.id, module: m, key: achado.key, lang: achado.lang,
+                            label: achado.label, value: achado.value, version: achado.version,
+                        };
+                    }
+                }
+                throw new Error('Item não encontrado.');
+            },
             searchContentItems: (t) => {
                 const alvo = String(t || '').toLowerCase();
                 return (itens.links || []).filter((i) =>
@@ -1651,6 +1663,75 @@ console.log('\n--- Smoke: Central de Conteúdo ---');
         // Buscar é leitura: o que ela devolve já vem filtrado pelo `ver` do
         // servidor, então não há por que esconder a porta.
         verdade(await page.locator('#btn-busca').isVisible(), 'o QA também busca');
+    });
+
+    await page.close();
+}
+
+// ------------------------------------------------- como o agente vê
+{
+    const page = await abrir({ sessao: 'admin', hash: '#/links' });
+
+    await check('todo item publicado oferece a prévia do agente', async () => {
+        await page.waitForTimeout(300);
+        verdade(/Como o agente vê/.test(await page.locator('#links-list').textContent()),
+            'faltou o botão na lista de links');
+    });
+
+    await check('a prévia mostra o texto no idioma escolhido', async () => {
+        await page.evaluate(() => verComoAgente('itm_1'));
+        await page.waitForTimeout(400);
+        const texto = await page.locator('#ag-corpo').textContent();
+        verdade(/Fila do dia/.test(texto), 'faltou a descrição em PT: ' + texto);
+        verdade(/go\/fila/.test(texto), 'faltou dizer o que o link abre');
+        // A prévia promete conteúdo, não pixel — e diz isso, para ninguém
+        // concluir que o app mudou de cara.
+        verdade(/o visual é o desta tela/i.test(texto), 'faltou a ressalva sobre o visual');
+    });
+
+    await check('trocar o idioma troca o que a prévia mostra', async () => {
+        // É o campo que mais silenciosamente fica em português dentro do
+        // bloco ES — e o editor, que mostra os dois lado a lado, esconde isso.
+        await page.evaluate(() => { document.getElementById('lang-global').value = 'ES'; });
+        await page.evaluate(() => verComoAgente('itm_1'));
+        await page.waitForTimeout(400);
+        const texto = await page.locator('#ag-corpo').textContent();
+        verdade(/Cola del día/.test(texto), 'faltou a descrição em ES: ' + texto);
+        igual(/Fila do dia/.test(texto), false, 'a descrição PT não pode vazar na prévia ES');
+    });
+
+    await check('descrição faltando no idioma é DITA, não escondida', async () => {
+        await page.evaluate(() => {
+            LIVE_LINKS.push({
+                id: 'itm_sem_es', module: 'links', key: 'tech', lang: 'ALL',
+                label: 'Sem espanhol', version: 1, status: 'live', lineage: 'itm_sem_es',
+                value: JSON.stringify({ name: 'Sem espanhol', url: 'https://go/x', desc: 'Só em PT' }),
+            });
+        });
+        // O dublê procura nos ITENS do fixture, então a prévia deste item vem
+        // do servidor dublado: basta o modal saber renderizar a falta.
+        await page.evaluate(() => renderComoAgente({
+            id: 'x', module: 'links', lang: 'ALL', label: 'Sem espanhol',
+            value: JSON.stringify({ name: 'Sem espanhol', url: 'https://go/x', desc: 'Só em PT' }),
+        }));
+        await page.waitForTimeout(150);
+        verdade(/sem descrição em ES/.test(await page.locator('#ag-corpo').textContent()),
+            'a falta precisa aparecer, não sumir');
+    });
+
+    await check('aviso fora da janela avisa que ninguém está vendo', async () => {
+        await page.evaluate(() => renderComoAgente({
+            id: 'x', module: 'broadcast', lang: 'ALL', label: 'Vencido',
+            value: JSON.stringify({
+                type: 'critical', title: 'Instabilidade', text: 'CRM lento.',
+                startsAt: '2020-01-01T08:00', endsAt: '2020-01-02T08:00',
+            }),
+        }));
+        await page.waitForTimeout(150);
+        const texto = await page.locator('#ag-corpo').textContent();
+        // Uma prévia que mostra o cartão sem dizer que ele já saiu do ar é uma
+        // prévia que afirma o contrário do que está acontecendo.
+        verdade(/Nenhum agente vê isto agora/.test(texto), 'faltou o aviso da janela: ' + texto);
     });
 
     await page.close();

--- a/specs/data-models/api-payloads.md
+++ b/specs/data-models/api-payloads.md
@@ -268,6 +268,7 @@ e texto:
 | Função | Params | Quem pode | Resposta |
 | :--- | :--- | :--- | :--- |
 | `searchContentItems(termo)` | termo com 2+ caracteres | qualquer papel ativo | Até 30 `{ id, module, key, label, lang, snippet }` |
+| `getContentItemForPreview(itemId)` | ID do item | `view` do módulo | `{ id, module, key, lang, label, value, version }` — o item cru, para a prévia "como o agente vê" |
 
 ### Regras
 - **O filtro é o `ver` da matriz.** Uma busca que ignora permissão é a porta dos
@@ -288,3 +289,17 @@ e texto:
   ir ao servidor. Sem o atraso, cada tecla vira uma execução; esperando a rede
   para mostrar "Aprovações", a busca pareceria lenta por causa da parte que nem
   precisava de rede.
+
+### Sobre a prévia "como o agente vê"
+- **Uma chamada por clique, não uma busca na memória.** As seis listas da tela
+  são seis variáveis diferentes; a prévia teria de saber em qual procurar — um
+  `if` por módulo que envelhece no próximo módulo novo.
+- **Ela promete CONTEÚDO, não pixel**, e diz isso na própria tela. Copiar o
+  visual do bundle criaria uma segunda cópia da aparência, que envelhece
+  sozinha — e uma prévia desatualizada mente com mais convicção que prévia
+  nenhuma.
+- **O idioma vem do seletor da Central.** É onde a tradução ES que ninguém
+  confere aparece: o editor mostra PT e ES lado a lado e por isso esconde a
+  falta; a prévia mostra um de cada vez e **nomeia o que está faltando**.
+- **Aviso fora da janela é anunciado.** Mostrar o cartão sem dizer que ele já
+  saiu do ar seria afirmar o contrário do que está acontecendo.


### PR DESCRIPTION
## O que muda

Último item da fase 5. Cada item publicado ganhou um botão **"Como o agente vê"**, que mostra o conteúdo resolvido no idioma escolhido.

## Por que assim

**O editor mostra campos; o agente lê texto.** Entre os dois cabe o erro que ninguém pega revisando o formulário: a descrição em espanhol que ficou em português, o passo do roteiro que só faz sentido com o anterior na frente, o placeholder que sobrou literal.

**A falta é nomeada, não escondida.** Se o link não tem `desc_es`, a prévia em ES escreve *"sem descrição em ES — o agente vê o cartão sem explicação"* em vermelho. E aqui está o ponto que justifica a feature inteira: **o editor exibe PT e ES lado a lado, e é justamente por isso que ele esconde a falta** — com os dois campos na tela, a ausência de um não salta. Um de cada vez, salta.

**Ela promete conteúdo, não pixel — e diz isso na própria tela.** Copiar o visual do bundle aqui criaria uma segunda cópia da aparência do app, que envelhece sozinha no primeiro ajuste de CSS que ninguém replicar. E **uma prévia desatualizada mente com mais convicção que prévia nenhuma**: a pessoa confere, vê "certo", e publica.

**Aviso fora da janela é anunciado.** Um `broadcast` agendado ou vencido aparece com o aviso de que nenhum agente está vendo aquilo agora. Mostrar o cartão calado seria afirmar o contrário do que está acontecendo — e, depois do PR #386, esse caso passou a existir de verdade.

**Uma chamada por clique**, em vez de procurar nas listas que a tela já tem. São seis variáveis diferentes (`LIVE_LINKS`, `TP_ITEMS`, `BC_ITEMS`…), e a prévia teria de saber em qual procurar: um `if` por módulo que envelhece no próximo módulo novo. Um clique é barato; a busca do PR #389 é que não podia ser.

## Como verificar

```
npm run smoke:content   # 104 verificações (eram 99)
```

```
✓ todo item publicado oferece a prévia do agente
✓ a prévia mostra o texto no idioma escolhido
✓ trocar o idioma troca o que a prévia mostra
✓ descrição faltando no idioma é DITA, não escondida
✓ aviso fora da janela avisa que ninguém está vendo
```

**Três mutações confirmam que elas falham quando devem** — prévia ignorando o idioma (2 falhas), falta de tradução sumindo em silêncio (1), e o aviso da janela suprimido (1).

Todas as 8 suítes `test:`, o `build` e os smokes de content, people, broadcast, wizards e env-badge verdes.

- [x] `npm run build` passa
- [x] Testes relevantes passam (`npm run test:*` / `smoke:*`)
- [x] Testado com o bookmarklet de dev — não se aplica: nada aqui muda o app do agente. **A ressalva honesta**: esta prévia mostra o *texto* que o app recebe, não o *visual* dele. Conferir se o cartão do agente ficou bonito continua sendo o bookmarklet de dev no CRM — e a tela diz isso a quem abre a prévia, em vez de deixar a pessoa supor.

## Checklist

- [x] Mexi em `gas-backend/`: `getContentItemForPreview` entrou em `specs/data-models/api-payloads.md`, com as quatro regras da prévia.
- [x] Regra de negócio: nenhuma nova — a prévia lê pelo mesmo `view` do módulo, sem exceção "porque é só olhar".
- [x] Decisão que alguém vai questionar depois: "por que não copiar o visual do app" está comentada no ponto exato do código e no CSS.
- [x] Muda algo perceptível: entrou em `CHANGELOG.md` sob `[Unreleased]`.
- [x] Não bumpei versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH

---
_Generated by [Claude Code](https://claude.ai/code/session_015DREhnk5dAcDGT8WN3ekLH)_