### PR TITLE
fix(sound): o "TU DUM" de abertura voltou a ter duas batidas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,16 @@ versions follow [Semantic Versioning](https://semver.org/).
   vão em bloco (`setValues`) em vez de uma chamada por coluna.
 
 ### Fixed
+- **O som de abertura voltou a fazer "TU DUM".** Virou um "TUM" só: o bloom
+  grave do segundo tempo era agendado a partir de `t`, com o atraso aplicado
+  apenas no **fim** da rampa (`linearRampToValueAtTime(vol, t + dumDelay + 0.1)`).
+  Uma rampa da Web Audio parte do evento anterior da automação, então o swell
+  subia desde `t = 0`, colado na batida seca — a variável `dumDelay` não
+  atrasava nada, só alongava o fade. Agora o DUM inteiro (ganho, filtro e
+  oscilador) sai de `dumStart = t + dumDelay`, com o atraso em 180 ms para
+  entrar depois de o TU morrer. Medido em renderização offline: o vale entre as
+  duas batidas foi de **27,5% do pico** (uma batida contínua) para **0%** (duas
+  batidas separadas).
 - **A auditoria mostrava o nome interno de metade das ações.** `role_update`,
   `audit_export`, `people_updated` e as outras que nasceram depois da barra
   lateral não tinham tradução, e apareciam como jargão de código exatamente na

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -12,6 +12,56 @@ Include the minimal code snippet / command when it is the fix.
 
 ---
 
+## Rampa da Web Audio começa no evento anterior: para atrasar um som, agende o **início**, não só o fim
+
+**Why**: o som de abertura devia fazer "TU DUM" (estilo Netflix) e fazia um
+"TUM" só. O código *parecia* certo — tinha até uma constante `dumDelay = 0.12`
+e o comentário "o volume sobe só depois do delay, criando a separação". Mas o
+envelope do segundo tempo era escrito assim:
+
+```js
+gain.gain.setValueAtTime(0, t);                                  // t = agora
+gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.6, t + dumDelay + 0.1);
+```
+
+Uma rampa da Web Audio interpola **do evento anterior da automação até o
+instante marcado**. Como o evento anterior estava em `t`, o volume começava a
+subir em `t = 0`, grudado na batida seca: `dumDelay` não atrasava o início,
+só esticava o fade. O mesmo valia para o `filter.frequency` e para o
+`osc.start(t)`. Resultado: dois eventos que deviam ser separados por silêncio
+soavam como um só. O conserto é dar ao segundo som um tempo próprio e agendar
+**tudo** a partir dele:
+
+```js
+const dumStart = t + dumDelay;
+gain.gain.setValueAtTime(0, dumStart);
+gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.6, dumStart + 0.1);
+osc.start(dumStart);
+```
+
+A versão que de fato soava "TU DUM" (commit `66f3b3f`) já fazia isso com um
+`bloomStart`; a reescrita seguinte trocou por `t + delay` nos finais de rampa
+e perdeu a separação sem que ninguém notasse no diff — o comentário continuou
+prometendo o que o código não fazia mais.
+
+**Segundo aprendizado, sobre provar**: som não tem teste no projeto e o
+container não tem browser. Dá para provar sem ouvir — um renderizador offline
+de ~150 linhas no scratchpad (stub de `AudioContext` que grava o grafo, depois
+sintetiza as amostras) executa o módulo **real** nas duas versões e mede o
+vale de RMS entre as batidas: 27,5% do pico antes, 0% depois. É o "behavior
+diff" que o `CLAUDE.md` pede, e ainda gera um `.wav` para ouvir.
+
+**When to apply**: sempre que agendar dois eventos sonoros que precisam ser
+percebidos como **separados** em `sound-manager.js`. Se o atraso aparece só
+como `t + delay` no argumento de tempo de um `linearRampToValueAtTime` /
+`exponentialRampToValueAtTime`, ele não está atrasando nada — confira se
+existe um `setValueAtTime(valorInicial, inícioDoSegundoEvento)` e um
+`osc.start(inícioDoSegundoEvento)` antes dele. Vale também para desconfiar de
+comentário que afirma um comportamento de timing: nesse arquivo o comentário
+estava certo sobre a intenção e errado sobre o código.
+
+---
+
 ## Campo referenciado em todo lugar menos no `FORM_CONFIG`: procure pelo nome antes de assumir bug de transporte
 
 **Why**: o email do anunciante chegava sempre vazio no `BAU_form_data`. A

--- a/src/modules/shared/sound-manager.js
+++ b/src/modules/shared/sound-manager.js
@@ -200,22 +200,12 @@ export const SoundManager = {
         const t = ctx.currentTime;
 
         // DEFINIÇÃO DO TEMPO (O Segredo do Ritmo)
-        // O "TA" acontece em t=0
-        // O "DUM" começa sutilmente em t=0.05 mas explode em t=0.15
-        const dumDelay = 0.12; 
+        // O "TU" bate em t=0 e morre em 150ms (estalo de 100ms + kick de 150ms).
+        // O "DUM" só pode entrar depois disso: é o silêncio entre os dois que
+        // faz o ouvido escutar duas batidas em vez de uma.
+        const dumDelay = 0.18;
 
-
-
-
-
-
-
-
-
-
-
-
-        // === EVENTO 1: O "TA" (O Impacto Seco) ===
+        // === EVENTO 1: O "TU" (O Impacto Seco) ===
         // Precisa ser agudo no início para cortar a mixagem
         
         // 1.1 O Estalo (Knock)
@@ -224,7 +214,7 @@ export const SoundManager = {
         const snapFilter = ctx.createBiquadFilter();
 
         snapOsc.type = 'square'; // Quadrada = Som oco/madeira
-        // Começa bem agudo (400Hz) e cai instantaneamente. Isso dá o "T" do "Ta"
+        // Começa bem agudo (400Hz) e cai instantaneamente. Isso dá o "T" do "Tu"
         snapOsc.frequency.setValueAtTime(400, t); 
         snapOsc.frequency.exponentialRampToValueAtTime(50, t + 0.1); 
 
@@ -240,7 +230,7 @@ export const SoundManager = {
         snapGain.connect(ctx.destination);
         snapOsc.start(t); snapOsc.stop(t + 0.12);
 
-        // 1.2 O Peso do TA (Kick)
+        // 1.2 O Peso do TU (Kick)
         // Um suporte grave para o estalo não ficar magro
         const kickOsc = ctx.createOscillator();
         const kickGain = ctx.createGain();
@@ -258,9 +248,11 @@ export const SoundManager = {
 
 
         // === EVENTO 2: O "DUM" (O Bloom Cinematográfico) ===
-        // Só começa DEPOIS que o TA bateu (usando a variável dumDelay)
-
-
+        // Tudo aqui é agendado a partir de dumStart, nunca de t: uma rampa da
+        // Web Audio parte do evento anterior da automação, então marcar só o
+        // FIM em "t + dumDelay" fazia o swell subir desde t=0, grudado no TU -
+        // os dois eventos viravam um "TUM" só.
+        const dumStart = t + dumDelay;
 
         const freqs = [55, 55.4, 110.5]; // Lá A1 + Oitava (Chorus effect)
 
@@ -274,25 +266,22 @@ export const SoundManager = {
 
             // FILTRO DE ABERTURA (O "Wahhh")
             filter.type = 'lowpass';
-            filter.frequency.setValueAtTime(30, t); // Começa fechado
-            // Abre o filtro EXATAMENTE após o delay
-            filter.frequency.linearRampToValueAtTime(900, t + dumDelay + 0.2); 
+            filter.frequency.setValueAtTime(30, dumStart); // Começa fechado
+            filter.frequency.linearRampToValueAtTime(900, dumStart + 0.2);
             // Fecha devagar
-            filter.frequency.exponentialRampToValueAtTime(40, t + 3.0); 
+            filter.frequency.exponentialRampToValueAtTime(40, dumStart + 3.0);
 
             // VOLUME (Fade In)
-            gain.gain.setValueAtTime(0, t);
-            // O volume sobe só depois do delay, criando a separação
-            gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.6, t + dumDelay + 0.1); 
-            gain.gain.exponentialRampToValueAtTime(0.001, t + 3.5);
+            gain.gain.setValueAtTime(0, dumStart);
+            gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.6, dumStart + 0.1);
+            gain.gain.exponentialRampToValueAtTime(0.001, dumStart + 3.5);
 
             osc.connect(filter);
             filter.connect(gain);
             gain.connect(ctx.destination);
 
-            // Note que o oscilador começa mudo em t, mas só aparece em t + dumDelay
-            osc.start(t); 
-            osc.stop(t + 3.6);
+            osc.start(dumStart);
+            osc.stop(dumStart + 3.6);
         });
     },
     playNotification: () => {


### PR DESCRIPTION
## O que muda

O som de boot fazia um "TUM" só, quando deveria fazer "TU DUM" (estilo Netflix). O segundo tempo — o bloom grave — agora entra de fato **depois** do primeiro, com silêncio entre os dois.

## Por que assim

A intenção de "TA-DUM" já estava toda no código desde `464825d`: existia a constante `dumDelay`, existia o comentário *"o volume sobe só depois do delay, criando a separação"*. Só que o envelope do bloom era agendado a partir de `t`, com o atraso aplicado apenas no **fim** da rampa:

```js
gain.gain.setValueAtTime(0, t);                                  // t = agora
gain.gain.linearRampToValueAtTime(MASTER_GAIN * 0.6, t + dumDelay + 0.1);
```

Uma rampa da Web Audio interpola **do evento anterior da automação** até o instante marcado. Como o evento anterior estava em `t`, o swell começava a subir em `t = 0`, colado na batida seca: `dumDelay` não atrasava o início, só esticava o fade. O mesmo valia para o `filter.frequency` (abrindo desde `t`) e para o `osc.start(t)`.

A versão que de fato soava "TU DUM" (`66f3b3f`, *"new netflix sound: roing on wood"*) agendava tudo a partir de um `bloomStart` próprio. A reescrita seguinte trocou por `t + delay` nos finais de rampa e perdeu a separação — o comentário continuou prometendo o que o código não fazia mais.

O conserto é dar ao segundo evento um tempo próprio e agendar **tudo** a partir dele (`dumStart = t + dumDelay`: ganho, filtro e oscilador). Optei por corrigir o agendamento em vez de voltar ao `66f3b3f` inteiro, porque só o timing estava errado — o timbre atual (TU de onda quadrada filtrada + DUM em Lá A1 com chorus) é o que já foi escolhido e aprovado.

O atraso subiu junto, de 120 ms para 180 ms: o TU só morre em 150 ms (estalo de 100 ms + kick de 150 ms), então mesmo agendado certo, 120 ms ainda entraria por cima da cauda dele.

## Como verificar

Som não tem harness no projeto, então escrevi um renderizador offline descartável (fora do repo): um stub de `AudioContext` que grava o grafo agendado, executa o **módulo real** nas duas versões e sintetiza as amostras. Envelope RMS, janela de 20 ms:

```
  t(s) | ANTES                               | DEPOIS
-------+-------------------------------------+------------------------------------
  0.00 | ##################################  | ##################################
  0.04 | ###                                 | ###
  0.08 | #####                               |
  0.12 | #######                             |
  0.16 | #########                           |
  0.20 | ############                        | ####
  0.26 | #########                           | ###########
  0.30 | #########                           | ###########

ANTES : vale entre as batidas = 27,5% do pico  ->  UMA batida contínua (TUM)
DEPOIS: vale entre as batidas =  0,0% do pico  ->  DUAS batidas separadas (TU ... DUM)
```

Antes o nível nunca zerava entre 0,04 s e 0,45 s — o bloom subia por cima da cauda do TU, e os dois eventos viravam um. Depois há silêncio de 0,07 s a 0,18 s e o DUM entra em 0,19 s.

- [x] `npm run build` passa (`dist/bundle.js 653.2kb`)
- [x] Testes relevantes passam — os 7 harnesses de `npm run test:*` (`content`, `call-script`, `emails`, `note-templates`, `shortcuts`, `prefs`, `deployment-env`)
- [ ] Testado com o bookmarklet de **dev** contra o CRM real — **falta ouvir no browser**: o container não tem áudio nem CRM, e a síntese offline aproxima o Web Audio (osciladores e biquad implementados à mão), então ela prova o **ritmo** das batidas, não o timbre final. Vale conferir se 180 ms é o intervalo que te agrada no ouvido.

## Checklist

- [ ] ~~Se mexi em `gas-backend/`~~ — não mexi
- [ ] ~~Se mexi numa regra de negócio~~ — não é regra de negócio
- [ ] ~~Se é uma decisão que alguém vai questionar depois~~ — é conserto de bug, não decisão estrutural
- [x] Se muda algo perceptível: entrou em `CHANGELOG.md`, sob `[Unreleased]`
- [ ] ~~Se bumpei versão~~ — não bumpei

Também entrou uma regra em `docs/LEARNINGS.md`: rampa da Web Audio começa no evento anterior, então para atrasar um som é preciso agendar o **início**, não só o fim. É uma armadilha que passa por qualquer revisão de diff — o código *parece* certo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9SV98B7ms9fww1nd2Gaf6

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9SV98B7ms9fww1nd2Gaf6)_